### PR TITLE
Fix the order of the questions in the form

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,8 +1,10 @@
+from collections import OrderedDict
+
 from django import forms
 
 
 def generate_form_from_questions(questions):
-    fields = {}
+    fields = OrderedDict()
 
     for question in questions:
         options = {


### PR DESCRIPTION
Python dicts aren't sorted, but an OrderedDict is, so we should use that instead.

Fixes #60.