### PR TITLE
Add menu item to previous event in the same city

### DIFF
--- a/core/tests/test_commands.py
+++ b/core/tests/test_commands.py
@@ -140,7 +140,8 @@ class CommandsTestCase(TestCase):
 
         assert new_eventpage.main_color == old_eventpage.main_color
         assert new_eventpage.content.count() == old_eventpage.content.count()
-        assert new_eventpage.menu.count() == old_eventpage.menu.count()
+        assert not new_eventpage.menu.count() == old_eventpage.menu.count()
+        assert new_eventpage.menu.count() == old_eventpage.menu.count() + 1
 
     def test_prepare_dispatch_with_data(self):
         today = date.today()


### PR DESCRIPTION
When copying an event via `./manage.py copy_event`, adds a menu item for the last event in the same city.

Fix #276 