### PR TITLE
Fixed #248 -- typo in contact form template

### DIFF
--- a/templates/core/contact.html
+++ b/templates/core/contact.html
@@ -16,7 +16,7 @@
                 {% include 'includes/_faq.html' %}
 
                 <p>
-                    If you didn't find what you wanted, please check our extended <a href="{% url 'core:faq' %}">FAQ section</a> or use the form bellow. :)
+                    If you didn't find what you wanted, please check our extended <a href="{% url 'core:faq' %}">FAQ section</a> or use the form below. :)
                 </p>
 
                 <form action="" method="post" style="margin-top: 30px;">


### PR DESCRIPTION
Fixed the typo in contact form: "bellow" became "below".

Thank you for the project! 💛