### PR TITLE
Make menus in event-related pages capable of showing absolute path and URI

### DIFF
--- a/applications/tests/test_utils.py
+++ b/applications/tests/test_utils.py
@@ -1,0 +1,11 @@
+from django.core.urlresolvers import reverse
+from django.test import TestCase
+
+from applications.utils import get_organiser_menu
+
+
+class MenuTest(TestCase):
+    def test_organiser_menu_entries(self):
+        menu = get_organiser_menu('london')
+        self.assertEqual(menu[0]['url'], '/london/applications/')
+        self.assertEqual(menu[1]['url'], '/london/communication/')

--- a/applications/tests/tests_views.py
+++ b/applications/tests/tests_views.py
@@ -164,6 +164,22 @@ class ApplicationsView(TestCase):
         self.assertEqual(resp.status_code, 200)
         self.assertEqual(len(resp.context['applications']), 3)
 
+    def test_organisor_menu_in_applications_list(self):
+        self.user.is_superuser = True
+        self.user.save()
+        self.client.login(email='test@user.com', password='test')
+        resp = self.client.get(self.url)
+        self.assertContains(
+            resp,
+            '<li><a href="/test/applications/">Applications</a></li>',
+            html=True,
+        )
+        self.assertContains(
+            resp,
+            '<li><a href="/test/communication/">Messaging</a></li>',
+            html=True,
+        )
+
     def test_get_sorted_applications_list(self):
         self.user.is_superuser = True
         self.user.save()

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -1,6 +1,25 @@
 from collections import OrderedDict
 
 from django import forms
+from django.core.urlresolvers import reverse
+
+
+def get_organiser_menu(city):
+    """
+    Get menu entries for organiser-visible pages
+    """
+    menu = [
+        {
+            'title': 'Applications',
+            'url': reverse('applications:applications', args=[city])
+        },
+        {
+            'title': 'Messaging',
+            'url': reverse('applications:communication', args=[city])
+        },
+    ]
+
+    return menu
 
 
 def generate_form_from_questions(questions):

--- a/applications/views.py
+++ b/applications/views.py
@@ -1,7 +1,6 @@
 from django.shortcuts import render, redirect, get_object_or_404
 from django.http import Http404, JsonResponse
 from django.views.decorators.csrf import csrf_exempt
-from django.core.urlresolvers import reverse
 from django.contrib import messages
 
 from core.utils import get_event_page
@@ -9,7 +8,7 @@ from core.models import EventPageMenu
 from .decorators import organiser_only
 from .models import Application, Form, Score, Question, Email
 from .forms import ApplicationForm, ScoreForm, EmailForm
-from .utils import get_applications_for_page, random_application
+from .utils import get_applications_for_page, get_organiser_menu, random_application
 
 
 def apply(request, city):
@@ -73,17 +72,12 @@ def applications(request, city):
     order = request.GET.get('order', None)
     applications = get_applications_for_page(page, state, rsvp_status, order)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
-
     return render(request, 'applications.html', {
         'page': page,
         'applications': applications,
         'all_applications_count': Application.objects.filter(form__page=page).count(),
         'order': order,
-        'menu': menu,
+        'menu': get_organiser_menu(city),
     })
 
 
@@ -113,11 +107,6 @@ def application_detail(request, city, app_id):
                     'applications:application_detail', city, new_app.id)
             return redirect('applications:applications', city)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
-
     return render(request, 'application_detail.html', {
         'page': page,
         'application': application,
@@ -125,7 +114,7 @@ def application_detail(request, city, app_id):
         'scores': all_scores,
         'user_score': score,
         'score_form': score_form,
-        'menu': menu,
+        'menu': get_organiser_menu(city),
     })
 
 
