### PR TITLE
Replacing Simple Captcha by reCAPTCHA

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -1,7 +1,7 @@
 from django import forms
 from django.template.loader import render_to_string
 from django.core.mail import EmailMessage
-from captcha.fields import CaptchaField
+from captcha.fields import ReCaptchaField
 
 from .models import Application, Answer, Question, Score, Email
 from .utils import generate_form_from_questions
@@ -17,7 +17,7 @@ class ApplicationForm(forms.Form):
         questions = kwargs.pop('questions')
         super(ApplicationForm, self).__init__(*args, **kwargs)
         self.fields = generate_form_from_questions(questions)
-        self.fields['captcha'] = CaptchaField()
+        self.fields['captcha'] = ReCaptchaField()
 
 
     def save(self, *args, **kwargs):

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -154,6 +154,11 @@ DEFAULT_FROM_EMAIL = "hello@djangogirls.org"
 
 SLACK_API_KEY = os.environ.get('SLACK_API_KEY')
 
+RECAPTCHA_PUBLIC_KEY = os.environ.get('RECAPTCHA_PUBLIC_KEY')
+RECAPTCHA_PRIVATE_KEY = os.environ.get('RECAPTCHA_PRIVATE_KEY')
+# Using new No Captcha reCaptcha with SSL
+NOCAPTCHA = True
+
 TEST_RUNNER = 'django_nose.NoseTestSuiteRunner'
 NOSE_ARGS = [
     '--with-coverage',

--- a/djangogirls/urls.py
+++ b/djangogirls/urls.py
@@ -20,6 +20,5 @@ urlpatterns = [
     url(r'^pages/', include('django.contrib.flatpages.urls')),
     url(r'^account/', include('django.contrib.auth.urls')),
     url(r'', include('applications.urls', namespace='applications')),
-    url(r'^captcha/', include('captcha.urls')),
     url(r'', include('core.urls', namespace='core')),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,4 +36,4 @@ requests==2.9.1
 six==1.10.0
 -e git://github.com/olasitarska/slacker.git#egg=slacker
 whitenoise==2.0.6
-django-simple-captcha
+django-recaptcha


### PR DESCRIPTION
Captcha made by simple Captcha are not easy to read at all: let's change it for reCAPTCHA :smile: 
Everything is already configured on PythonAnywhere :wink: 