### PR TITLE
Moving the 'how to organize' section up

### DIFF
--- a/templates/core/events.html
+++ b/templates/core/events.html
@@ -23,6 +23,10 @@
                 {% endfor %}
             </div>
 
+            <section id="organize">
+                {% include 'includes/_no_event.html' %}
+            </section>            
+
             <div class="row past-events">
                 <div class="col-md-12">
                     <h2>Past events</h2>
@@ -36,10 +40,6 @@
                 {% endfor %}
             </div>
 
-        </section>
-
-        <section id="organize">
-            {% include 'includes/_no_event.html' %}
         </section>
 
     </div>


### PR DESCRIPTION
"Don’t see an event in your city?" section is at the bottom of the page: the events list got bigger (:tada:) so it might be a good idea to bring it up between the next and past events.