### PR TITLE
If the question form is successful, add the success message and render the page without the completed form

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -42,6 +42,12 @@ def apply(request, city):
         form.save(form=form_obj)
         messages.success(request, "Yay! Your application has been saved. You'll hear from us soon!")
 
+        return render(request, 'apply.html', {
+            'page': page,
+            'menu': menu,
+            'form_obj': form_obj,
+        })
+
     number_of_email_questions = Question.objects.filter(question_type='email', form=form_obj).count()
 
     return render(request, 'apply.html', {


### PR DESCRIPTION
Fixes a bug raised in the Slack channel (https://djangogirls.slack.com/archives/applications-testing/p1434924327000003)