### PR TITLE
[WIP] Privacy policy

### DIFF
--- a/applications/tests/tests_views.py
+++ b/applications/tests/tests_views.py
@@ -372,13 +372,13 @@ class ApplicationsDownloadView(TestCase):
         reader = csv.reader(csv_file)
         csv_list = list(reader)
         self.assertEquals(len(csv_list), 5)
-        self.assertEquals(len(csv_list[0]), 17)
+        self.assertEquals(len(csv_list[0]), 18)
         self.assertEquals(csv_list[0][0], "Application Number")
         self.assertEquals(csv_list[1][1], "submitted")
         self.assertEquals(csv_list[2][1], "accepted")
         self.assertEquals(csv_list[3][1], "rejected")
         self.assertEquals(csv_list[4][1], "waitlisted")
-        self.assertEquals(csv_list[1][16], "answer to last for app 1")
+        self.assertEquals(csv_list[1][17], "answer to last for app 1")
 
     def test_download_applications_list_uses_query_parameters_to_filter_applications(self):
         self.user.is_superuser = True
@@ -421,15 +421,15 @@ class ApplicationsDownloadView(TestCase):
         reader = csv.reader(csv_file)
         csv_list = list(reader)
         self.assertEquals(len(csv_list), 6)
-        self.assertEquals(len(csv_list[0]), 18)
+        self.assertEquals(len(csv_list[0]), 19)
 
         # question x should be in next to last column
-        self.assertEquals(csv_list[0][16], "questionx")
+        self.assertEquals(csv_list[0][17], "questionx")
 
         # old application should have blank for question x in next-to-last column
-        self.assertEquals(csv_list[1][16], "")
-        self.assertEquals(csv_list[1][17], "answer to last for app 1")
+        self.assertEquals(csv_list[1][17], "")
+        self.assertEquals(csv_list[1][18], "answer to last for app 1")
 
         # new application should have answer for question x in next-to-last column
-        self.assertEquals(csv_list[5][16], "answer to questionx for app 5")
-        self.assertEquals(csv_list[5][17], "answer to last for app 5")
+        self.assertEquals(csv_list[5][17], "answer to questionx for app 5")
+        self.assertEquals(csv_list[5][18], "answer to last for app 5")

--- a/applications/utils.py
+++ b/applications/utils.py
@@ -191,6 +191,19 @@ DEFAULT_QUESTIONS = [
         "is_multiple_choice": True,
     },
     {
+        "title": "I acknowledge that some of my data will be used on Third Party Sites and Service.",
+        "help_text": "Data collected through this form is used only for the "
+        "purpose of Django Girls events. We're using Third Party Sites "
+        "and Services to make it happen: for example, we're using "
+        "Mandrill to send you emails. Don't worry: We don't share your data with spammers, "
+        "and we don't sell it! More info on our Privacy policy "
+        "<a href='/privacy-cookies/'>here</a>.",
+        "question_type": "choices",
+        "choices": "Yes",
+        "is_required": True,
+        "is_multiple_choice": True,
+    },
+    {
         "title": "It is important that all attendees comply with the "
         "<a href='/pages/coc/'>Django Girls Code of Conduct</a>",
         "question_type": "choices",

--- a/core/urls.py
+++ b/core/urls.py
@@ -17,6 +17,8 @@ urlpatterns = [
         name='foundation-governing-document'),
     url(r'^contribute/$', views.contribute, name='contribute'),
     url(r'^2015/$', views.year_2015, name='year_2015'),
+    url(r'^terms-conditions/$', views.terms_conditions, name='terms-conditions'),
+    url(r'^privacy-cookies/$', views.privacy_cookies, name='privacy-cookies'),
 
     url(r'^(?P<city>[\w\d/]+)/$', views.event, name='event'),
     url(r'^$', views.index, name='index'),

--- a/core/views.py
+++ b/core/views.py
@@ -145,3 +145,9 @@ def year_2015(request):
         'events': Event.objects.public().filter(date__lt='2016-01-01').order_by('date'),
         'mapbox_map_id': settings.MAPBOX_MAP_ID,
     })
+
+def terms_conditions(request):
+    return render(request, 'core/terms_conditions.html', {})
+
+def privacy_cookies(request):
+    return render(request, 'core/privacy_cookies.html', {})

