### PR TITLE
Fix the apply view when two forms are created

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -24,7 +24,7 @@ def apply(request, city):
         )
 
     try:
-        form_obj = Form.objects.get(page=page)
+        form_obj = Form.objects.filter(page=page).first()
     except Form.DoesNotExist:
         return redirect('core:event', city)
 


### PR DESCRIPTION
When two forms are created for an event page and you go to the
apply view you will get an error. Instead of using .get on the query
we can just grab the first one. It seems to me that creating two forms
is a mistake by the user and we just need to handle it gracefully.

Fixes #143