### PR TITLE
changed og:url to point to the city's event url rather than main domain on the base event template

### DIFF
--- a/templates/event/base.html
+++ b/templates/event/base.html
@@ -11,7 +11,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
   <meta property="og:type" content="website" />
-  <meta property="og:url" content="http://djangogirls.org/" />
+  <meta property="og:url" content="http://djangogirls.org/{{ page.url }}" />
   <meta property="og:image" content="https://raw.githubusercontent.com/olasitarska/djangogirls/gh-pages/resources/graphics/logo_square.png" />
 
   <link rel="stylesheet" href="//brick.a.ssl.fastly.net/Linux+Libertine:400,600,700,400i,600i,700i/Roboto:300,400,300i,400i">


### PR DESCRIPTION
When sharing the link to the event page on Facebook the link points to the main django girls domain rather than to the specific event. I changed it to include the city so that you can link directly to the event.