### PR TITLE
New read only fields in admin

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -41,7 +41,7 @@ class EventAdmin(admin.ModelAdmin):
 
     def get_readonly_fields(self, request, obj=None):
         if obj and not request.user.is_superuser:
-            return ('email', 'team')
+            return ('email', 'team', 'is_deleted', 'is_on_homepage')
         return self.readonly_fields
 
 
@@ -60,6 +60,8 @@ class EventPageAdmin(admin.ModelAdmin):
             # Don't let change objects for events that already happened
             if not obj.event.is_upcoming():
                 return set([x.name for x in self.model._meta.fields])
+            else:
+                return ('url', 'is_deleted')
         return self.readonly_fields
 
 


### PR DESCRIPTION
I added a few fields in read only:

On event detail page:
* Is deleted: remove it to prevent organizers to accidentally delete their event.
* Is on homepage: they don't need to change it.

On event website page:
* Is deleted: remove it to prevent organizers to accidentally delete their website.
* Url: some organizers are changing their event website: it can create problem if they don't understand what they are doing. Sometime, they also chose an url that won't be compatible with a `clone-event` (ex: city2016).