### PR TITLE
Fix menu entries in the applications pages

### DIFF
--- a/applications/tests/tests_utils.py
+++ b/applications/tests/tests_utils.py
@@ -1,0 +1,9 @@
+from django.test import TestCase
+from applications.utils import get_organiser_menu
+
+
+class MenuTest(TestCase):
+    def test_menu_entries(self):
+        menu = get_organiser_menu('london')
+        self.assertEqual(menu[0]['url'], 'applications/')
+        self.assertEqual(menu[1]['url'], 'communication/')

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 
 from django import forms
+from django.core.urlresolvers import reverse
 
 
 def generate_form_from_questions(questions):
@@ -178,3 +179,30 @@ DEFAULT_QUESTIONS = [
         "is_multiple_choice": True,
     }
 ]
+
+
+def get_organiser_menu(city):
+    """
+    Get menu entries for organiser-visible pages
+    """
+    # Remove the city prefix from the URL
+    # as it is already added in by the menu system
+    def strip_url(url):
+        return url.replace('/{}/'.format(city), '')
+
+    menu = [
+        {
+            'title': 'Applications',
+            'url': strip_url(
+                reverse('applications:applications', args=[city])
+            )
+        },
+        {
+            'title': 'Messaging',
+            'url': strip_url(
+                reverse('applications:communication', args=[city])
+            )
+        },
+    ]
+
+    return menu

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import Http404, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.core.urlresolvers import reverse
 from django.contrib import messages
 
 from core.utils import get_event_page
@@ -9,7 +8,7 @@ from core.models import EventPageMenu
 from .decorators import organiser_only
 from .models import Application, Form, Score, Question, Email
 from .forms import ApplicationForm, ScoreForm, EmailForm
-from .utils import get_applications_for_page, random_application
+from .utils import get_applications_for_page, get_organiser_menu, random_application
 
 
 def apply(request, city):
@@ -73,10 +72,7 @@ def applications(request, city):
     order = request.GET.get('order', None)
     applications = get_applications_for_page(page, state, rsvp_status, order)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
+    menu = get_organiser_menu(city)
 
     return render(request, 'applications.html', {
         'page': page,
@@ -113,10 +109,7 @@ def application_detail(request, city, app_id):
                     'applications:application_detail', city, new_app.id)
             return redirect('applications:applications', city)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
+    menu = get_organiser_menu(city)
 
     return render(request, 'application_detail.html', {
         'page': page,
@@ -136,10 +129,7 @@ def communication(request, city):
     """
     page = get_event_page(city, request.user.is_authenticated(), False)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
+    menu = get_organiser_menu(city)
 
     emails = Email.objects.filter(form__page=page).order_by('-created')
 
@@ -159,10 +149,7 @@ def compose_email(request, city, email_id=None):
     form_obj = get_object_or_404(Form, page=page)
     emailmsg = None if not email_id else get_object_or_404(Email, form__page=page, id=email_id)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
+    menu = get_organiser_menu(city)
 
     form = EmailForm(request.POST or None, instance=emailmsg, initial={
         'author': request.user, 'form': form_obj


### PR DESCRIPTION
Menu entries have been broken in the organiser-visible application
pages, the problem is that the city part of the URL goes in twice. This
strips it out before it gets sent off to the template :tulip:

fixes #80 