### PR TITLE
Define 'city' at top of decorator

### DIFF
--- a/applications/decorators.py
+++ b/applications/decorators.py
@@ -14,14 +14,15 @@ def organiser_only(function):
 
     @wraps(function)
     def decorator(request, *args, **kwargs):
-        if not kwargs.get('city'):
+        city = kwargs.get('city')
+
+        if not city:
             raise ValueError(
                 '"City" slug must be present to user this decorator.')
 
         if not request.user.is_authenticated():
-            return redirect('core:event', kwargs.get('city'))
+            return redirect('core:event', city)
 
-        city = kwargs.get('city')
         page = get_event_page(city, request.user.is_authenticated(), False)
         if page and (request.user in page.event.team.all() or request.user.is_superuser):
             return function(request, *args, **kwargs)


### PR DESCRIPTION
`city` value used several times in related decorator. Defining it at top is better for both readability and preventing duplication.