### PR TITLE
Preventing organizers to create more than one form

### DIFF
--- a/applications/models.py
+++ b/applications/models.py
@@ -38,7 +38,7 @@ RSVP_LINKS = ['[rsvp-url-yes]', '[rsvp-url-no]']
 
 @python_2_unicode_compatible
 class Form(models.Model):
-    page = models.ForeignKey(EventPage, null=False, blank=False)
+    page = models.ForeignKey(EventPage, null=False, blank=False, unique=True)
     text_header = models.CharField(
         max_length=255, default="Apply for a spot at Django Girls [City]!")
     text_description = models.TextField(


### PR DESCRIPTION
When organizers create more than one form in the applications app, it makes "sending messages to attendees" crash: more than one object gets returned.