### PR TITLE
made adjustments to event template text

### DIFF
--- a/templates/default/values.html
+++ b/templates/default/values.html
@@ -2,47 +2,50 @@
 	<div class="col-md-6">
 		<h3>Django Girls</h3>
 		<p>
-			If you are a female and you want to learn how to make websites, 
-			we have good news for you! We are holding a one-day workshop for beginners!
+			If you are a woman and want to learn how to make websites, we have
+			good news for you: we are holding a one-day workshop for beginners!
 	    </p>
 
 		<p>
-			It will take place on <strong>21st of July</strong> in <strong>Berlin</strong>,
-			on the first day of a big IT conference: <a href="http://europython.eu/">EuroPython</a>, 
-			which gathers a lot of talented programmers from all over the world.
+			It will take place on <strong>DAY, MONTH, YEAR</strong> at
+			<strong>VENUE</strong> in <strong>CITY</strong>.
 		</p>
 
 		<p>
-			We believe that IT industry will greatly benefit from bringing more women
-			into technology. We want to give you an opportunity to learn how to program
-			and become one of us - female programmers!
+			We believe the IT industry will greatly benefit from bringing more women
+			into technology. We want to give you an opportunity to learn how to
+			program and become one of us &ndash; women programmers!
 		</p>
 
 		<p>
-			Workshops are free of charge and if you can’t afford coming to Berlin,
-			but you are very motivated to learn and then share your knowledge with others,
-			we have some funds to help you out with your travel costs and accommodation. 
-			Don’t wait too long - you can apply for a pass only until <strong>30th of June</strong>!
-	 	</p>      
-	 </div>      
+			Workshops are free of charge and if you cannot afford coming to CITY
+			but are very motivated to learn and then share your knowledge with
+			others, we may have some funds to help you out with your travel costs
+			and accommodation. Don't wait too long: you can apply for
+			the workshop only until <strong>DATE</strong>!
+	 	</p>
+	 </div>
 
 	 <div class="col-md-6">
-	 	<h3>Apply for a pass!</h3>
+	 	<h3>Apply for the workshop!</h3>
 	 	<p>
-	 		If you are a woman, you know English and have a laptop - you can apply
-	 		for a pass! You don’t need to know any technical stuff - workshops
-	 		are for people who are new to programming.
+	 		If you are a woman, know English and have a laptop, you can apply
+	 		for our event! You dont need to know any technical stuff &ndash; our
+	 		workshop is for people who are new to programming.
 	 	</p>
 
 	 	<p>
 	 		As a workshop attendee you will:
 	 		<ul>
-	 			<li>attend one-day Django workshops during which you will create your first website</li>
-	 			<li>get a free EuroPython ticket (which normally costs 400 €!), where you can meet people from the industry and learn more about programming</li>
-	 			<li>be fed by us - during workshops and EuroPython food is provided</li>
+	 			<li>attend a one-day Django workshop during which you will create
+	 			your first website</li>
+	 			<li>be fed by us: during our event, food is provided</li>
 	 		</ul>
 	 	</p>
 
-	 	<p>We have space only for 40 people, so make sure to fill the form very carefully!</p>
+	 	<p>
+	 		We have space only for XX people, so make sure to fill out the form
+	 		very carefully!
+	 	</p>
 	 </div>
 </div>

--- a/templates/default/values.html
+++ b/templates/default/values.html
@@ -30,7 +30,7 @@
 	 	<h3>Apply for the workshop!</h3>
 	 	<p>
 	 		If you are a woman, know English and have a laptop, you can apply
-	 		for our event! You dont need to know any technical stuff &ndash; our
+	 		for our event! You don't need to know any technical stuff &ndash; our
 	 		workshop is for people who are new to programming.
 	 	</p>
 


### PR DESCRIPTION
As discussed a while ago on Slack, I sat down to modify (part of) the template text for events.

In particular I changed instances of "female" to woman/women and removed references to the EuroPython conference as they are not applicable to most DG workshops. I also introduced some grammar & style fixes and added placeholder text for event-specific dates, numbers, places.