### PR TITLE
Fixing event trello dashboard

### DIFF
--- a/core/management/commands/sync_events_dashboard.py
+++ b/core/management/commands/sync_events_dashboard.py
@@ -3,8 +3,10 @@ from core.models import Event
 import re
 import datetime
 from collections import namedtuple
+import time
 
-from trello import TrelloClient
+from trello import TrelloClient, ResourceUnavailable
+
 
 # Create new command
 
@@ -60,7 +62,12 @@ def sync(events, token):
             create_checklist(card)
 
         #fetch card to get due date
-        card.fetch()
+        try:
+            card.fetch()
+        except ResourceUnavailable:
+            print("Oopsie: too many requests! Let's wait 10 seconds!")
+            time.sleep(10)
+            card.fetch()
 
         if e.date != card.due_date.date():
             print('Changing due date of {} to {}'.format(e.city, e.date))


### PR DESCRIPTION
Trello event dashboard was not working anymore: we have so many events that the script was reaching Trello Api requests limit! I've added a 10s sleep as a workaround: every time we reach the limit, the script will take a 10s pause and start again.