### PR TITLE
Change "state" to "status"

### DIFF
--- a/templates/applications.html
+++ b/templates/applications.html
@@ -30,9 +30,9 @@
               <a href="?rsvp_status=yes" class="text-success">RSVP: confirmed</a> | 
               <a href="?rsvp_status=no" class="text-danger">RSVP: rejected</a>
           </p>
-          <p>Change the state of selected applications to:
+          <p>Change the status of selected applications to:
               <select name="state">
-                  <option value="" selected>Choose state</option>
+                  <option value="" selected>Choose status</option>
                   <option value="submitted">Application submitted</option>
                   <option value="accepted">Application accepted</option>
                   <option value="rejected">Application rejected</option>


### PR DESCRIPTION
We're using "status" later in the page, so for consistency, I'd like to change "state" to "status." Also, "Choose state" sort of made me think that I could see the applications from Texas versus Oklahoma, so "status" is a little clearer (to me, anyway) :-)