### PR TITLE
Fixed event page horizontal scroll on mobile

### DIFF
--- a/static/css/event.css
+++ b/static/css/event.css
@@ -139,7 +139,8 @@ a:hover {
   color: #fff;
 }
 .without-background {
-  padding: 60px 0px;
+  padding-top: 60px;
+  padding-bottom: 60px;
 }
 #about .overlay {
   padding: 150px 0;

--- a/static/css/event.css
+++ b/static/css/event.css
@@ -333,3 +333,11 @@ a:hover {
     margin-top: 20px;
   }
 }
+@media only screen and (max-width: 320px) {
+  #about .overlay h1 {
+    font-size: 50px;
+  }
+  #about .overlay h2 {
+    font-size: 30px;
+  }
+}

--- a/static/css/event.styl
+++ b/static/css/event.styl
@@ -132,7 +132,8 @@ a, a:hover
 
 
 .without-background
-    padding: 60px 0px
+    padding-top: 60px
+    padding-bottom: 60px
 
 #about
     .overlay

--- a/static/css/event.styl
+++ b/static/css/event.styl
@@ -326,3 +326,12 @@ a, a:hover
     .navbar-default .navbar-collapse
         border: 0px !important
         margin-top: 20px
+
+@media only screen and (max-width : 320px)
+    #about
+        .overlay
+            h1
+                font-size: 50px
+
+            h2
+                font-size: 30px


### PR DESCRIPTION
It fixes 3 problems on mobile:
- Horizontal scroll (white column on the right)
- No left margin on "without-background"
- Text getting cut off on 320px (iPhone 4 and 5)

Images below.

![1](https://cloud.githubusercontent.com/assets/850280/7213365/76b30a86-e551-11e4-8984-1ea376706220.jpg)

![2](https://cloud.githubusercontent.com/assets/850280/7213364/608b8544-e551-11e4-8ea9-bb9bd73fe45f.jpg)

![3](https://cloud.githubusercontent.com/assets/850280/7213360/55e4d866-e551-11e4-8d4c-197c0240cc95.jpg)