--- a/static/css/global.css
+++ b/static/css/global.css
@@ -697,6 +697,38 @@ footer .row .col-md-2 ul li a {
 }
 /*
 ---------------------
+    Text Pages
+---------------------
+*/
+#textonly-pages {
+  font-size: 18px;
+  line-height: 180%;
+  color: #000;
+  overflow-x: hidden;
+}
+#textonly-pages h1 {
+  font-size: 32px;
+  margin: 20px 0 40px 0;
+  font-weight: bold;
+  text-align: center;
+}
+#textonly-pages a {
+  color: #f7921d;
+}
+#textonly-pages p {
+  margin-bottom: 15px;
+}
+#textonly-pages .important {
+  text-align: center;
+  font-weight: bold;
+  font-size: 22px;
+}
+#textonly-pages ul {
+li
+  margin-bottom: 15px;
+}
+/*
+---------------------
     Responsiveness
 ---------------------
 */

--- a/static/css/global.styl
+++ b/static/css/global.styl
@@ -668,6 +668,33 @@ footer
             font-style: normal
             font-family: serif_font
 
+/*
+---------------------
+    Text Pages
+---------------------
+*/
+#textonly-pages
+    font-size: 18px
+    line-height: 180%
+    color: black
+    overflow-x: hidden
+
+    h1
+        font-size: 32px
+        margin: 20px 0 40px 0
+        font-weight: bold
+        text-align: center
+    a
+        color: orange
+    p
+        margin-bottom: 15px
+    .important
+        text-align: center
+        font-weight: bold
+        font-size: 22px
+    ul
+        li
+        margin-bottom: 15px
 
 /*
 ---------------------

--- a/templates/core/privacy_cookies.html
+++ b/templates/core/privacy_cookies.html
@@ -1,0 +1,148 @@
+{% extends 'global/base.html' %}
+{% load staticfiles %}
+
+{% block title %}Cookie and Privacy Policies of Django Girls Website{% endblock %}
+{% block description %}This Policy applies to our use of any and all Data collected by us in relation to your use of the Site.
+{% endblock %}
+
+{% block content %}
+    <section id="annual-report" xmlns="http://www.w3.org/1999/html">
+            <div class="row clearfix">
+                <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1">
+                    <div class="report-head">
+                        <h2>Cookie and Privacy Policies of Django Girls Website</h2>
+                    </div>
+
+                    <p><b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP</p>
+                    <p><b>You, Your</b> Are a visitor to the Site</p>
+
+                    <p><b>Site</b> djangogirls.org</p>
+
+                    <p>This Policy applies to our use of any and all Data collected by us in relation to your use of the Site.</p>
+
+                    <h3>Definitions and Interpretation</h3>
+
+                    <p>In this Policy the following terms shall have the following meanings:</p>
+
+                    <ul>
+                        <li><b>Data</b> means all the information you submit to us via the Site.  This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998.</li>
+                        <li><b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site.</li>
+                        <li><b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011.</li>
+                        <li><b>User</b> means you or anyone who uses the Site.</li>
+                    </ul>
+
+                    <h3>Scope of this Policy</h3>
+
+                    <p>This Policy applies only to the actions of you and us when using the Site.  It does not extend to:</p>
+                    <ul>
+                        <li>any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or</li>
+                        <li>any websites that can be accessed from this Site including, but not limited to, any links we might provide.</li>
+                    </ul>
+
+                    <h3>Data Collected</h3>
+
+                    <p>Without limitation, all or any of the following Data may be collected by the Site from time to time:</p>
+
+                    <ul>
+                        <li>name;</li>
+                        <li>date of birth;</li>
+                        <li>gender;</li>
+                        <li>contact information such as email addresses and telephone numbers;</li>
+                        <li>demographic information such as post code, preferences and interests;</li>
+                        <li>IP address (automatically collected);</li>
+                        <li>web browser type and version (automatically collected);</li>
+                        <li>operating system (automatically collected); and</li>
+                        <li>a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected).</li>
+                    </ul>
+
+                    <h3>Our Use of Data</h3>
+
+                    <p>We will keep any personal Data you submit for 60 months.
+</p>
+
+                    <p>Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group.</p>
+
+                    <p>All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998.</p>
+
+                    <p>We use your Data so as to give you the best possible service and experience when using the Site.</p>
+
+                    <p>Specifically, Data may be used by us for the following reasons:</p>
+                    <ul>
+                        <li>internal record keeping;</li>
+                        <li>improvement of our products / services;</li>
+                        <li>transmission by email of promotional materials that may be of interest to you;</li>
+                        <li>contact for market research purposes which may be done using email, telephone, fax or mail;</li>
+                        <li>the organisation of an Event for which you have applied or in which you have expressed interest; or</li>
+                        <li>to customise or update the Site.</li>
+                    </ul>
+
+                    <h3>Third Party Sites and Services</h3>
+
+                    <p>We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing.  The providers of such services have access to some of your Data.</p>
+
+                    <p>Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested.  Any use for other purposes is strictly prohibited.</p>
+
+                    <p>Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998.</p>
+
+                    <h3>Links to Other Websites</h3>
+
+                    <p>We may, from time to time, provide links to other websites.  We have no control over such websites and can’t be responsible for their content.  This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them.</p>
+                    <h3>Changes of Business Ownership and Control</h3>
+
+                    <p>We may, from time to time, expand or reduce our business and that may mean that the people who control our business change.  If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy.</p>
+
+                    <p>If we do transfer Data for this reason we will not tell you in advance.</p>
+
+                    <h3>Controlling Use of Your Data</h3>
+                    <p>If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:</p>
+
+                    <ul>
+                        <li>use of Data for direct marketing purposes; and</li>
+                        <li>sharing Data with third parties.</li>
+                    </ul>
+
+                    <h3>Your Right to Withhold Information</h3>
+
+                    <p>You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data.</p>
+
+                    <p>You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information.</p>
+
+                    <h3>Accessing Your Own Data</h3>
+
+                    <p>You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10.</p>
+                    <h3>Security</h3>
+
+                    <p>Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site.</p>
+
+                    <h3>Cookies</h3>
+
+                    <p>The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected.</p>
+
+                    <p>All Cookies used by the Site are used in accordance with current UK and EU Cookie Law.</p>
+
+                    <p>Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below.</p>
+
+                    <p>The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it.</p>
+
+                    <p>You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk.</p>
+
+                    <p>The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:</p>
+
+                    <ul>
+                        <li>You can choose to enable or disable Cookies in your internet browser.</li>
+                        <li>Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies.</li>
+                        <li>By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser.</li>
+                        <li>You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings.</li>
+                    </ul>
+
+                    <p>We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser.</p>
+
+                    <h3>Changes to this Policy</h3>
+
+                    <p>We have the right to change this Policy as and when we decide from time to time or as may be required by law.  Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes.</p>
+
+
+                     </div>
+                </div>
+         </section>
+{% endblock %}

--- a/templates/core/privacy_cookies.html
+++ b/templates/core/privacy_cookies.html
@@ -6,12 +6,10 @@
 {% endblock %}
 
 {% block content %}
-    <section id="annual-report" xmlns="http://www.w3.org/1999/html">
+    <section id="textonly-pages">
             <div class="row clearfix">
                 <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1">
-                    <div class="report-head">
-                        <h2>Cookie and Privacy Policies of Django Girls Website</h2>
-                    </div>
+                        <h1>Cookie and Privacy Policies of Django Girls Website</h1>
 
                     <p><b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP</p>
                     <p><b>You, Your</b> Are a visitor to the Site</p>

--- a/templates/core/terms_conditions.html
+++ b/templates/core/terms_conditions.html
@@ -1,0 +1,192 @@
+{% extends 'global/base.html' %}
+{% load staticfiles %}
+
+{% block title %}Terms and Conditions of use of Django Girls Website{% endblock %}
+{% block description %}Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain.{% endblock %}
+
+{% block content %}
+    <section id="annual-report" xmlns="http://www.w3.org/1999/html">
+            <div class="row clearfix">
+                <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1">
+                    <div class="report-head">
+                        <h2>Terms and Conditions of use of Django Girls Website</h2>
+                    </div>
+
+                    <p><b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP</p>
+                    <p><b>Site</b> is djangogirls.org</p>
+                    <p><b>You</b> are a visitor to our Site</p>
+
+                    <p>Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain.
+</p>
+                    <p><b>By entering our site you are accepting these T&Cs</b></p>
+
+                    <p>One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us.</p>
+
+                        <h3>Agreement</h3>
+                    <p>This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says.</p>
+
+                        <h3>Definition</h3>
+                    <p>There are some definitions at the bottom of the page.</p>
+
+                        <h3>You promise us:</h3>
+                    <ul>
+                        <li>That you have the right to agree these T&Cs with us and that you are over the age of 18 years.</li>
+                        <li>That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to.</li>
+                        <li>That you won’t use robots, spiders, scrapers or similar things on the Site.</li>
+                        <li>That you won’t try to get around any things we put on the Site to stop or limit access to parts of it.</li>
+                        <li>That you won’t do anything that might cause our systems to crash.</li>
+                        <li>That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site.</li>
+                        <li>That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site.</li>
+                        <li>That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own.</li>
+                    </ul>
+
+                    <h3>Intellectual property</h3>
+                    <p>Either we or third parties own all of the information and intellectual property on the Site.</p>
+
+<p>We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href="http://organize.djangogirls.org/">here</a>.</p>
+
+                    <h3>Price and payment</h3>
+                    <p>We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge.</p>
+
+                    <p>If you wish to make a donation for the use of any of our services, please follow this <a href="https://www.patreon.com/djangogirls">link</a>.</p>
+
+                    <h3>Use of communications facilities</h3>
+
+                    <p>When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:</p>
+                    <ul>
+                        <li>you must not use language that may be offensive to other Users;</li>
+                        <li>you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;</li>
+                        <li>you must submit no Content that is intended to promote or incite violence;</li>
+                        <li>Content must be posted, and communications with us must be made, using the English language;</li>
+                        <li>you must not post links to other sites containing any of the above types of Content;</li>
+                        <li>the means by which you identify yourself must not violate these T&Cs or any applicable laws;</li>
+                        <li>you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;</li>
+                        <li>you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;</li>
+                        <li>you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and</li>
+                        <li>you must not use our System for unauthorised mass communication such as “spam” or “junk mail”.</li>
+                    </ul>
+
+                    <p>You acknowledge that we have the right to monitor any and all communications made to us or using our System.</p>
+
+                    <p>You acknowledge that we may retain copies of any and all communications made to us or using our System.</p>
+
+                    <p>You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information.</p>
+
+                    <h3>Privacy and cookies</h3>
+
+                    <p>We and you both agree that <a href="{% url "core:privacy-cookies" %}">our Privacy and Cookie Policy</a> forms part of these T&Cs.</p>
+
+                    <h3>Disclaimers</h3>
+
+                    <p>We have tried to make sure of the following things:</p>
+
+                    <ul>
+                        <li>that the Site will meet your needs;</li>
+                        <li>that all the information we publish is correct, up to date and not misleading;</li>
+                        <li>that the Site always works properly;</li>
+                        <li>that the Site is fit for the purpose you need;</li>
+                        <li>that the Site doesn’t infringe the rights of others;</li>
+                        <li>that the Site will work with all systems; and</li>
+                        <li>that the Site is secure,</li>
+                    </ul>
+
+                    <p>but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation.</p>
+
+                    <p>We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur.</p>
+
+                    <p>The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist.</p>
+
+                    <p>If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href="https://github.com/DjangoGirls/djangogirls/">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome.</p>
+
+                    <h3>Events</h3>
+
+                    <p>Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it.</p>
+
+                    <p>You accept that all issues arising relating to an Event must be addressed to the Event Organiser.</p>
+
+                    <h3>Problems</h3>
+
+                    <p>We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away.</p>
+
+                    <p>We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem.</p>
+
+                    <h3>Availability of the site</h3>
+
+                    <p>We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result.</p>
+
+                    <p>We have the right to change the Site and the services it offers, suspend it or stop it at any time.</p>
+
+                    <h3>Limitation of liability</h3>
+
+                    <p>To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it.</p>
+
+                    <p>You use the Site and its Content at your own risk.</p>
+
+                    <p>Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part.</p>
+
+                    <h3>Linking</h3>
+
+                    <p>We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them.</p>
+
+                    <p>Just because we link to a site does not mean that we endorse or recommend that site.</p>
+
+                    <p>We can never guarantee that a link will work.</p>
+
+                    <p>If you find any link we offer to be offensive, please let us know and we will consider removing it.</p>
+
+                    <p>If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites.</p>
+
+                    <p>If you wish to link to the Site you may link to our Home page on the following conditions:</p>
+
+                    <ul>
+                        <li>the link mustn’t damage our reputation;</li>
+                        <li>the link must be fair and legal;</li>
+                        <li>you can only link from a site that you own;</li>
+                        <li>you can’t suggest that we are associated with you, endorse you and approve of you in any way; and</li>
+                        <li>you mustn’t frame our Site on any other site.</li>
+                    </ul>
+
+                    <p>We always have the right to break any link you make even if we can’t give a reason for our decision.</p>
+
+                    <h3>Modifications to these T&Cs & the site</h3>
+
+                    <p>We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes.</p>
+
+                    <p>We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make.</p>
+
+                    <h3>General stuff</h3>
+
+                    <ul>
+                        <li><i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it.</li>
+                        <li><i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture.</li>
+                        <li><i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you</li>
+                        <li><i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you.</li>
+                        <li><i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs.</li>
+                        <li><i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us.</li>
+                        <li><i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand.</li>
+                        <li><i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time.</li>
+                        <li><i>Entire Agreement</i> – these T&Cs contain the entire understanding between us.</li>
+                        </ul>
+
+                        <h3>The Schedule</h3>
+
+                        <h4>Definitions</h4>
+
+                    <p><b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013.</p>
+                    <p><b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site.</p>
+
+                    <p><b>Event</b> means any event organised by an Organiser using the material we offer on the Site.</p>
+
+                    <p><b>Organiser</b> means the organiser or promoter of an Event.</p>
+
+                    <p><b>System</b> means the communications and other system or systems we use in connection with the Site.
+means the communications and other system or systems we use in connection with the Site.</p>
+
+                    <p><b>T&Cs</b> means these terms and conditions.</p>
+
+                    <p><b>User</b> means any person, firm or company using the Site for any purpose.</p>
+
+                    </div>
+                </div>
+         </section>
+{% endblock %}

--- a/templates/core/terms_conditions.html
+++ b/templates/core/terms_conditions.html
@@ -5,12 +5,10 @@
 {% block description %}Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain.{% endblock %}
 
 {% block content %}
-    <section id="annual-report" xmlns="http://www.w3.org/1999/html">
+    <section id="textonly-pages">
             <div class="row clearfix">
                 <div class="col-md-8 col-md-offset-2 col-sm-10 col-sm-offset-1 col-xs-10 col-xs-offset-1">
-                    <div class="report-head">
-                        <h2>Terms and Conditions of use of Django Girls Website</h2>
-                    </div>
+                        <h1>Terms and Conditions of use of Django Girls Website</h1>
 
                     <p><b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP</p>
                     <p><b>Site</b> is djangogirls.org</p>
@@ -18,7 +16,9 @@
 
                     <p>Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain.
 </p>
-                    <p><b>By entering our site you are accepting these T&Cs</b></p>
+                    <div class="important">
+                    <p>By entering our site you are accepting these T&Cs</p>
+                    </div>
 
                     <p>One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us.</p>
 

--- a/templates/global/footer.html
+++ b/templates/global/footer.html
@@ -45,6 +45,14 @@
                 </ul>
             </div>
 
+             <div class="col-md-2">
+                <p>Website</p>
+                <ul>
+                    <li><a href="{% url 'core:terms-conditions' %}">Terms & Conditions</a></li>
+                    <li><a href="{% url 'core:privacy-cookies' %}">Privacy & Cookies</a></li>
+                </ul>
+            </div>
+
             <div class="col-md-2">
                 <p>♥</p>
                 <ul>


### PR DESCRIPTION
Some organizers asked us to provide a privacy policy for the website. Here it is :tada: 
I created a new column in the footer with two links for those documents and would like feedback on this: maybe we could put those two links elsewhere.
Since the CSS for the report is really nice and make those two long walls of text okay to read, I'll create a specific set of rules for text only pages.

- [x] T&Cs text
- [x] Cookie and Privacy Policies text
- [x] Links in the footer
- [x] Create a CSS for text only pages
- [x] Add a "sharing Data with third parties." mandatory question in attendee form
- [x] Add link to privacy policy in attendee form