@@ -136,16 +125,11 @@ def communication(request, city):
     """
     page = get_event_page(city, request.user.is_authenticated(), False)
 
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
-
     emails = Email.objects.filter(form__page=page).order_by('-created')
 
     return render(request, 'communication.html', {
         'page': page,
-        'menu': menu,
+        'menu': get_organiser_menu(city),
         'emails': emails,
     })
 
@@ -158,11 +142,6 @@ def compose_email(request, city, email_id=None):
     page = get_event_page(city, request.user.is_authenticated(), False)
     form_obj = get_object_or_404(Form, page=page)
     emailmsg = None if not email_id else get_object_or_404(Email, form__page=page, id=email_id)
-
-    menu = [
-        {'title': 'Applications', 'url': reverse('applications:applications', args=[city])},
-        {'title': 'Messaging', 'url': reverse('applications:communication', args=[city])},
-    ]
 
     form = EmailForm(request.POST or None, instance=emailmsg, initial={
         'author': request.user, 'form': form_obj
@@ -178,7 +157,7 @@ def compose_email(request, city, email_id=None):
 
     return render(request, 'compose_email.html', {
         'page': page,
-        'menu': menu,
+        'menu': get_organiser_menu(city),
         'form': form,
         'email': emailmsg,
     })

--- a/core/templatetags/core_tags.py
+++ b/core/templatetags/core_tags.py
@@ -1,0 +1,16 @@
+from six.moves.urllib.parse import urlparse
+
+from django.template import Library
+
+
+register = Library()
+
+
+@register.simple_tag
+def build_menu_item_url(menu_url, event_page_url):
+    parse_result = urlparse(menu_url)
+    if parse_result.netloc:     # A full URI with domain.
+        return menu_url
+    elif parse_result.path.startswith('/'):     # Absolute path.
+        return menu_url
+    return '/{}/{}'.format(event_page_url, menu_url)

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -56,7 +56,7 @@
               <tbody>
                   {% for app in applications %}
                   <tr>
-                      <td><input type="checkbox" name="application" value="{{ app.id }}" /></div>
+                      <td><input type="checkbox" name="application" value="{{ app.id }}" /></td>
                       <td><a href='{{ app.id }}'>{{ app.number }}</a></td>
                       <td>{{ app.email|default:"No email" }}</td>
                       <td>

--- a/templates/event.html
+++ b/templates/event.html
@@ -4,7 +4,7 @@
 {% block description %}{{ page.description }}{% endblock %}
 {% block custom_css %}
     <style>
-        {{ page.custom_css }}
+        {{ page.custom_css|default_if_none:'' }}
     </style>
 {% endblock %}
 
@@ -15,5 +15,5 @@
         {% include 'includes/item.html' with item=item %}
 
     {% endfor %}
-    
+
 {% endblock %}

--- a/templates/event/base.html
+++ b/templates/event/base.html
@@ -1,6 +1,7 @@
 {% load staticfiles %}
 
 <!DOCTYPE HTML>
+<html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
   <title>{% block title %}Django Girls - start your journey with programming{% endblock %}</title>

--- a/templates/event/menu.html
+++ b/templates/event/menu.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load staticfiles core_tags %}
 
 <div class="navbar navbar-default" role="navigation">
   <div class="container">
@@ -16,7 +16,7 @@
     <div class="navbar-collapse collapse">
       <ul class="nav navbar-nav">
         {% for item in menu %}
-        <li><a href="/{{ page.url }}/{{ item.url }}">{{ item.title }}</a></li>
+        <li><a href="{% build_menu_item_url item.url page.url %}">{{ item.title }}</a></li>
         {% endfor %}
       </ul>
     </div><!--/.nav-collapse -->

--- a/templates/global/base.html
+++ b/templates/global/base.html
@@ -1,5 +1,6 @@
 {% load staticfiles %}
 <!DOCTYPE HTML>
+<html>
 <head>
   <meta http-equiv="Content-Type" content="text/html; charset=utf-8" >
   <title>{% block title %}Django Girls - start your journey with programming{% endblock %}</title>


### PR DESCRIPTION
<http://djangogirls.org/taipei/> has links to external pages in the menu (the third one from the left), and simply joining path components doesn’t work.

I use a custom template tag to detect absolute URLs (using `urllib.parse.urlparse`) and choose the right behaviour accordingly.