### PR TITLE
Add preventDefault() so that when applications' state is changed, the…

### DIFF
--- a/static/js/applications.js
+++ b/static/js/applications.js
@@ -3,7 +3,7 @@ $(document).ready(function() {
         $(".application-box").prop('checked', $(this).prop('checked'));
     });
 
-    $('.state-change').click(function(){
+    $('.state-change').click(function(e){
         var state = $(this).data('state'),
             appId = $(this).data('app-id'),
             url = $('#applications').data('change-state-url'),
@@ -12,6 +12,7 @@ $(document).ready(function() {
         $.post(url, {'state': state, 'application': appId}, function(data){
             updateApplicationState(appId, state, name);
         });
+        e.preventDefault();
     });
 
     $('#change-state-form').submit(function(){


### PR DESCRIPTION
On the applications page, when a user changes the state of the application, the page jumps to the top. This can be frustrating with events with many applications, for example NYC has 100+ applications. This commit should fix that behavior.

:) ✨