### PR TITLE
Linked event with no website to temporary webpage

### DIFF
--- a/templates/includes/_event.html
+++ b/templates/includes/_event.html
@@ -1,4 +1,4 @@
-{% if event.eventpage.is_live %}<a href="/{{ event.eventpage.url }}">{% endif %}
+<a href="/{{ event.eventpage.url }}">
     <div class="col-md-4 event"{% if event.photo %} style="background-image: url({{ event.photo.url }})"{% endif %}>
         <div class="overlay">
             <p class="city">{{ event.city }}</p>
@@ -6,4 +6,4 @@
             {% if event.photo_credit %}<p class="credit" rel="{{ event.photo_link }}">Photo credit: {{ event.photo_credit }} (<span rel="https://creativecommons.org/licenses/by-nc-sa/2.0/">CC</span>)</p>{% endif %}
         </div>
     </div>
-{% if event.eventpage.is_live %}</a>{% endif %}
+</a>


### PR DESCRIPTION
I realized that events with no website have a nice [temporary page](https://github.com/DjangoGirls/djangogirls/blob/master/templates/event_not_live.html) but it was not used. It will probably help to reduce emails received at hello@ :wink: 