### PR TITLE
Correcting applications Application model test (test_average_score)

### DIFF
--- a/applications/tests/tests_models.py
+++ b/applications/tests/tests_models.py
@@ -88,8 +88,8 @@ class ApplicationModel(TestCase):
     def test_average_score(self):
         self.assertEqual(self.application.average_score, 0)
 
-        score_1 = Score.objects.create(user=self.user_1, application=self.application, score=random.randint(0,5))
-        score_2 = Score.objects.create(user=self.user_2, application=self.application, score=random.randint(0,5))
+        score_1 = Score.objects.create(user=self.user_1, application=self.application, score=random.randint(1,5))
+        score_2 = Score.objects.create(user=self.user_2, application=self.application, score=random.randint(1,5))
         average = sum([score_1.score, score_2.score]) / 2.0
 
         self.assertEqual(self.application.average_score, average)


### PR DESCRIPTION
To get an average score, the test draw a random digit between 0 and 5.
But the average_score property in the Application model takes only scores with are not 0 (if s.score).

This makes the test unstable.
If the test draws 0 and 5, the average with be 2.5 for the test but 5 for the model (it will ignore 0)
and the test will fail.

I've changed the test to draw a random digit between 1 and 5.