### PR TITLE
Fix typo in about template for event website

### DIFF
--- a/templates/default/about.html
+++ b/templates/default/about.html
@@ -2,6 +2,6 @@
 
 	<h1>Free programming workshop for women</h1>
 	<h2>Build your first website at EuroPython 2014 in Berlin!</h2>
-	<a class="btn" href="#value">Learn more »</a>
+	<a class="btn" href="#values">Learn more »</a>
 
 </div>


### PR DESCRIPTION
The "learn more" button in the "about" section is now leading you to the good section :smile_cat: 
Thanks @lwyso :rose: 