### PR TITLE
Exclude events with no date from past events

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -69,7 +69,7 @@ class EventQuerySet(models.QuerySet):
         return self.public().filter(date__gte=datetime.now().strftime('%Y-%m-%d')).order_by('date')
 
     def past(self):
-        return self.public().filter(date__lt=datetime.now().strftime('%Y-%m-%d')).order_by('-date')
+        return self.public().filter(date__isnull=False, date__lt=datetime.now().strftime('%Y-%m-%d')).order_by('-date')
 
 
 @python_2_unicode_compatible


### PR DESCRIPTION
Fixes https://github.com/DjangoGirls/djangogirls/issues/142

I am excluding events with no date from the past events. How do you test this? When I made an event it never showed up on the page no matter what I did because of authentication failure. 
