### PR TITLE
Update event urls to remove catch-all url

### DIFF
--- a/core/fixtures/core_views_testdata.json
+++ b/core/fixtures/core_views_testdata.json
@@ -101,6 +101,22 @@
 },
 {
     "fields": {
+        "city": "Hidden_no_date",
+        "name": "Django Girls Hidden",
+        "country": "Event",
+        "latlng": null,
+        "team": [
+            1
+        ],
+        "is_on_homepage": false,
+        "main_organizer": 1,
+        "date": ""
+    },
+    "model": "core.event",
+    "pk": 4
+},
+{
+    "fields": {
         "custom_css": null,
         "description": "Django Girls is a one-day workshop about programming in Python and Django tailored for women.",
         "title": "Django Girls Kensington",
@@ -134,6 +150,18 @@
     },
     "model": "core.eventpage",
     "pk": 3
+},
+{
+    "fields": {
+        "custom_css": null,
+        "description": "Django Girls is a one-day workshop about programming in Python and Django tailored for women.",
+        "title": "Django Girls Hidden",
+        "url": "hidden_no_date",
+        "is_live": false,
+        "main_color": "FF9400"
+    },
+    "model": "core.eventpage",
+    "pk": 4
 },
 {
     "fields": {

--- a/core/urls.py
+++ b/core/urls.py
@@ -2,12 +2,13 @@ from django.conf.urls import patterns, include, url
 from . import views
 
 urlpatterns = patterns('',
+#    url(r'^test-404/$', 'core.views.error404'),
     url(r'^events/$', views.events, name='events'),
     url(r'^events/calendar.ics$', views.events_ical, name='icalendar'),
     url(r'^resources/$', views.resources, name='resources'),
     url(r'^organize/$', views.organize, name='organize'),
     url(r'^story/$', views.stories, name='stories'),
 
-    url(r'^(?P<city>[\w\d/]+)$', 'core.views.event', name='event'),
+    url(r'^(?P<city>[\w\d/]+)/$', 'core.views.event', name='event'),
     url(r'^$', views.index, name='index'),
 )

--- a/core/views.py
+++ b/core/views.py
@@ -2,11 +2,12 @@ from datetime import datetime
 
 import icalendar
 
-from django.http import HttpResponse
+from django.http import HttpResponse, Http404
 from django.shortcuts import render, redirect
 from django.utils import timezone
 
 from .models import *
+
 
 def index(request):
 
@@ -18,6 +19,7 @@ def index(request):
         'stories': stories,
     })
 
+
 def events(request):
 
     return render(request, 'events.html', {
@@ -25,11 +27,14 @@ def events(request):
         'past_events': Event.objects.past(),
     })
 
+
 def resources(request):
     return render(request, 'resources.html', {})
 
+
 def organize(request):
     return render(request, 'organize.html', {})
+
 
 def stories(request):
 
@@ -39,16 +44,15 @@ def stories(request):
 
 
 def event(request, city):
-    if city[-1:] == "/":
-        city = city[:-1]
 
     try:
-        if request.user.is_authenticated() or request.GET.has_key('preview'):
-            page = EventPage.objects.get(url=city)
-        else:
-            page = EventPage.objects.get(url=city, is_live=True)
+        page = EventPage.objects.get(url=city)
+        if not (request.user.is_authenticated() \
+                or request.GET.has_key('preview') \
+                or page.is_live):
+            raise Http404
     except EventPage.DoesNotExist:
-        return redirect('core:events')
+        raise Http404
 
     menu = EventPageMenu.objects.filter(page=page)
     content = EventPageContent.objects.filter(page=page, is_public=True)
@@ -70,4 +74,5 @@ def events_ical(request):
             continue  # Skip events with an approximate date
         calendar.add_component(ical_event)
 
-    return HttpResponse(calendar.to_ical(), content_type='text/calendar; charset=UTF-8')
+    return HttpResponse(calendar.to_ical(),
+                        content_type='text/calendar; charset=UTF-8')

--- a/templates/404.html
+++ b/templates/404.html
@@ -10,7 +10,8 @@
                     <p>
                         Sorry! The page you're looking for isn't available.</p>
                     <h3>See all <a href="{% url 'core:events' %}">upcoming events</a>.</h3>
-                    <p><a href="{% url 'core:organize' %}">Find out</a> about organizing a Django Girls workshop in your city.</p>
+                    <p><a href="{% url 'core:organize' %}">Find out</a> about
+                        organizing a Django Girls workshop in your city.</p>
                 </div>
             </div>
 

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,0 +1,20 @@
+{% extends 'global/base.html' %}
+
+{% block content %}
+
+        <div class="container">
+
+            <div class="row">
+                <div class="col-md-12">
+                    <h2>Page not found</h2>
+                    <p>
+                        Sorry! The page you're looking for isn't available.</p>
+                    <h3>See all <a href="{% url 'core:events' %}">upcoming events</a>.</h3>
+                    <p><a href="{% url 'core:organize' %}">Find out</a> about organizing a Django Girls workshop in your city.</p>
+                </div>
+            </div>
+
+
+    </div>
+
+{% endblock content %}

--- a/templates/event_not_live.html
+++ b/templates/event_not_live.html
@@ -1,0 +1,29 @@
+{% extends 'global/base.html' %}
+
+{% block content %}
+
+        <div class="container">
+
+            <div class="row">
+                <div class="col-md-12">
+                    <h2>{{ city|title }}</h2>
+                    {% if past %}
+                        <p>The event for {{ city|title }} has already happened and the webpage is
+                        no longer live.</p>
+                    {% else %}
+                        <p>The event page for {{ city|title }} will be coming soon.</p>
+                    {% endif %}
+                    <p>If you want to contact the organizers of this
+                    event, you can email them at
+                        <a href="mailto:{{ city }}@djangogirls.org">{{ city|lower }}@djangogirls.org</a></p>
+
+
+                    <h3>See all other <a href="{% url 'core:events' %}">upcoming events</a>.</h3>
+                </div>
+            </div>
+
+
+    </div>
+
+{% endblock content %}
+


### PR DESCRIPTION
Resolves #13 
Updated the url for event so that an unrecognised url now raises a 404 which shows the all events link (rather than just redirecting to the events page).  Also added different pages for unpublished events depending on whether past or future, which include links to the all events page and an email link for the organiser of the requested event. 