### PR TITLE
Changed size of h1 and h2 in #about to not break on iPhone 6S

### DIFF
--- a/static/source/css/event.styl
+++ b/static/source/css/event.styl
@@ -418,6 +418,13 @@ a, a:hover
     #about
         background-position: 0
 
+        .overlay
+            h1
+                font-size: 50px
+
+            h2
+                font-size: 30px
+
     h1
         font-size: 30px
 
@@ -449,9 +456,9 @@ a, a:hover
     #about
         .overlay
             h1
-                font-size: 50px
+                font-size: 40px
 
             h2
-                font-size: 30px
+                font-size: 25px
 
 @import "common"


### PR DESCRIPTION
I changed the media queries for the headings in the about box so the heading gets smaller earlier.

The word "programming", which is used by default in the H1, was wide enough to break the page on some mobile devices with the previous css (Issue #306).
