### PR TITLE
Made it easier to find event when adding postmortems

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -187,7 +187,7 @@ class CoachAdmin(admin.ModelAdmin):
 
 class PostmortemAdmin(admin.ModelAdmin):
     list_display = ('event', 'attendees_count', 'applicants_count')
-
+    raw_id_fields = ('event',)
 
 class UserAdmin(auth_admin.UserAdmin):
     fieldsets = (


### PR DESCRIPTION
We now have so many events (:heart_eyes_cat: by the way) that it became difficult to find the event you're looking for in the dropdown menu. Changing it for a search field will probably make our life easier :wink: 