### PR TITLE
Fix toggling of the last question in the FAQ

### DIFF
--- a/templates/includes/_faq.html
+++ b/templates/includes/_faq.html
@@ -34,9 +34,9 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#apply"><strong>Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?</strong></a>
+            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#tutorial"><strong>Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?</strong></a>
         </div>
-        <div id="apply" class="panel-collapse collapse">
+        <div id="tutorial" class="panel-collapse collapse">
             <div class="panel-body">
                 <p>A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href="https://gitter.im/DjangoGirls/tutorial/">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)</p>
             </div>


### PR DESCRIPTION
The div id was duplicated from the first question, so that clicking on the last question was toggling the answer for the first, and there was no way to see the last answer.