### PR TITLE
Small corrections in setup email and applicants form

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -57,7 +57,7 @@ def generate_form_from_questions(questions):
         widget=forms.RadioSelect,
         label='Do you want to receive news from the Django Girls team?',
         help_text='No spam, pinky swear! Only helpful programming tips and '
-            'latest news from Django Girls world. We send this very rarely.',
+            'latest news from Django Girls world. We send it once every two weeks.',
         required=True,
         choices=(('yes', 'Yes please!'), ('no', 'No, thank you'))
     )

--- a/templates/emails/setup.txt
+++ b/templates/emails/setup.txt
@@ -29,11 +29,7 @@ Your website is currently hidden for public, you can only see it if you’re log
 
 Instructions on editing website: http://organize.djangogirls.org/website/
 
-3) Your event in Django Girls Dispatch
-
-When you open the registrations for your event, send us an email at hello@djangogirls.com so we can announce it in the Django Girls bi-weekly newsletter.
-
-4) Postponing or canceling
+3) Postponing or canceling
 
 If you need to cancel or postpone your event, please, send us an email. It can happen and we won't be mad at you ;) Also, if you're stuck on something, we can try to help you!
 


### PR DESCRIPTION
Two small correction:
- The dispatch is now send once every two weeks.
- Point 3 of setup email for organizers is not useful anymore since we can now filter events with open registration.
:tada: 