### PR TITLE
small fixes in event page templates

### DIFF
--- a/templates/default/coach.html
+++ b/templates/default/coach.html
@@ -2,23 +2,19 @@
 	<div class="col-md-6">
 		<h2>Be a Mentor!</h2>
 		<p>
-			We would be delighted if you would like to join us as a mentor! 
-			Fill in the form  <a href="http://t.co/YvvAFiUvKN">here</a>, but 
-			select the option to be a mentor.
-		</p>
-		<p>
-			We will contact you :)
+			We would be delighted if you would like to join us as a mentor!
+			<a href="{% url 'core:contact' %}">Contact us</a> if you're interested ❤️
 		</p>
 	</div>
 
 	<div class="col-md-6">
 		<h2>Django Girls</h2>
 		<p>
-			Django Girls Australia is a part of bigger initiative: <a href="http://djangogirls.org/">Django Girls</a>.  
-			It is a non-profit organization and events are organized by volunteers in different places of the world.  
+			This workshop is a part of bigger initiative: <a href="http://djangogirls.org/">Django Girls</a>.
+			It is a non-profit organization and events are organized by volunteers in different places of the world.
 		</p>
 		<p>
-			To see the source for the program find us on Github: 
+			To see the source for the program find us on Github:
 			<a href="https://github.com/DjangoGirls/">github.com/DjangoGirls</a>.
 		</p>
 		<p>

--- a/templates/default/footer.html
+++ b/templates/default/footer.html
@@ -2,12 +2,12 @@
 
 	<div class="col-md-4">
 		<div class="facebook">
-			<div class="fb-page" 
-			     data-href="https://www.facebook.com/djangogirls" 
-			     data-small-header="true" 
-			     data-adapt-container-width="true" 
-			     data-hide-cover="true" 
-			     data-show-facepile="false" 
+			<div class="fb-page"
+			     data-href="https://www.facebook.com/djangogirls"
+			     data-small-header="true"
+			     data-adapt-container-width="true"
+			     data-hide-cover="true"
+			     data-show-facepile="false"
 			     data-show-posts="false"
 			>
 				<div class="fb-xfbml-parse-ignore">
@@ -21,9 +21,9 @@
 
 	<div class="col-md-4">
 		<div class="twitter">
-			<a href="https://twitter.com/djangogirls" 
-			   class="twitter-follow-button" 
-			   data-show-count="false" 
+			<a href="https://twitter.com/djangogirls"
+			   class="twitter-follow-button"
+			   data-show-count="false"
 			   data-size="large"
 			>
 				Follow @djangogirls
@@ -39,8 +39,8 @@
 
 <div class="row credits">
 	<div class="col-md-12">
-		♥ Django Girls Europe is organized by <a href="http://twitter.com/olasitarska">Ola Sitarska</a> a
-		nd <a href="http://twitter.com/asednecka">Ola Sendecka</a> with the support from 
+		♥ Django Girls Europe is organized by <a href="http://twitter.com/olasitarska">Ola Sitarska</a>
+		and <a href="http://twitter.com/asednecka">Ola Sendecka</a> with the support from 
 		<a href="http://europython.eu/">EuroPython 2014</a>.<br>
 
 		Django Girls Europe is a part of <a href="/">Django Girls</a>.


### PR DESCRIPTION
- Removed the coach form: some events don't change it and keep this old link.
- "Django Girls Australia..." to "This workshop": some events don't change it.
- Fix typo in footer