### PR TITLE
Use initial color for forms in overlay

### DIFF
--- a/static/css/event.css
+++ b/static/css/event.css
@@ -122,6 +122,13 @@ a:hover {
   background: rgba(0,0,0,0.6);
   color: #fff;
 }
+.overlay button,
+.overlay input,
+.overlay optgroup,
+.overlay select,
+.overlay textarea {
+  color: initial;
+}
 .btn,
 .btn:hover {
   background: #ff9400;

--- a/static/css/event.styl
+++ b/static/css/event.styl
@@ -118,6 +118,8 @@ a, a:hover
     height: 100%
     background: rgba(0,0,0,0.6)
     color: white
+    button, input, optgroup, select, textarea
+        color: initial
 
 .btn, .btn:hover
     background: mint


### PR DESCRIPTION
On the Django Girls San Diego website we had the problem that when we added a sign up form to the sections that use a background color with a white text color, the input boxes in our form used white text on a white background.

The cause seems to be a `color: inherit` style declared by Bootstrap. Removing this style for all form fields would work. Instead of doing that, I've added a `color: initial` to form fields within the `.overlay` blocks.

I tested this out and this fixes the problem with our form so that this:

![selection_675](https://cloud.githubusercontent.com/assets/285352/13944296/79e5e1ee-efc1-11e5-8bec-63b2c3a4f70c.png)

Becomes this:

![selection_676](https://cloud.githubusercontent.com/assets/285352/13944304/7eb01abe-efc1-11e5-9b40-ad524c488f76.png)

We have already fixed this problem for the [San Diego](https://djangogirls.org/sandiego/) page (once the website comes back up). This pull request will fix this *potential problem* on all pages.

---

Keep in mind that forms that rely on the inherited color values of their surrounding elements could break due to this change (if that inherited color is different than the initial color).

The downside to this change is that **forms could break** and **inheriting color may sometimes be more convenient** than not inheriting color.