### PR TITLE
Add search functionality for admin coach list page

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -168,6 +168,7 @@ class SponsorAdmin(SortableModelAdmin):
 
 class CoachAdmin(admin.ModelAdmin):
     list_display = ('name', 'photo_display_for_admin', 'twitter_handle', 'url')
+    search_fields = ('name', 'twitter_handle', 'url')
 
     def get_queryset(self, request):
         qs = super(CoachAdmin, self).get_queryset(request)


### PR DESCRIPTION
![a5](https://cloud.githubusercontent.com/assets/166637/12295653/209b5970-ba0b-11e5-87e8-a6c96752ad46.png)

Search fields: name, twitter_handle, url.

Fixes #197 
