### PR TITLE
Tiny fix for 2.x compatibility issues.

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -205,7 +205,7 @@ class ContactEmail(models.Model):
     class Meta:
         ordering = ('-created_at',)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s to %s" % (self.email, self.sent_to)
 
     def save(self, *args, **kwargs):
@@ -222,7 +222,7 @@ class ContactEmail(models.Model):
         except SMTPException:
             self.sent_successfully = False
 
-        super().save(*args, **kwargs)
+        super(ContactEmail, self).save(*args, **kwargs)
 
     def _get_to_email(self):
         if self.event and self.event.email:


### PR DESCRIPTION
While setting up locally my env I faced two small issues (because I use python 2.7 in here):
* models decorated with `@python_2_unicode_compatible`  should have a single `__str__` method declared (otherwise an error raised during model load) [1]
* 2.7 does not understand short form of `super` call (I see all elsewhere in project only full form call is used)

[1] https://docs.djangoproject.com/en/dev/ref/utils/#django.utils.encoding.python_2_unicode_compatible