### PR TITLE
Support filtering on application state

### DIFF
--- a/applications/migrations/0004_auto_20150322_1050.py
+++ b/applications/migrations/0004_auto_20150322_1050.py
@@ -1,0 +1,20 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('applications', '0003_auto_20150311_2109'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='application',
+            name='state',
+            field=models.CharField(max_length=50, null=True, verbose_name=b'State of the application', choices=[(b'submitted', b'Submitted'), (b'accepted', b'Accepted'), (b'rejected', b'Rejected')]),
+            preserve_default=True,
+        ),
+    ]

--- a/applications/models.py
+++ b/applications/models.py
@@ -11,6 +11,12 @@ QUESTION_TYPES = (
     ('email', 'Email')
 )
 
+APPLICATION_STATES = (
+    (0, 'Submitted'),
+    (1, 'Accepted'),
+    (2, 'Rejected'),
+)
+
 
 class Form(models.Model):
     page = models.ForeignKey(EventPage, null=False, blank=False)
@@ -93,6 +99,11 @@ class Question(models.Model):
 class Application(models.Model):
     form = models.ForeignKey(Form, null=False, blank=False)
     created = models.DateTimeField(auto_now_add=True)
+    state = models.CharField(
+        max_length=50,
+        choices=APPLICATION_STATES, verbose_name="State of the application",
+        null=True
+    )
 
     def __unicode__(self):
         return str(self.pk)

--- a/applications/views.py
+++ b/applications/views.py
@@ -44,9 +44,12 @@ def apply(request, city):
 def applications(request, city):
     """
     Display a list of applications for this city.
+    If 'state' get parameter is passed, filter the list.
+    e.g /applications/?state=accepted&state=rejected
     """
+    state = request.GET.getlist('state', None)
     page = get_event_page(city, request.user.is_authenticated(), False)
-    applications = get_applications_for_page(page)
+    applications = get_applications_for_page(page, state)
     return render(request, 'applications.html', {
         'page': page,
         'applications': applications,

--- a/core/utils.py
+++ b/core/utils.py
@@ -36,7 +36,7 @@ def get_event_page(city, is_user_authenticated, is_preview):
     return page
 
 
-def get_applications_for_page(page):
+def get_applications_for_page(page, state=None):
     """
     Return a QuerySet of Application objects for a given page.
     Raises Form.DoesNotExist if Form for page does not yet exist.
@@ -45,4 +45,6 @@ def get_applications_for_page(page):
     if not page_form.exists():
         raise Form.DoesNotExist
     page_form = page_form.first()
+    if state:
+        return page_form.application_set.filter(state__in=state)
     return page_form.application_set.all()


### PR DESCRIPTION
Adds a new "state" field on applications. Allows the list of applications to be filtered based on their state. Looks for query parameters like the following:

```
applications/?state=rejected&state=submitted
```

This is some progress for #18.