### PR TITLE
command to create PSQL dump/upload to S3

### DIFF
--- a/core/management/commands/backup_postgres_to_s3.py
+++ b/core/management/commands/backup_postgres_to_s3.py
@@ -1,0 +1,47 @@
+# -*- encoding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.conf import settings
+from django.core.management.base import BaseCommand
+
+from boto3.session import Session
+from datetime import datetime
+import os
+
+
+class Command(BaseCommand):
+    help = 'Backs up PostgreSQL database to AWS S3'
+
+    def handle(self, *args, **options):
+        AWS_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID')
+        AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_S3_SECRET_ACCESS_KEY')
+        AWS_REGION_NAME = os.environ.get('AWS_S3_REGION_NAME')
+        AWS_BUCKET_NAME = os.environ.get('AWS_S3_BUCKET_NAME')
+
+        session = Session(aws_access_key_id=AWS_ACCESS_KEY_ID,
+                          aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+                          region_name=AWS_REGION_NAME)
+
+        s3 = session.resource('s3')
+
+        bucket = s3.Bucket(AWS_BUCKET_NAME)
+
+        timestamp = datetime.utcnow().strftime('%Y_%m_%d_%H%M_UTC')
+        db_file = "pgbackup_{}.dump".format(timestamp)
+        db_host = settings.DATABASES['default']['HOST']
+        db_port = settings.DATABASES['default']['PORT']
+        db_name = settings.DATABASES['default']['NAME']
+        db_user = settings.DATABASES['default']['USER']
+
+        pg_dump_command = "pg_dump --host={host} --port={port} --user={user} --format=c --file={file_name} {name}".format(
+            host=db_host,
+            port=db_port,
+            user=db_user,
+            file_name=db_file,
+            name=db_name)
+        self.stdout.write("Enter {}'s psql password".format(db_user))
+        os.system(pg_dump_command)
+
+        bucket.upload_file(db_file, db_file)
+        os.system("rm {}".format(db_file))
+        self.stdout.write("{} successfully uploaded to AWS S3".format(db_file))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 Django==1.8.2
 Pillow==2.5.1
-boto==2.32.0
+boto3==1.1.4
 click==2.5
 coverage==3.7.1
 cssselect==0.9.1


### PR DESCRIPTION
First stab to address issue https://github.com/DjangoGirls/djangogirls/issues/135 so there are consistent backups to S3. Haven't added any tests (not sure how for AWS...), open to suggestions there. 

Also haven't added a bash script to add as a cron job. If we went the absolute path approach (`/path/to/virtualenv/bin/python/ /path/to/djangogirls/manage.py backup_postgres_to_s3`) we might not need/want a .sh file. It's possible we'll hit a permissions issue on PythonAnywhere.