### PR TITLE
Removing CoC and email address from the editable footer

### DIFF
--- a/applications/utils.py
+++ b/applications/utils.py
@@ -213,7 +213,7 @@ DEFAULT_QUESTIONS = [
     },
     {
         "title": "It is important that all attendees comply with the "
-        "<a href='/pages/coc/'>Django Girls Code of Conduct</a>",
+        "<a href='/coc/'>Django Girls Code of Conduct</a>",
         "question_type": "choices",
         "choices": "I've read and understood the Django Girls Code of Conduct",
         "is_required": True,

--- a/static/source/css/event.styl
+++ b/static/source/css/event.styl
@@ -210,9 +210,6 @@ a, a:hover
     margin-top: 30px
     .facebook
         margin: -10px 0 10px 0
-        float: left
-        width: 250px
-        height: 70px
 
     .twitter
         margin-top: 10px

--- a/templates/default/footer.html
+++ b/templates/default/footer.html
@@ -1,49 +1,45 @@
-<div class="row social">
+<div class="container">
+	<div class="row social">
 
-	<div class="col-md-4">
-		<div class="facebook">
-			<div class="fb-page"
-			     data-href="https://www.facebook.com/djangogirls"
-			     data-small-header="true"
-			     data-adapt-container-width="true"
-			     data-hide-cover="true"
-			     data-show-facepile="false"
-			     data-show-posts="false"
-			>
-				<div class="fb-xfbml-parse-ignore">
-					<blockquote cite="https://www.facebook.com/djangogirls">
-						<a href="https://www.facebook.com/djangogirls">Django Girls</a>
-					</blockquote>
+		<div class="col-md-6 col-xs-6 text-center">
+			<div class="facebook">
+				<div class="fb-page"
+				     data-href="https://www.facebook.com/djangogirls"
+				     data-small-header="true"
+				     data-adapt-container-width="true"
+				     data-hide-cover="true"
+				     data-show-facepile="false"
+				     data-show-posts="false"
+				>
+					<div class="fb-xfbml-parse-ignore">
+						<blockquote cite="https://www.facebook.com/djangogirls">
+							<a href="https://www.facebook.com/djangogirls">Django Girls</a>
+						</blockquote>
+					</div>
 				</div>
+			</div>
+		</div>
+
+		<div class="col-md-6 col-xs-6 text-center">
+			<div class="twitter">
+				<a href="https://twitter.com/djangogirls"
+				   class="twitter-follow-button"
+				   data-show-count="false"
+				   data-size="large"
+				>
+					Follow @djangogirls
+				</a>
 			</div>
 		</div>
 	</div>
 
-	<div class="col-md-4">
-		<div class="twitter">
-			<a href="https://twitter.com/djangogirls"
-			   class="twitter-follow-button"
-			   data-show-count="false"
-			   data-size="large"
-			>
-				Follow @djangogirls
-			</a>
+	<div class="row credits">
+		<div class="col-md-12 col-xs-12">
+			♥ Django Girls Europe is organized by <a href="http://twitter.com/olasitarska">Ola Sitarska</a>
+			and <a href="http://twitter.com/asednecka">Ola Sendecka</a> with the support from
+			<a href="http://europython.eu/">EuroPython 2014</a>.<br>
+
+			Django Girls Europe is a part of <a href="/">Django Girls</a>.
 		</div>
-	</div>
-
-	<div class="col-md-4">
-		<a href="{% url 'core:contact' %}">Get in touch</a><br>
-		<br><br>
-	</div>
-</div>
-
-<div class="row credits">
-	<div class="col-md-12">
-		♥ Django Girls Europe is organized by <a href="http://twitter.com/olasitarska">Ola Sitarska</a>
-		and <a href="http://twitter.com/asednecka">Ola Sendecka</a> with the support from 
-		<a href="http://europython.eu/">EuroPython 2014</a>.<br>
-
-		Django Girls Europe is a part of <a href="/">Django Girls</a>.
-		<br>Every participant needs to follow the <a href="/pages/coc/">Code of Conduct</a>.
 	</div>
 </div>

--- a/templates/global/footer.html
+++ b/templates/global/footer.html
@@ -9,7 +9,7 @@
                     <li><a href="{% url 'core:foundation' %}">Foundation</a></li>
                     <li><a href="{% url 'core:newsletter' %}">Newsletter</a></li>
                     <li><a href="http://gitter.im/DjangoGirls/tutorial"><strong>Chat with us!</strong></a></li>
-                    <li><a href="/pages/coc/">Code of Conduct</a></li>
+                    <li><a href="{% url 'core:coc' %}">Code of Conduct</a></li>
                     <li><a href="{% url 'core:contact' %}">Contact</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
Small fixes:

- Updating CoC's link in the global website footer.
- Removing CoC's link and event email address from the editable footer.