### PR TITLE
Add a 'short email' option for new_event command

### DIFF
--- a/core/management/commands/new_event.py
+++ b/core/management/commands/new_event.py
@@ -152,7 +152,8 @@ def brag_on_slack_bang(city, country, team):
 
 
 @click.command()
-def command():
+@click.option('--short', '-s', is_flag=True, help="Shorter version of the setup email to use with a canned email.")
+def command(short):
     """Creates new Django Girls event"""
     # Basics
     (city, country, date, url, event_mail) = get_basic_info()
@@ -207,10 +208,16 @@ def command():
         event.email
     ))
     click.echo("BODY:")
-    click.echo(render_to_string('emails/setup.txt', {
-        'event': event,
-        'email_password': 'UNDEFINED',
-        'settings': settings
-    }))
+
+    if short:
+        click.echo(render_to_string('emails/setup-short.txt', {
+            'event': event,
+        }))
+    else:
+        click.echo(render_to_string('emails/setup.txt', {
+            'event': event,
+            'email_password': 'UNDEFINED',
+            'settings': settings
+        }))
 
     brag_on_slack_bang(city, country, members)

--- a/core/tests/test_commands.py
+++ b/core/tests/test_commands.py
@@ -109,6 +109,32 @@ class CommandsTestCase(TestCase):
         event = Event.objects.last()
         assert event.team.count() == 2
 
+    def test_new_event_short(self):
+        assert Event.objects.count() == 4
+
+        random_day = self._get_random_day()
+
+        command_input = (
+            "Oz\n"
+            "Neverland\n"
+            "{random_day}\n"
+            "oz\n"
+            "oz@djangogirs.org\n"
+            "Jan Kowalski\n"
+            "jan@kowalski.example\n"
+            "N\n"
+        ).format(random_day=random_day.strftime("%d/%m/%Y"))
+
+        result = self.runner.invoke(
+            new_event,
+            args=["--short"],
+            input=command_input
+        )
+        assert Event.objects.count() == 5
+        short_email_body = """Event e-mail is: oz@djangogirs.org@djangogirls.org
+Event website address is: http://djangogirls.org/oz"""
+        assert short_email_body in result.output
+
     def test_copy_event(self):
         assert Event.objects.count() == 4
 

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -158,7 +158,7 @@ MEDIA_URL = '/uploads/'
 MEDIA_ROOT = os.path.join(BASE_DIR, 'uploads')
 DJANGO_GULP_REV_PATH = os.path.join(BASE_DIR, 'static/rev-manifest.json')
 
-if DEBUG:
+if DEBUG or 'TRAVIS' in os.environ:
     STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static/local')]
 else:
     STATICFILES_DIRS = [os.path.join(BASE_DIR, 'static/build')]

--- a/templates/emails/setup-short.txt
+++ b/templates/emails/setup-short.txt
@@ -1,0 +1,2 @@
+Event e-mail is: {{ event.email }}
+Event website address is: http://djangogirls.org/{{ event.eventpage.url }}


### PR DESCRIPTION
I've added an option `--short` or `-s` to the `new_event` command: by default, the whole setup email will be displayed. If you use this option, you'll only get event's email and website.
