### PR TITLE
Changed order of EventPage, Coach and Sponsor for alphabetic by name/…

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -188,6 +188,7 @@ class EventPage(models.Model):
         return "Website for %s" % self.event.name
 
     class Meta:
+        ordering = ('title', )
         verbose_name = "Website"
 
     def delete(self):
@@ -304,7 +305,7 @@ class Sponsor(models.Model):
         return self.name
 
     class Meta:
-        ordering = ("position", )
+        ordering = ("name", )
 
     def logo_display_for_admin(self):
         if self.logo:
@@ -328,7 +329,7 @@ class Coach(models.Model):
         return self.name
 
     class Meta:
-        ordering = ("?",)
+        ordering = ("name",)
         verbose_name_plural = "Coaches"
 
     def photo_display_for_admin(self):

--- a/core/models.py
+++ b/core/models.py
@@ -119,6 +119,7 @@ class Event(models.Model):
         return self.name
 
     class Meta:
+        ordering = ('date', )
         verbose_name_plural = "List of events"
 
     def is_upcoming(self):

--- a/core/models.py
+++ b/core/models.py
@@ -119,7 +119,7 @@ class Event(models.Model):
         return self.name
 
     class Meta:
-        ordering = ('date', )
+        ordering = ('pk', )
         verbose_name_plural = "List of events"
 
     def is_upcoming(self):


### PR DESCRIPTION
…title

Hi, managing pages content became much harder after the 3rd event appeared in my admin panel. I see that now they're ordered by default chronically but maybe it would be better to order them just by title?

Same in case of sponsors and coaches - instead of default order it could be much easier to navigate if they're alphabetically :)

Justyna