### PR TITLE
use app.number instead of id in url

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -218,6 +218,10 @@ class Application(models.Model):
     def is_accepted(self):
         return self.state == 'accepted'
 
+    @property
+    def city(self):
+        return self.form.page.event.city
+
     def __str__(self):
         return str(self.pk)
 

--- a/applications/models.py
+++ b/applications/models.py
@@ -218,10 +218,6 @@ class Application(models.Model):
     def is_accepted(self):
         return self.state == 'accepted'
 
-    @property
-    def city(self):
-        return self.form.page.event.city
-
     def __str__(self):
         return str(self.pk)
 

--- a/applications/urls.py
+++ b/applications/urls.py
@@ -6,7 +6,7 @@ urlpatterns = patterns(
         'applications.views.apply', name='apply'),
     url(r'^(?P<city>[\w\d/]+)/applications/$',
         'applications.views.applications', name='applications'),
-    url(r'^(?P<city>[\w\d/]+)/applications/(?P<app_id>\d+)$',
+    url(r'^(?P<city>[\w\d/]+)/applications/(?P<app_number>\d+)$',
         'applications.views.application_detail', name='application_detail'),
     url(r'^(?P<city>[\w\d/]+)/applications/change_state/$',
         'applications.views.change_state', name='change_state'),

--- a/applications/views.py
+++ b/applications/views.py
@@ -82,7 +82,6 @@ def applications(request, city):
         'all_applications_count': Application.objects.filter(form__page=page).count(),
         'order': order,
         'menu': get_organiser_menu(city),
-        'city': city
     })
 
 @organiser_only
@@ -110,7 +109,7 @@ def application_detail(request, city, app_number):
     """
     Display the details of a single application.
     """
-    application = [app for app in Application.objects.filter(number=app_number) if app.city == city][0]
+    application = Application.objects.get(form__page__url=city, number=app_number)
     try:
         score = Score.objects.get(
             user=request.user, application=application)

--- a/applications/views.py
+++ b/applications/views.py
@@ -82,6 +82,7 @@ def applications(request, city):
         'all_applications_count': Application.objects.filter(form__page=page).count(),
         'order': order,
         'menu': get_organiser_menu(city),
+        'city': city
     })
 
 @organiser_only
@@ -105,11 +106,11 @@ def applications_csv(request, city):
 
 
 @organiser_only
-def application_detail(request, city, app_id):
+def application_detail(request, city, app_number):
     """
     Display the details of a single application.
     """
-    application = Application.objects.get(pk=app_id)
+    application = [app for app in Application.objects.filter(number=app_number) if app.city == city][0]
     try:
         score = Score.objects.get(
             user=request.user, application=application)

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -57,7 +57,7 @@
                   {% for app in applications %}
                   <tr>
                       <td><input type="checkbox" name="application" value="{{ app.id }}" /></td>
-                      <td><a href='{{ app.number }}'>{{ app.number }}</a></td>
+                      <td><a href="{% url 'applications:application_detail' city=app.form.page.url app_number=app.number %}">{{ app.number }}</a></td>
                       <td>{{ app.email|default:"No email" }}</td>
                       <td>
                           <div class="dropdown">
@@ -109,7 +109,7 @@
                           {% endif %}
                       </td>
                       <td class="text-right">
-                          <a href="{{ app.number }}" class="btn">View Application</a>
+                          <a href="{% url 'applications:application_detail' city=app.form.page.url app_number=app.number %}" class="btn">View Application</a>
                       </td>
                   </tr>
                   {% endfor %}

--- a/templates/applications.html
+++ b/templates/applications.html
@@ -57,7 +57,7 @@
                   {% for app in applications %}
                   <tr>
                       <td><input type="checkbox" name="application" value="{{ app.id }}" /></td>
-                      <td><a href='{{ app.id }}'>{{ app.number }}</a></td>
+                      <td><a href='{{ app.number }}'>{{ app.number }}</a></td>
                       <td>{{ app.email|default:"No email" }}</td>
                       <td>
                           <div class="dropdown">
@@ -109,7 +109,7 @@
                           {% endif %}
                       </td>
                       <td class="text-right">
-                          <a href="{{ app.id }}" class="btn">View Application</a>
+                          <a href="{{ app.number }}" class="btn">View Application</a>
                       </td>
                   </tr>
                   {% endfor %}


### PR DESCRIPTION
For https://github.com/DjangoGirls/djangogirls/issues/118

Just changed the url so it looks for `app.number` instead of `app.id` 

I looked around but could't find any other places that it might have been referenced but I'm fairly sure that I might have missed something.