### PR TITLE
Clone event

### DIFF
--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -11,6 +11,7 @@ def copy_event(previous_event, event_date):
     """
     number = Event.objects.filter(city=previous_event.city,
                                   country=previous_event.country).count()
+    previous_event_id = previous_event.pk
     # If event is already Django Girls City #2, remove #2 from it
     if '#' in previous_event.name:
         generic_event_name = previous_event.name.split(' #')[0]
@@ -29,7 +30,9 @@ def copy_event(previous_event, event_date):
     new_event.save()
 
     # Change url, title and name of previous event to {name} #{number-1}
+    previous_event = Event.objects.get(pk=previous_event_id)
     previous_event.name = previous_event_name
+    previous_event.save()
     previous_event.page_title = previous_event_name
     previous_event.page_url = "{}{}".format(previous_event.page_url, number-1)
     previous_event.save()

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -1,0 +1,68 @@
+from core.models import Event
+
+
+def copy_event(previous_event, event_date):
+    """
+        Copy event from the previous one. This does the following steps:
+        - change name of previous event to {name} #{number}, i.e.
+          Django Girls London #1
+        - create new event based on previous event
+        - copy content and menu from previous event
+    """
+    number = Event.objects.filter(city=previous_event.city).count()
+
+    # Change the name of previous event to {name} #{number-1}
+    previous_event_name = "{} #{}".format(previous_event.name, number-1)
+    previous_event.name = previous_event_name
+    previous_event.save()
+
+    # Copy event with a name {name} #{number} and new date
+    event_name = "{} #{}".format(previous_event.name, number)
+    new_event = previous_event
+    new_event.pk = None
+    new_event.name = event_name
+    new_event.date = event_date
+    new_event.is_page_live = False
+    new_event.save()
+
+    # Change the title and url of previous event page
+    previous_event.page_title = previous_event_name
+    previous_event.page_url = "{}{}".format(previous_event.page_url, number-1)
+    previous_event.save()
+
+    # populate content & menu from the default event
+    copy_content_from_previous_event(previous_event, new_event)
+    copy_menu_from_previous_event(previous_event, new_event)
+
+    return new_event
+
+
+def copy_content_from_previous_event(previous_event, new_event):
+    """
+        Copies page content from the previous event
+    """
+    previous_event.refresh_from_db()
+    for obj in previous_event.content.all():
+        # fetch related objects before we change pk of the event
+        coaches = obj.coaches.all()
+        sponsors = obj.sponsors.all()
+
+        new_content = obj
+        new_content.id = None
+        new_content.event = new_event
+        new_content.save()
+
+        new_content.coaches = coaches
+        new_content.sponsors = sponsors
+        new_content.save()
+
+
+def copy_menu_from_previous_event(previous_event, new_event):
+    """
+        Copies page menu from the previous event
+    """
+    for obj in previous_event.menu.all():
+        new_obj = obj
+        new_obj.pk = None
+        new_obj.event = new_event
+        new_obj.save()

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -21,6 +21,9 @@ def copy_event(previous_event, event_date):
     previous_event_name = "{} #{}".format(generic_event_name, number)
     event_name = "{} #{}".format(generic_event_name, number+1)
 
+    previous_event_name = "{} #{}".format(previous_event.name, number)
+    event_name = "{} #{}".format(previous_event.name, number+1)
+
     # Change the name of previous event to {name} #{number-1}
     previous_event.name = previous_event_name
     previous_event.save()

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -11,7 +11,6 @@ def copy_event(previous_event, event_date):
     """
     number = Event.objects.filter(city=previous_event.city,
                                   country=previous_event.country).count()
-
     # If event is already Django Girls City #2, remove #2 from it
     if '#' in previous_event.name:
         generic_event_name = previous_event.name.split(' #')[0]
@@ -20,9 +19,6 @@ def copy_event(previous_event, event_date):
 
     previous_event_name = "{} #{}".format(generic_event_name, number)
     event_name = "{} #{}".format(generic_event_name, number+1)
-
-    previous_event_name = "{} #{}".format(previous_event.name, number)
-    event_name = "{} #{}".format(previous_event.name, number+1)
 
     # Change the name of previous event to {name} #{number-1}
     previous_event.name = previous_event_name

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -11,13 +11,14 @@ def copy_event(previous_event, event_date):
     """
     number = Event.objects.filter(city=previous_event.city).count()
 
+    previous_event_name = "{} #{}".format(previous_event.name, number)
+    event_name = "{} #{}".format(previous_event.name, number+1)
+
     # Change the name of previous event to {name} #{number-1}
-    previous_event_name = "{} #{}".format(previous_event.name, number-1)
     previous_event.name = previous_event_name
     previous_event.save()
 
     # Copy event with a name {name} #{number} and new date
-    event_name = "{} #{}".format(previous_event.name, number)
     new_event = previous_event
     new_event.pk = None
     new_event.name = event_name

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -9,10 +9,17 @@ def copy_event(previous_event, event_date):
         - create new event based on previous event
         - copy content and menu from previous event
     """
-    number = Event.objects.filter(city=previous_event.city).count()
+    number = Event.objects.filter(city=previous_event.city,
+                                  country=previous_event.country).count()
 
-    previous_event_name = "{} #{}".format(previous_event.name, number)
-    event_name = "{} #{}".format(previous_event.name, number+1)
+    # If event is already Django Girls City #2, remove #2 from it
+    if '#' in previous_event.name:
+        generic_event_name = previous_event.name.split(' #')[0]
+    else:
+        generic_event_name = previous_event.name
+
+    previous_event_name = "{} #{}".format(generic_event_name, number)
+    event_name = "{} #{}".format(generic_event_name, number+1)
 
     # Change the name of previous event to {name} #{number-1}
     previous_event.name = previous_event_name
@@ -44,17 +51,9 @@ def copy_content_from_previous_event(previous_event, new_event):
     """
     previous_event.refresh_from_db()
     for obj in previous_event.content.all():
-        # fetch related objects before we change pk of the event
-        coaches = obj.coaches.all()
-        sponsors = obj.sponsors.all()
-
         new_content = obj
         new_content.id = None
         new_content.event = new_event
-        new_content.save()
-
-        new_content.coaches = coaches
-        new_content.sponsors = sponsors
         new_content.save()
 
 

--- a/core/deploy_event.py
+++ b/core/deploy_event.py
@@ -20,10 +20,6 @@ def copy_event(previous_event, event_date):
     previous_event_name = "{} #{}".format(generic_event_name, number)
     event_name = "{} #{}".format(generic_event_name, number+1)
 
-    # Change the name of previous event to {name} #{number-1}
-    previous_event.name = previous_event_name
-    previous_event.save()
-
     # Copy event with a name {name} #{number} and new date
     new_event = previous_event
     new_event.pk = None
@@ -32,7 +28,8 @@ def copy_event(previous_event, event_date):
     new_event.is_page_live = False
     new_event.save()
 
-    # Change the title and url of previous event page
+    # Change url, title and name of previous event to {name} #{number-1}
+    previous_event.name = previous_event_name
     previous_event.page_title = previous_event_name
     previous_event.page_url = "{}{}".format(previous_event.page_url, number-1)
     previous_event.save()

--- a/core/fixtures/core_views_testdata.json
+++ b/core/fixtures/core_views_testdata.json
@@ -198,7 +198,7 @@
     "fields": {
         "name": "Company name"
     },
-    "model": "core.sponsor",
+    "model": "sponsor.sponsor",
     "pk": 1
 },
 {

--- a/core/fixtures/core_views_testdata.json
+++ b/core/fixtures/core_views_testdata.json
@@ -52,6 +52,7 @@
 },
 {
     "fields": {
+        "email": "kensinton@djangogirls.org",
         "city": "Kensington",
         "name": "Django Girls Kensington",
         "country": "the Neverlands",

--- a/core/fixtures/core_views_testdata.json
+++ b/core/fixtures/core_views_testdata.json
@@ -189,12 +189,29 @@
 },
 {
     "fields": {
+        "name": "Anna Smith"
+    },
+    "model": "core.coach",
+    "pk": 1
+},
+{
+    "fields": {
+        "name": "Company name"
+    },
+    "model": "core.sponsor",
+    "pk": 1
+},
+{
+    "fields": {
         "name": "coach",
         "content": "<div class=\"row\"><div class=\"col-md-6\"><h2>Be a Mentor!</h2><p>We would be delighted if you would like to join us as a mentor! Fill in the form  <a href=\"http://t.co/YvvAFiUvKN\">here</a>, but select the option to be a mentor.</p><p>We will contact you :)</p></div><div class=\"col-md-6\"><h2>Django Girls</h2><p>Django Girls Australia is a part of bigger initiative: <a href=\"http://djangogirls.org/\">Django Girls</a>.  It is a non-profit organization and events are organized by volunteers in different places of the world.  </p><p>To see the source for the program find us on GitHub: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>.</p><p>If you want to bring Django Girls to your city, drop us a line: <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>.</p></div></div>",
         "background": "event/backgrounds/photo0_cBUZ8zp.jpg",
         "is_public": true,
         "position": 40,
-        "event": 1
+        "event": 1,
+        "coaches": [
+          1
+        ]
     },
     "model": "core.eventpagecontent",
     "pk": 5
@@ -206,7 +223,10 @@
         "background": "",
         "is_public": true,
         "position": 50,
-        "event": 1
+        "event": 1,
+        "sponsors": [
+          1
+        ]
     },
     "model": "core.eventpagecontent",
     "pk": 6

--- a/core/tests/test_deploy_event.py
+++ b/core/tests/test_deploy_event.py
@@ -19,10 +19,11 @@ class CopyEventTest(TestCase):
         copy_content_from_previous_event(previous_event, new_event)
         self.assertEquals(new_event.content.count(), 7)
 
+        # coaches and sponsors shouldn't carry over
         coaches = Coach.objects.filter(eventpagecontent__event=new_event)
         sponsors = Sponsor.objects.filter(eventpagecontent__event=new_event)
-        self.assertEquals(coaches.count(), 1)
-        self.assertEquals(sponsors.count(), 1)
+        self.assertEquals(coaches.count(), 0)
+        self.assertEquals(sponsors.count(), 0)
 
     def test_copy_menu_from_previous_event(self):
         previous_event = Event.objects.get(pk=1)

--- a/core/tests/test_deploy_event.py
+++ b/core/tests/test_deploy_event.py
@@ -1,7 +1,9 @@
+from datetime import date
 from django.test import TestCase
 
 from core.deploy_event import (
     copy_content_from_previous_event,
+    copy_event,
     copy_menu_from_previous_event,
 )
 from core.models import Coach, Event, Sponsor
@@ -9,9 +11,6 @@ from core.models import Coach, Event, Sponsor
 
 class CopyEventTest(TestCase):
     fixtures = ['core_views_testdata.json', 'groups_testdata.json']
-
-    def test_copy_event(self):
-        pass
 
     def test_copy_content_from_previous_event(self):
         previous_event = Event.objects.get(pk=1)
@@ -31,3 +30,17 @@ class CopyEventTest(TestCase):
         self.assertEquals(new_event.menu.count(), 0)
         copy_menu_from_previous_event(previous_event, new_event)
         self.assertEquals(new_event.menu.count(), 5)
+
+    def test_copy_event(self):
+        previous_event = Event.objects.get(pk=1)
+        previous_name = previous_event.name
+        new_date = date(2020, 10, 20)
+
+        new_event = copy_event(previous_event, new_date)
+
+        # we need to refetch the event as we changed id of the object
+        # inside copy_event method
+        previous_event = Event.objects.get(pk=1)
+
+        self.assertEquals(previous_event.name, "{} #1".format(previous_name))
+        self.assertEquals(new_event.name, "{} #2".format(previous_name))

--- a/core/tests/test_deploy_event.py
+++ b/core/tests/test_deploy_event.py
@@ -1,0 +1,33 @@
+from django.test import TestCase
+
+from core.deploy_event import (
+    copy_content_from_previous_event,
+    copy_menu_from_previous_event,
+)
+from core.models import Coach, Event, Sponsor
+
+
+class CopyEventTest(TestCase):
+    fixtures = ['core_views_testdata.json', 'groups_testdata.json']
+
+    def test_copy_event(self):
+        pass
+
+    def test_copy_content_from_previous_event(self):
+        previous_event = Event.objects.get(pk=1)
+        new_event = Event.objects.create()
+        self.assertEquals(new_event.content.count(), 0)
+        copy_content_from_previous_event(previous_event, new_event)
+        self.assertEquals(new_event.content.count(), 7)
+
+        coaches = Coach.objects.filter(eventpagecontent__event=new_event)
+        sponsors = Sponsor.objects.filter(eventpagecontent__event=new_event)
+        self.assertEquals(coaches.count(), 1)
+        self.assertEquals(sponsors.count(), 1)
+
+    def test_copy_menu_from_previous_event(self):
+        previous_event = Event.objects.get(pk=1)
+        new_event = Event.objects.create()
+        self.assertEquals(new_event.menu.count(), 0)
+        copy_menu_from_previous_event(previous_event, new_event)
+        self.assertEquals(new_event.menu.count(), 5)

--- a/core/tests/test_deploy_event.py
+++ b/core/tests/test_deploy_event.py
@@ -44,3 +44,13 @@ class CopyEventTest(TestCase):
 
         self.assertEquals(previous_event.name, "{} #1".format(previous_name))
         self.assertEquals(new_event.name, "{} #2".format(previous_name))
+        self.assertTrue(previous_event.date != new_event.date)
+
+        self.assertEquals(previous_event.city, new_event.city)
+        self.assertEquals(previous_event.country, new_event.country)
+        self.assertEquals(previous_event.latlng, new_event.latlng)
+        self.assertEquals(previous_event.photo, new_event.photo)
+        self.assertEquals(
+            previous_event.main_organizer,
+            new_event.main_organizer
+        )

--- a/core/tests/test_deploy_event.py
+++ b/core/tests/test_deploy_event.py
@@ -1,12 +1,13 @@
 from datetime import date
 from django.test import TestCase
 
-from core.deploy_event import (
+from ..deploy_event import (
     copy_content_from_previous_event,
     copy_event,
     copy_menu_from_previous_event,
 )
-from core.models import Coach, Event, Sponsor
+from ..models import Coach, Event
+from sponsor.models import Sponsor
 
 
 class CopyEventTest(TestCase):

--- a/organize/models.py
+++ b/organize/models.py
@@ -119,7 +119,8 @@ class EventApplication(models.Model):
 
         self.change_status_to(DEPLOYED)
 
-        if self.previous_event:
+        if Event.objects.filter(city=self.city,
+                                country=self.get_country_display()).exists():
             event = copy_event(self.previous_event, self.date)
         else:
             event = self.create_event()

--- a/organize/models.py
+++ b/organize/models.py
@@ -102,9 +102,11 @@ class EventApplication(models.Model):
         """
         previous_event = Event.objects.filter(city=self.city,
                                               country=self.country).order_by('-id').first()
-        organizers = previous_event.team.all().values_list('email', flat=True)
-        applicants = self.get_organizers_emails()
-        return len(set(organizers).intersection(applicants)) > 0
+        if previous_event:
+            organizers = previous_event.team.all().values_list('email', flat=True)
+            applicants = self.get_organizers_emails()
+            return len(set(organizers).intersection(applicants)) > 0
+        return False
 
     @transaction.atomic
     def deploy(self):

--- a/organize/models.py
+++ b/organize/models.py
@@ -119,9 +119,19 @@ class EventApplication(models.Model):
 
         self.change_status_to(DEPLOYED)
 
-        if Event.objects.filter(city=self.city,
-                                country=self.get_country_display()).exists():
-            event = copy_event(self.previous_event, self.date)
+        event = None
+        if self.previous_event:
+            previous_event = self.previous_event
+        else:
+            previous_event = (
+                Event.objects
+                .filter(city=self.city, country=self.country)
+                .order_by("-date")
+                .first()
+            )
+
+        if previous_event:
+            event = copy_event(previous_event, self.date)
         else:
             event = self.create_event()
 

--- a/organize/models.py
+++ b/organize/models.py
@@ -122,15 +122,12 @@ class EventApplication(models.Model):
         self.change_status_to(DEPLOYED)
 
         event = None
-        if self.previous_event:
-            previous_event = self.previous_event
-        else:
-            previous_event = (
-                Event.objects
-                .filter(city=self.city, country=self.country)
-                .order_by("-date")
-                .first()
-            )
+        previous_event = (
+            Event.objects
+            .filter(city=self.city, country=self.country)
+            .order_by("-date")
+            .first()
+        )
 
         if previous_event:
             event = copy_event(previous_event, self.date)

--- a/organize/tests/test_models.py
+++ b/organize/tests/test_models.py
@@ -1,3 +1,4 @@
+import vcr
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.test import TestCase
@@ -35,6 +36,7 @@ class EventApplicationTest(TestCase):
         email = mail.outbox[0]
         assert email.to == event_application.get_organizers_emails()
 
+    @vcr.use_cassette('organize/tests/vcr/deploy_from_previous_event.yaml')
     def test_deploy_event_from_previous_event(self):
         event_application = EventApplication.objects.get(pk=1)
         event_application.previous_event_id = 1

--- a/organize/tests/test_models.py
+++ b/organize/tests/test_models.py
@@ -5,10 +5,11 @@ from django.test import TestCase
 
 from organize.constants import DEPLOYED, ON_HOLD, REJECTED
 from organize.models import EventApplication
+from core.models import Event
 
 
 class EventApplicationTest(TestCase):
-    fixtures = ['event_application_testdata.json', "core_views_testdata.json"]
+    fixtures = ['event_application_testdata.json']
 
     def test_comment_required_for_on_hold_application(self):
         event_application = EventApplication.objects.get(pk=1)
@@ -39,8 +40,10 @@ class EventApplicationTest(TestCase):
     @vcr.use_cassette('organize/tests/vcr/deploy_from_previous_event.yaml')
     def test_deploy_event_from_previous_event(self):
         event_application = EventApplication.objects.get(pk=1)
-        event_application.previous_event_id = 1
-        event_application.save()
+        Event.objects.create(
+            city=event_application.city,
+            country=event_application.country
+        )
 
         event_application.deploy()
 

--- a/organize/tests/vcr/deploy_from_previous_event.yaml
+++ b/organize/tests/vcr/deploy_from_previous_event.yaml
@@ -1,0 +1,881 @@
+interactions:
+- request:
+    body: grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImYzMTAwOGJlYzU4YmM4OTc2MmYwNTk2NmI4ZjYyZGM2OWY2YTI3NTAifQ.eyJpYXQiOjE0ODUxMjMyMDAsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9hZG1pbi5kaXJlY3RvcnkudXNlciIsImV4cCI6MTQ4NTEyNjgwMCwic3ViIjoiaGVsbG9AZGphbmdvZ2lybHMub3JnIiwiaXNzIjoiZGphbmdvLWdpcmxzLXdlYnNpdGVAZGphbmdvZ2lybHMtd2Vic2l0ZS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImF1ZCI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiJ9.RZEEM2YasU8IRdLl_c8GhdFEXZa2nwGNBt-lP8C55NkZj6cy1nl_jpdLMP1fu5c45-26Ul-4p6kturYrX0W8smiFB0rkz--hm0ZS_HF5xut8wcHSKMSKqzWHKHDz4sPHFExR2umPp7sPAdocW1B5Bg6vlwDU9EGn9dgDpdHPY1lGEEJp1Yq--4rH1Cd883VtzLlzeUg97w0dlbDIvfIbzbIcw3Mixeq-tr5dOXxSmY-FBCtid8YjihMlhtIpt3GnmDYn7jM6CJ1Cs_EDCxh46igVPSgaJh5NjYaNkvB9r3StHtjcA1L_4JLv8--wmwGQGBJqEyhZwWqF88zeK8zqOw
+    headers:
+      accept-encoding: ['gzip, deflate']
+      content-type: [application/x-www-form-urlencoded]
+      user-agent: [Python-httplib2/0.9.2 (gzip)]
+    method: POST
+    uri: https://accounts.google.com/o/oauth2/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/xzPwU6DMAAA0Pu+gnBW0xUK1BvMsIlFBaoOLwSahhUUkAK2GP/dyPXd3s/OMMyS
+        MS5lMfUt70zj1jB1CfHNsXMrX7FUOBnN6IHk5CvaT95Z0BjFBDBoRU7DKr9Wd6OrQkRm/AZqZ/6Y
+        3KjPEr1vWtsX9BK3OBTeg6T3kXcKLAupuuELhPAzDKiHwHqZg3pYdDDrwxNTlHU0765lde7hccVp
+        AmIMU/79vKJT4clySfpHew5fNM5ffaLela198+q/wdUgRi4LsSUsB4CNt1Yx6YFvt4CXIx/N3e8f
+        AAAA//8DACCo+wr7AAAA
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Content-Disposition: [attachment; filename="json.txt"; filename*=UTF-8''json.txt]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 22 Jan 2017 22:13:21 GMT']
+      Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [ESF]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      accept-encoding: ['gzip, deflate']
+      authorization: [Bearer ya29.Gn7bAxcRi6STSTCLYLqJ1t8XiTM5ML0c23J6jcbAgxDr7xF5Lu9W0g6ult7JoSQy1jk4AiThMk9Fi8KsTIJ8HB335xgjev222mFBT850zhuBgpvyBuyCOcxTcnTYn-sbXo2Gz9RQ0M92RewPz5H_8savQoN4uFUy9YVALxZx4yA]
+      user-agent: [Python-httplib2/0.9.2 (gzip)]
+    method: GET
+    uri: https://www.googleapis.com/discovery/v1/apis/admin/directory_v1/rest
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAO19a3PjNrLo9/kVqMmtu8kpjzyPbGo3t07dUmzPrE/Gj2vZSe092ZqiRFjijkRq
+        Scoeb2r+++luACRAgiT4kF9RVSojk0SjAfQbjcbvL9jLz0Hov/yRvfSDZBbd8Pjum5gn6SFPZnGw
+        ToMofLkHX/HUm+NXv71Mp3fJDwffv47e/OXD/7+9O+Hhnz+cfPZ/fvUu2f/zf/0zOn/3y/zPG3/8
+        9+//7b/92ywJ/+r/PJ6c/PaS4GS9/MLjBIEDzJs39CogNDx/FYQ/+kHMZ2kU332SL0NvxbPX9GTm
+        hVEYzLzlqXyVtaHXNzn8ErCY3wTq5dvXb3548/bN9/QiDdIlwRpjN+xQNWTj82OBvjYt8NnlgjPx
+        6eTwZ/NztuRpwu6iDbsJ+C3zQp+tvNCbc8bDlMfrOEg4g5mONvGMJyzZzBbMS9gmAbzp63kcbdbJ
+        HqMRB0kae2lww1kYpcE1DBtRgLcJn23iIL1j19xLNwBvT3QVxXxEGEe3IY8Po5UXEMbzKJov+WgW
+        rfK3agI/0Dt6vvZmnwHXcy9dmLMezKBbePT7C8ZefnnzA75dpOk6+XF///b2djRPUkBthh3sBysA
+        kexPY8AoCOf76zjyN7N0/82XfYHG/NObH/z1aB3OETbAe/e2J7x3byW8F+wrrVc026xgwmm6Pgbh
+        Zx2+z2/4MlrDhI/yadmnsb5K/M/7Gd3sizmJozSaRUsEgSxCD6dewq/iZQltguetgySHqcG7ebOf
+        tVZzXPlRHEVpcxf0KRDPTTAzl83abTpbqI/oD7noMVACEGe2wN4ylT+BN+7WRCVAiYFcsBI/HHqp
+        x66jeOWl+A9LF0Tja6AZQY7U5NrbENyX/0yEdIGnPNys4NF/4x/yBf78R/5Wk0hJ/uWFhJ6w2yBd
+        sIMImCtMX10Csiy6Zt56vZTMsl8EuozEC8TkXxsQSfjyKxHidcCXftJq6BO+pFlmyZrPgus7+JDd
+        LgLgagGMpRELwtly43P4l3kMZjsNvGVpfmrQ+szvWuGEYgjajNjfQcow+RcLfJghkCGcxFPMgK7/
+        CaiT3IDfN/BeCC6aUWzlzUBEgWT51yZKPSFgYr6O4jQZsQv+rw0QmM824RI+ooYSCnzIzsYbAPJ2
+        9BrG/5mHDoOMPGjxib5uNdhCTxn9gXyMYcAkWR26X8c8Te/OoZ8y6U+jCDgutPd/wUH+hkm2nmL6
+        QLkq8SPE+jIIOZvG3PucWDgijTe8GUdahysYTztquPGCpTddciRFmA2aIQLF1pt4HSET4SMUIjx+
+        ldAK5vwDa30ACzrFZb1jXjwNQCWBrhNdgu5KgnkIdADAPZrsPTbdpCxZRJulj2qL8S8zDh98/5rN
+        FiBqZihpRuwMOouJ5rDR8ZoF12wawdR5MVeU5DssnGjdakaOz0G7+jGSLcgKJJYkSGHhFhy6FrIL
+        OklSFsXBPAi9lAO+MO/wLkgQT+ISD4gLBs1DmLwZoAxzh7jASq+CNKnHXKopJHklc4n+32bjAHNp
+        zTNRVK9loKHQIqNM5o9mmySNVjmplGfhl4J9olrA6JcwZB9oWIj0QMpPMeE9cBkB+ftRuLxrQGp7
+        mIDqBz05mi1igB8l7pNDEvOAmrGzCRNwkj8x0JueD9pvULRc5+lekFpF04CM4zYzJRptFaMRCBKB
+        QgViJ5X4sOkdsivSFIkw09JOveRzMiSibVZzSxOn/ADHNUQZSCIYvSWcIhCTAoZQFYSq4tK+c0Vw
+        XSdJYaEkAwjgIZEh56vfPAn/jUWhQExOfX+sRiu+mraR59QKHMxpbj9vDSvX5bsfnNogM2z/hpfu
+        vlRGM6DtGQdB5A+KWRTPN2GQuuMEDbww+DfhxLDpsDMl8XFdqy1jowIyo5m35KHvtWAzmwxQULRA
+        z1axdTastowXuEliVjD20qiZfXCd5yTFCRDD5pp+GR4jZyWzfcQ2SRtRbqMxETEccvnIU/aWgddC
+        cpHHQ20GpqUcGddV2y4qLZDYQu8q3NvMUxiJE3EbNHFXQZKQTkHi3Q5uyWwBLNaflpkAtC0EW1FR
+        LSov5P+UEy8/Vn78WGcgubkhnu0ZAYpoitE3e4DivyZnpyzlqzUaubR2BIGJNqy4RaFiDTCtsOZp
+        oMcNivxsi49YYkaCkRgMLFiaSyB3hNrBO7r05irWkmkvEy7NVDuoV2Hwrw1nga9AC/Py2wtY6le4
+        1t+x0ie0vtoXJhJyU6wdGj9DIwSvBibDRCoEZEb6iEK/ySj0G7E+BhLrOFh58d0RzX1bZD7gFPwJ
+        mF8AEStoTgnMQN0HRTLfy6iaW+mat6bsLFSakTi4cUvwwDPx3ZrCuY3GvTj27qom6iP2h1sFGmdp
+        SxYAbhpMDWh4J2ZITNHW+eKBSJIndjpI1kUagCfu6487p/mqL7wUUBTxc8A4uAn8jbdk48k5+3Ys
+        lNhB5PPvSK3V0cAMvjq2TVMQpnwOplbFPCE6GyEijg/VQkD3+TyJwKME9e6tuTYzUCoI6jJY8dZr
+        RFMBDTHuHKqO2S0QI4Hl/ogdfVljlJoioCjKvogGAqcKHH/4fmB5TdPRnyRpuHJ7jsCeH+ckzy4F
+        fQI33np3CSuRZLJ2I10gRgPVpZekuDog9DqibF0hBIuqZKA1klkO7bHDhmpCtT0bwVlK3e3hrh3g
+        iAkIPsY+4UUgzMFjf0/kJcCLSjI0ccVmP/O7TuiWWI208e0igqVPNhjOM+mtJHtKCggf1Ugfm6zY
+        mgFjagw3LTQWeg8g46xnbnmNHvpfMb9Wctemhx6EOVGZujIofmtd3wMZnbiQHRfWuvS6jz2tgDEF
+        rYttjZTU3rbels4vrmG+fu9hwOXQzx59deMt0T4ur2r23TeqafJNcQmcltwFkDl81eLQGGD72ZjG
+        Ab9m2gs1NaXJGNkR6GaCX9LkS3Na2tcg8rLEhFLn7AMPeSwCTgkliFAQkYwL3J9ioS12V4Gz1Qxq
+        I5qr8czae2EYpcUgN6IgckJeqjQd6qsUtkyyuGUyCsANiKU4YOwfNoGmmp0OoSQtk4/cwb94IBz4
+        HruMwdHHSb+IohV7M37YIV+KMfaTA5YhozVE60wOMw43DwgHodmKVDSa0fG1lxNdveQuquny+2Fl
+        N/lyKiWsqyR/NDYBLmBpxsS6BCge5ly6diBwXSwFu7Adwmw4zlPKCDeQXh6bRUtMiZPitjSQRnPC
+        pi9mRSjOBocztIJFzr+k5zDTl3o+WisWnEUwNeFG2uMIZo88Box1rEUgFJhvvgBfIp5zuZws4Zhc
+        dy4T6WhSpYbG3EHcOMXUpDDNUpQAmvCgiQwR7TKFWFl2ARKNL4uMKp+6s+c4NHYvMcULIWRDvcU0
+        U2LbLBaBn8wzG9ce0xHpWZ0mXqV2iXQuc2sVc8t8vgxuyOMRmg6mWCJdYF7+ZR3EXifr4xBlFQa9
+        yReEtbDOUd7BHv6WbiQxUeZIJilopj1c/lWwBF+BA135mD5HfXlLRw+zQ3R1zK6u0FOLWRJA36gK
+        hI0gM//IxwwKEsA+k8MJF0dakyQmkhJzvfcLstKPxCnXwRdoJIfy20tvHXwjwf320i5Y8i8K4VpM
+        n7aRqs42lun1/UAsIcsTsElqxCBAEStJqHfZOKd84d0EUWxbfS8Dd17mp8o5LxMun8FK80QanRlm
+        GDZAO2pkVR5r724ZebYlNlJnbTT2k/hASjlKlvZxfSnoAgsVMwkcNQbmXGLMJR/+UCYwiLFo7UkL
+        uEzZuYKHRaAUbyQ1kaJh0D2bpJRq683iCGSQH1xfc0pDRo9ank1JKtC+ioMOTCqBvhL558EsRzzO
+        THmFbYWVknZScjBlpWzgXLbCSmLPKSq3NJfJmBvNPeBSg5HzZnhGqDCjFYud9rWNM/ZacewrSFZC
+        kFRphaL+xLTLs+SQMvVKatR42cvYlemdCRPAckJstUcyw9RGDIRekGBsa5JmmyUzkSKJWi0WIlbf
+        OWrcPDFFohVXE139cWVU3ybHNkKxFhWn3sQa2s8pjKDCMthRKMjRChOA9rbBHLN3S9CzXl8Y/5oC
+        Vnqf3B+DiZB2kW+inTylEgCZ+xviWB6iusHsGEZ0r2xSlPm5z/vSjs3HPLm9JToq/T5mKkFeeVIi
+        9RW1PXSSxav1JN0orkDnykyqcdxERv/W6NuEDhosPYn89rJGcC40/8wQBlsBkOqdZ9F1h5XNdrgz
+        qY9eV5YULqVGZb/b8nxJd4c8PfFm447GvDaBAIVlNBMyBRxslPQ2ij/n8YnqgV4H8eoWTJv8AGpn
+        bBQopXsfUz6BOkNgI2XctTrK+L3TpqXp2Gj8mu2KCYECjGtTDKbse4VAyihO7sLZFhBLACxMThj8
+        Gze70BChVKRoGczu0O/GWGsW/hJnYtl4vU5M0aMsdDBL0STvNMjVNnjiFpi/DT+seAef8EQcTzj6
+        1yZYk86wGJvvPqhTDDMv9tWEaohXowQSsn24XZ8SBFANHxVK+yk/xVZowTopoyj2eXy6KaTqtx4J
+        gWEhwakeUBTPQfyn8khvu87ORNs61RclAwhLsFx/aRKTaO4i1wzQnQLVLJsxzT5MUf13NocFCCVp
+        KNmQQjX4OafD6nIhgW5IBi2jOfIDiqht2M3c3K+qnkDLmGivq3gukpJP2blIHmC0nxVoO/fkSoFu
+        Eqmdvs2CNt20VhgVNzIoZ9rJXIYPA2/ZnwsFnEY2xFoFm/aCRTQr2L3VnWzWePT6KPQPDafEsbP3
+        AUaafJF2lStHcI3waK8E3lVrI5jxJo0ueMhv20eBfkUstGn3NhTVxgCUd42OiEQPbAtfDKEpXdF0
+        wMfGSUGrjy4/aempZ0F43WMH65B2bWfZ8SbVlTLGDc/9UJ5JdPDguzhaM7n/gKucenhAPtIVcoZU
+        z41O0+xM1OFM+aV1k9PnWRo4rGZSN7jmJS7tOBbetl7YYoYqriyJ/aJrBSu85nmwwTkkU5ixriqo
+        5Ok1Z7Jm+4JmlMq2Rs8nqbU43aZh2G+3j+pOqE0IefjC2IkjRMV2XEU0sXBaX1GxetwrgqhO0/dJ
+        dfKWIIexEkL3lBh1RPdPCRPBOIwbozcFskJmyUjrQ24RG8/AmUDBhGJMCrAE0zrEyQyMFqVaF4eW
+        oyPq3UHfnF1tHCr/V7PoWmrOAsY98VE5/XJWKPFFABixw4iKcahaNLQtcHsLTfh18EUkfxYzjlTZ
+        hkd7AKQicSmfEOnGA09GmzAd6UvUXx4dV+wQiSwINXlq07EkkAzebhBe6lsD6aUXzjcYXO5JNceT
+        M/bDu7++essURIb59MiFaCgSVnmeIA9fXU0K7tsiCnlHa7vIUVIeEEhleAMpH43e/PB9llRt9h6B
+        Ib0sB1QyNSehnxvfOTIUtclkkFaHpF6On9twKgh1Cz4dJXwBS9yn0Zi3RqiLBh+DkL9pb1ka87S4
+        S7Amny7BuS66UW7PohVWGyIdjqtLW4Qx51QbqbgpquH2tj1usmMquvQ2S5CXuFV29K5fR+/qO5Kk
+        3TmNMauKIwHBtGs78nkvIOjiu4MuOxZZYhZT1j6TZHMnk4hz4DovgD4XCgUlybs3P/ygPiQ5wviS
+        Tl8X5wM3fpbmmVbHgJyWz6mAjNg4VFmcggHUm1xykW7AJ/B+AiT5PvbCGdalHJWialmtge6rBcSO
+        BbNo1sRPPN9EISnLsgkW7rhqXEkAIbbHLIeWzQktq/zs38FarIyqPvnm9evXf80T89CgAo0Z+zA/
+        sp7ZK4ZHb3/c30c/HDMcJBEmo5Cn+34MfjplIIwW6Wr5jWSAT3LlS/kO8y6urL7sAkR50cXzfMlP
+        /55ZBRhtoa9OwbT5exR/tktwYYjZDvHqb/pIawGn+4ne3ofOTKtVhZ+kIU0n7vX4imOCmZ/PTmee
+        0XGwMcnz8Ua12SolkwHDCBLpPI8CiOEFZAfCjDmmrLokmgV09gAZXQoB1Ng8oPQrLPyXORZUJlD5
+        bjp8bEspqgW7o3NASRZ6csmWv+ExpTS0Dzwey1wzoRsEHJmNkIkLr5o1mgRIKSplvusdk1KnpnUE
+        Wx6e9m3Yto1BGTTlHn86LDLBsw0+mbNcTTV2ehlE3dy3ojmoVjI91cvAdOq2EedKs34/ya2LVHV8
+        5/4F6tYiPMm50CN9JHVg2CvCrDXDXgZ1PQrON7G4H301ss2DVei8tUudt8MpKAmxg2bqy+tttdEf
+        QxPZddAHvfilpAXxrI/+IQgds5YR+QNRhaADsyRaTSBZywATMURNN70izn8UIkIDFJRpmxitb3SW
+        9km7n4LWTlAbNZIKypUW5IQqeSYHGLpp3ZFYZQGIiZqgiYgCuen3QuaKK4vRDhEMTCPTzgpSlAN9
+        UP04UPbvh2IZrIeWOhaa61TyRAyMmprAovDIDygu1dNEDDG7WIIajpMtcrZo6suHvVVulqfwQVa3
+        7ZScsC0KnxtDb7s4QpS7q/QPOdkNcdq5Pws8trSDE6OktKRE+bCPzhcguin9nppA6J77P+8wlOzO
+        dnnKA2HWBjU1D/XPmubl/jlC1jM3sMBKu62xuIhE+N8GsGNq5iRLzVTzdrxabUgrFOat2zFEmdVa
+        CdzGpkWNoZ4OpzIkxEemMx6KMgvCemUuQlvdJZfaXXmdaNRc0F4PrzfofIf16KvxqpcOEWdIep16
+        9aeTKv5vOpjuT9m3V5OfmM+nm/kcpvM7xkNkUR83Qfwgkb/DxsRt/S6lzj6lBgOmAHdxZe/GNDVb
+        p44HCWB8sBJ3ZhyzmsQsmB8KCFkoUxuB7ZiAvHiwR4fnAoJzh1lxbHt/xrLUrMx5oci23q3Wurgg
+        lqFlb75a0JWnWcwEAR1I85FodQqHdv4LE6S1cjgVLZHpsVgKl9rFemH8a4pAvEFx6oV+1xNDpnT5
+        SUJrPjSEJ3mxGgWPB+o5g+fQN16A2bc/hFHTxSZY+h0z+QodIaTGkzNSCX/sk8moMhQp4YcLxSZT
+        hE2U6s5eiwtBRamJpKvSOFRwwIISorqjyhDvD6IViGeQLtyvxKjNksxyeEyePRr+OLrZpeMBKtHb
+        uZckt1HcdbCHFiA1fmCFm+mkjun6XDqP9qdCmvqAcV8ezuI76nqQ1T/KwLHGudmSJX8dxNs43U1g
+        H9Hx7oUX+1geoOeC/U2CqV4n1VFvNs26Oq7RDTDO9vWJzH6OT46OG4XBZyztsBxGvf5MsB5jnQZx
+        RL6qSsMfoAQCnRgei4MZx8lZeIYy9TyOrgNrCKhB9aoyYrJ6GB5iCaQjKw9/YKoA7oJhN/sqY2At
+        +kP9jIdjqisTeOHm2pvhTet9DSMd1HaqM8iOgNcOG5mtW8kFPRWXINRVEajY6WmvaBHQcOpVlso4
+        o1hX1HtVxV9IR7IERyQBs2+BED11B/N3NcUcOpSmMNZBYCBid0D/yV0C01LoA1M6JdMlx+F11Dkg
+        IWHIuhh2m7bP8gCH3sB4OvgEhyfjOQ/T3DGvKwEBQiPpXBKoGKIiYJmycShA0blcoTXE7+jtqLvE
+        zrEo4Ed0WXoOfCIBgj7A+ptLBNmgFSwZAL1qNhQQmpwiJ06E83G6neoNky7VG5JfQTR0VnLYOFNZ
+        eckGB4ey2y6FUSyxvoNN+DkEYT0R9ZS7OtBXAgpTNa87us+oL0gG9KQjcaMgATLgY6mlHnXNzE5+
+        Dd4H7GR8kJ2Wa0ow1yPs1soWlg9a7xFV17WYRSswYfykFHx+HGUt7PHwbhlBuo1eX9KieoVKu3bG
+        uwH37vRx77bwjKUrmrz6q472j0n5LXb19O0xu1n6wHt7p1ph3gLtGq/cSfdSJ9ZCCe/C3SJWqpxG
+        fvtDoj9BI0WVRo/3H/WKo1VXVaHOFyMMdrsIZovygALtxvDq4E1yFeKdNIN41qoytw2VDXUjHeq+
+        ZxaM4v0jMi/zTaXK7zZrvbCuNYNz2AuWXASSjmIxeTF/U+cKFKzl0O92ABRjQ14qiclYPQwTUZ23
+        ThGdZCNEQGs7WrRz5NVqWVVUtOa7jtLKvD2CzjIoHfxkrpPJU1v1sejXyTjordMS+T4qjtpCYiWZ
+        vBwkTkB3XRTuVjElTtEXQhFo0F9VUn3D9aTSdcUq4kKsGtyhTrbL8z52Nzu7stTkHFn9s8Az6mlL
+        s9SwRgEGo8KinVJ2psto9vk4BO0SpFh9oL2+miyizdJnBAi6ziEZazTgoQo1afdiTNy/JR3Zhtcp
+        e19FKw0q62wbAF4bgOJ0YEOOoUOg7divXOI+xXexUSVgcXz/rCfOsghAcw+9BmDtxSpqivo5ezyc
+        D3ymFW4hGbTzgyM1y0XSzSbKWJu2NgVFyNy9X4NM7LGT82LcX5JL/ryPcsp2FbppJzAGln6GSY/L
+        fglQjg1d+aZ+SzcZZpZiC1TM2mNpzPmIHeHVOfkgsEzHwrvBCh1VkP+PIBd6TTUV1+md7AG06HX+
+        pcPy5WtgE7LbOzV+tpnMojWGf9ubA8cCtjlnU+oMEJulMlICmlwXHqhZHvzSc8vS1HD62lyc0j7a
+        INenaigZvUhi7Xj3bDS93iQzOp+bXw2u6F94KdnyBcQf9u4HGaJTvxUyq6jjtBfDabmctx+Zdut5
+        Afp5STa7qJR6mfSATOumn/PPrZR1oZ2HkjRFj/roQDxj1fFo3tYk/GQDnY1xbi7sJ8AapPwFXYGa
+        gJbEXXHZWaTK3iUIXZ77x6fl7ilVYqiuVRHFdcxfwdIHIebbUg+23u+fRAUSDsRJp/EMZPHJYQ/X
+        ecySBRby900XWi1XsVAgPOri/xyaMK1xkWL6AX7aSX8YZQmN/jpeGQ4w3C4Jhw+726KXpOpI8GoK
+        hcrEYSLoPKarNkWNVtxhMEbW93hRhVFSPekVA6gzTfKZYnYDpXVvnc2UbOnywyzbppGyGhknSTAP
+        V1pWhKZQtJd9VUsOquOhPWrP/UtbblqbcuDarTE5DcuSh9QDEPdjLjDZW8bnK+Es7TU6MAbQI4Bm
+        KuNmt2tPXr6K9WWxZhTVFc6Lu5e+p6f8C49nQaLtcNv6s6iXfMA9FI3szzbfjTqno8tk6jghtzXS
+        dkQgAbeaX3bNDaPWyNtqY9rCYyN2HsFPrKZCRXnpCvYf2W/hK3ZwNbk8Ozm6wN9nFx8+XZ0eX1Ya
+        wfncFn2s4tvhHC1zTZ+Zt3VhF9UuLteFRVA8uN9VWKwOEq/bHmIVwdrIdGjifIYk2ZoQHxH5uRPd
+        cKQ2mS34yivQmnzYx5ITIB5XmOA64Eu/NX29p1ZU81+bljqyEt9Ru8mazxSF9TPZEwKaGe17NZ9s
+        K3+p10aSQK5oPuCzoY4vSJKrTqGn9518dAmadq0HXUbrGtk4NKcmG6vmb/vwbAYlX+GcldsVX90q
+        Cw9FMDTeugu/4XXvkA5B6RvTGZb5CaVuVrum3h7hwEA+gSPXI0cVbyAJru+KOao0VHGxCXVQyk7V
+        5B6GcR96015M2TdC32UaKMtfh1YBXSo29EypwDX18Ir8NV9Onpox027ZrDg418c4qwBJF28VQszi
+        Q8vGhJHKEBdwJYmyn+5UjY89cQUx/4JXhK3otBmIhRhvYCvfZEv5mzqkZMQm4oyzyOcrYw/W3TK6
+        BS/WC+c8Ay1OmWSA8yW0RjdfrrwvtDras3wyxHlcnVEKZ4O8L8Fqs5I32KjogpwIZYOuYAVTiZZK
+        y74BmevJdcTLO/B2phn6378ItzvapEngSzoU46MpS1I5cZI39th0k7KEezFM7goLOIlLF0GBwFgp
+        mqDFN4wAgx9tpplBngdfXwJx95iQIHwuE2ITeZjVOaZjGp0EOuo+Nj74mKjjT4JbDe6OKOXhJuC3
+        KgRTmEWYkMDXwjPst5fjjx8/HZ6djI9PP11Nji4mv72kwgLw4vDk+HTyaXx6+Gly9PH9by+tAq3Y
+        vMZ1KfrJ6ulwnrI0/h6Xq/xQSiWx2dSd07+uQOur6XVOAptonoTdZDb8YEkX4lkf8ziltO5uexJh
+        FN6toi5HWn/V7BCtypmITc9hHnmsanGIghvi6sT80jptR1tvv8BbRkOWYcYOlgEG8o4PixcC0vOO
+        YeYMqCJnHQX8W0wqUWGysQXZZSXBS/6l/dEQqu4l2lM9bn27rzUij4qTe8WaaKhOPE9fFjO3UTWO
+        1+t+pFyebkZnxFRlSm15HAk60AtbIjhMEvicRmu0PWVxC3Fos5j8hdsQPcKO3iZdRLHaUhLQbNjJ
+        LXGHXfCasha4G/kzb3+csW5rk7Z+xCqolbHnqZEMLSpc+XA4fUsIPLPQ9KWhO1y03GXOeg8enKYV
+        wbVxFxr4tZWGUOUXKIge9dHMV3kWecv6vrLmnm1hwzuTArx5zDGr4JLHVkpocwEVMR5pYAJKWTII
+        1npyEk38M3gCUFD2mUht76qZQrd9hNZsge6Rqqw4Tk9BmX+M5tb76jvW6ZLCLBGHt0SHbC17RKKg
+        03dL6tTErc8ldVeJ5ZZ4835U+/1wttOwLustqvtPKq3u+liJuDlcBjN0JaCF8Xw/wM+95bk1OKHE
+        E45cgNO+s669vI+ggwF5kDVVvkJr/vD5kruvbtdVoQqeTkJkQPXkhNgXECuwlsf2ba8idiCRFu83
+        YbeSKn+DxuxathamNp2YkTw4YpMssoYxgpPDP++xyd/Gr95QZIBqixZU7kBh/hLhmL3Y1XpxaoJw
+        ttz4/Dj8sIym3nKsLn1PbF5JJxlG8ouMWOqJhJbojKkqDppSVWitf12AREYzo08018QkWCMetxpg
+        s8+EEq0Hl91BUr5azYnKg+QQ2HyOiZVbw8xXPXTG8UgGEI/Dt5ObDvZDwt6+gsVYm9c2qrBkJ4Ti
+        CJ2l7ghxCQFJ1YZce5xOQJBOoy8Tnm46OJiA0koAwNTkwhVmLgjcf1Rtk2in9+tQw/qrZDP1MVSo
+        iCsZQVuwTQpnunVL4VTfOLejNsDeOs6lU+b7A1z3NqA1DVPj5rH0OWAuT9oq/Vl9/NcJE2UEdKXb
+        rP09Ech6EYVucywLAR91unQM8VExyStdEGx5eDFfuq9dsknWPPT7XTes2Tc5PEs3WPAUuCfpYH9O
+        MgAgiRGCtdPWKiFdbFbTEFb3fBGl0VFf+12WIl4jsJ64XMXtKY4aMmhphADb4nHLp0nQJIResGLY
+        ZzyNNsXDI/nzPgEggsC+Jcn4HQU25Mq3OZsfhSm4DZ22UUX/0Bq60c7UU8BNJLcHxs3bsi/6YMSO
+        U2rEA4qOTzmDgeHV0zFbpKulmb9AQ1TtxW4ryMbNSgSR5KEHCSAF968Qxrwx99FdhzdLN+CGZFvo
+        hIQ9REzraRar01davumz1jJoV7+UG1yK9gEH0a64ASaemlcntYNIdyYVwVJ0oxO5yTgOUU8hvgAO
+        P4q5rvUCj2R75XIW0+/INLS7mvWA36uW+fqZ5i1evhOk7dfso2xYgLeOfoq+tLd6iAPXXpxSeMyO
+        6jrCXaZO5HBOTW3UIO2IDjo2PzGsdIu8m0Bhz1CMMzBolIAS9a3wJoH4My5I1qR4vonPuwSCLqhZ
+        cZNNVCpPJqBM6O6CDuYEBXIwjWoZ5HQkqg5mUEcs70G7Uwfl5OnZpZbd5aVi3oQf9Pdow1bBfCEy
+        c9CYB2l6G4OS02Dn8EROD+g6lfVCmT/8BiYYBCXMNkCZLaPpFDfnizOBlVjSrgw6odYFkGkXIUKl
+        YNxUFhBt6Huxb+T/eFLhjRjwNqbUgYzm2apkRAbfLqIV32N0qQFPZ6DvQqbCzOJ8MM97wP73GOVb
+        FTCb5UJPRAzhFVZuzpcBQ4x4jgy/kBsB1BY7EIfFpAoDisnAeMskMrugJFcBsFLFlULfZV1X+qSX
+        0lNnreUs5FqPfRuMYORAdSquD5rfIxkWzDZLDziGdgukZVcf4C+ZceaoDS9HG6p43mt8obgGy2G3
+        rj2h0/1agW9ueAysiy/LungLIl3MUWeBfm9yAt/Wiglx59lDCIlcRiTbFhJH2e6LjWfyl30ZJ4Mk
+        Z7rOMt6G0dmJrIoJCcdFPdnNVclThSTcwK9eoOOVZWHgYZ8FoRwkcO1WaCiEc7EF5YX6NmvNyoBM
+        TqNZ1N6xP8j0ArW/D18jWLUGdlyanKC47FuQmsGqu8hcd10QtZKimL68Eq1EHOT8SzGEcjDM6Faa
+        WlS4/Tiji0uSWytvDbZOsApQvaNwJHkYpJq4K8iyMMvpFvEHsagUewTUTNpTJ3seqeoozeGDG5tb
+        VyQn0LOxs6mJq/xdS6llvaNF3uG3H/Ob6DNug4rdziS7q6hDYK3yfqT2m7Ihvy1hpEy6QYLnq2w2
+        5Sd1JzOzna3yquQbXh3VSHaxdfv5vvZAMNx1Orj4EfcHT+9xJ+56s1x2wvQ9NBSYGvDmAfjg3QDS
+        JbD3MvYyFemFhy3UZLzuaS0a9W+a7cUoSQ/gqw5Xql1SnBvmdEbtdVbFdAp0UEWpm+1bKnlvrYEe
+        Zk3pjIXU4/oklvrS27ftLPtTTVddT1S2v9O6iKYU48ruhDEIY8qXEV7lWjoFgXHaTmP7KBtaByYS
+        kENMhZWn41Aw3LF/bbwl5nFVRY17lZEvYjGcHQqWWMEErVnG5G417WBfTqiZA5mkQWotS9l0zQu0
+        Yt/C02AeEtjvjC3DZkZ4PBajQdm6rZjMFrCW27EWURMhIaDBiGTa3148cLYXzzF9waJHxPN+cUhK
+        jbiPQMP9RNTEcKyn0x8PAQski17Op2vvi6DdPXW+6dHTcJXP0yvmQ2Qtb6quZYo0sjMFPO/DFCKp
+        osP5k20dVlpw3MqyQG64Luhv1A6HsA6+8GXmXq3zKWJV1wOpoNC9JG0/TJ7mN2IeDExWwapbAcQT
+        vEftUguAWoDTo0Mv9VpD/8lL+A/fA5fjVrMv0418hFRexeldOozPQ704FWrplTV3rm+GNNPKbeBb
+        8x8beOFXbNaNFcqy50Im3FnET/aqn1pWKX0PpJk7bwFkeOubc2wSaXWZy/U/Qd1hosYeu/bEvwmd
+        g99j01i+WHmhN8cfWEeU4oV7tCUalrb+um8z6KfJ1TCq1c9VSGeRbGZZ9qpvBA94fCNhdQkcDZ8v
+        XJ6GX0XqoGUW1Jt+fCBTE5+PgaoG9MhNVIWmPRS/h9fpzf+g5qkk7GrRYMseGfJAPcEzz9OP1+vk
+        4e3UhzHjtnDXZ8sLsxX3xsEclNQnyhtrP783lEGM/CgBUQEH0ZkghW+p2pnagJx5or75+SZZsAv5
+        TcFY2ujkqKGyjcvccj1hD4z/oh0l07MtJZeUXvdRHMaxNbSZH0e5y2EvxW0q83BTmFEnjio2KtNT
+        /0u9rIVLirK5glqc+xyD9I/pMsoSMWSXBwjr9Di8wYpnhBq8IP6yEBAaqhjNjumCH5lkADaoti6a
+        TKin/aKKKL8fTl1YhvKsarGUl7dNXZaS2DEk2KPg28S5VIu1ZZEgX9CwXmaTJAf20kvWOVmueLqI
+        tCoDL01vJyPcPGaAzUe644NUJFwPoYb2f5fFjr7u47f7v+NaHftfs68Xabo+oX6xzeHRx6PLo+qt
+        NeEVgekzOVfljqZ30k3SSnJ6MViSqaEFcRvUL1z9UxVGsC9rSYAhEqLcpJiBvCqUGWzRzopawg35
+        G21bTkyifPNVfVIuHFVJlxbvRIXmktIGkKgjRH6oXqdLXpKpn3gzojZyO29PnJktPkShKmaMusKS
+        dA6zUzkHL4ypyJf4LPZpX/u/i3O0V1h38ec/FICsYFjWECkx+XF///b2djSnYjDeGizSWbTax+pg
+        +8R3IzNeNko4KBw88iLBGxJkztMm3sFPhmCcD0eXVVzzgWM0WJAdSkuPzrk9Iibasc3TYRtlcti0
+        6jhZvyz0dx9ctjTrt1jZjL5x4bP27CXK3QlKTlrz04403UmzHSkm90qLpuWPpctCvqyxrJI0WpeI
+        VvSnGo/omyLRCqT2M6Q+3bzZVy32jRYmBZ+fTSpJeIIFNm+xkjrmZ2Y2ItBJHG3m8lIv2cnLfPqJ
+        vGyzf2B+qq2tzOrL7NDtrFHecacVJuIfAsYIz99j+KYnsAxMLcnF0YpHiaiOWkN5XrEyWFFgFiCN
+        ZIMiIaqacGCZZCXevu7LRvsKyP7vaqnxbQGUO4VeUtq2qEoG/x0QdHY2YYfUX5PRYilf10bOrlYb
+        URwmP38mqwVSCFaWDOwlDDMCyadrEFyrZmq7ElubcNvASoK8RpIg+meJQH48y1P8hpQZsqKwotkO
+        tnyRZ2xmvSvDiCedTP0LDuTBb/hzZhA1PY+PPXJ1F0cYuTPEbAskL+R1pYbXlgUgqSq2PEic8CWn
+        a03l1SYaTB5uVhpPwJOfxpPjg/wL9vL91cePCvmMG2VTLYs5McEci9KGibiFBZd66iXBjAFVeZic
+        ok4wf8tH89EeU8u1h5ckB97ylDK89uTZjz3avUMl952OWdYHnoguALZhrC8JXthyN4zIykitheVp
+        Sqzty6rOlkUBUIWR4eZjFcWf1d1yk389hB4SS5Gh5Xkn1SP7du3NgxCj/t89I5m48r5c0EZEYsW1
+        MTKjLhwS6ZdyYxbBobQRkmcEE0ohaIxhv3n9WgNWHZpZiXt78NWbioiNya7ZiCLkz5+6+cUH0XKz
+        orwEECziRFwUp9K1oUmqE5MyeY776rCDLpiyl3qlNxqSl6STu3CmPxM1/rQHugQ0novDdfoTUeLk
+        KPQPtTQ8dyEt2GAaRZ+ZmmxGd4VI9DFAQbcboFAAZo29NIpHOgYaBPL2i62dWlKpygSmpeoDUQmr
+        M2YTmlB2KrOG7R+J2a18K2aacdBDuBs4aqdfNBe3lH3QgmRFBgJQrDrgm2cfyIiOLlIdMdpZIY/F
+        CsnWRDzushwTcfeY+EwRhVgYyqEKsRgS6kwwASRNSzOATIDMvfD2p0G474XJLXDM+u7/Lpb/ycP/
+        Lf7+zzc//PUv7969a0dnKFyVOdV+XNl9MkrRZKoHS+AkM+BLHDAIcWyY/eXjHr6oB0A5K3iBYcik
+        1hDbrAnJf7+WGseTg6PTw+PTD/q6Hx5lT1vT5biAowG3OIDtm7KdDdctRE8fxnJdY1izhekqvt+W
+        734+vjz4W5Uhe0U59yUTVqYOiECe0leYhYI3XyYcbx4MZknjxt0TMmd3Lv5OuRYxvncX3zEmWZST
+        jyk2YJOH8mCPu0CUDbYmEa8qHfsKebgTdDtBtxN0O0FXJeheMGNfVM5FzY5ow9aOAlC7qZPkchBz
+        SbpHMRMtWulq03VPIFESLouPinzGWCLj95Ihrem1ZZKHulpsePpSCHX3UbIl7OecZLRX75a4UZ+D
+        82FQ36B+x+A0KuySx0Ch1QK0gkAfmKi7mYUZKTYYhI602GT2PQo5uKOxQWjM1MiiblXhzqYOZw8M
+        OFWHEMpuCjgp1FBe9AQeSg4H09P6HE1Aoj0UZbkIXpGsXAl5m55Lv6TN3J40Z60TxqqIl6xkJpJO
+        CxbIPeWYljV+cYAFlhzAiBWl32zSuN4iNQnfLdWoK9U7WqzGCu6I/rkSfZ1SOcybbsHhE7zSfcuA
+        2tcb47Lapyvfyc9bs16H7Ndj6kpTLs+Uz9oTrrudVEOeD03VNmJsSLgySdEx3cqNEBuOuoizJrrw
+        4s+QEvPwp4enyQUV9Bb5VAmJAKoJxOQkUa+lMKN47lwohWsO/rapEgYMEXaU8FvZH96mjLe5IP2d
+        jw5uR2Z6DeFrSKJ5vuznD8N4eank/LD2w5pYj9KlaOtMONFyOw9iR8ptSPmB4vQuxNysSJ6aCmnn
+        JnRwEPq5Bs+VgbbvFHRwCB6hM9DaDRjAAXiGlv89WNDJ2ycm+UzjeR5Hm15FgwSAKtNZvN3/nf6t
+        2UFyKhX0AYE00KTqqBNNinsp8cq4jDjz3aS53vt2qTEbxOA2pRhEe5NSrrLNonRdYpdDX3/4Fa6T
+        Nx+0tRtQ2Jij7ta8p5ElqavCxpIiqr05dQBYlcRGjQFhneAHW5EOtoOcR6vpUDuLrgcyBRBxn7E0
+        UdufwdyquYDFjFVZ1dVmmQavBJ576GRR9E0fiKhQrRDbY9d4aTgVSKGUPrrZECg7d9XcAncFj6qX
+        i5jbZyP2voAeDAkkcjYYvJhS5j7CJ6rRZXYWp7iC+vyIoWcZE8bwWw76vs+vvt36+dXHdxywT6Wp
+        Wh0o6k5dKzqKEq5IJg9iI7rc3xM6k06riVbouK64XDTgxGuG2bVBdp3qipLN8NI2ycRaeeIuAfFG
+        0bwFx2772rIpjVAKeXsOoasx5nJ0iaZwmLzBLdtsLrRGH5aJ7UFsvCdsgTSmFkryrMgrdKbPxoMk
+        j8BV2JHd9snuRdZDqdwxPPLMvENLAMMSwqgmWs+aflhHvvtZChb9+Kq1qQtw2MzsVUQXXohsEFXe
+        vOiSWulcTYTxqJrQLRYKlmgwUpcQGd9oUkWxNTSrGSwVzNgKyza+e2eE1a+vljkvspo+qL3iWqi/
+        tcNAJQbpySLZVV6aYVj0tZuJ3fS6XYi9ksh1Z7y8fmPf70zfz5t4LLRSltaa+B0bFPZVb1WS2S7N
+        7oMwzdBFM1kWfKLuRKnFNspkQfV+0S9WqToiIrAjy0qybCQwvmUS2+sJoOh9mSJaOjiTzVRfJ5zs
+        giGmmScv1GaKcH777KZICM7bKfuywf7v4kfnLRZpf0hwi2D9wC7dMGka2aQMj6UAfc8mvWVgBSv/
+        kUQ45OwYprzTRpNiAKedphbU77z7xE6Mhd1R/1Oi/jqf9UQnyccWESzMZy8oAxQqH2JTT3Fy7a6e
+        hZk7bPShZ0GxZHV7JQXaA+7LOM0TZub2XFJiicqwj50jnjoP2Yi1Yd9UkWrNxqk7obrupUooYitO
+        hAnd91IfM8nmYnq3Ebj1jcA4WnL79DYX1l2tsF4PEhhW6kFI6kZv3CsPlkB04oo+Ne2R4/73AEKr
+        SQY91q29p6fIm/YblXB03HBsYZO7bELmDqmo/a3fi1RU87utygfwBOQFrI2DUokBD7ET5uI47Kyk
+        5r1dJQpcN3fbyILGDd82kmDH4zse3/G4weMvmBGpjqbBkve/XsyA0+1yMQFiO1eLnRDs51dqdOB7
+        xazTtF2+HexSMYH7vVwpJii1O3MaYBSz2BRx8zaRwXbOx9Yb2K7TxpE8m7PjtOfBaUMzi428G3aA
+        DNpuf/eeO2G7ROqeK13vKkHbKkGvIpCleQlonA1RCFo82faFMn80YVNrYGt6/Wlp9IGg9bnCz5Sh
+        HS7wMyem4w6HQX+7u/u2seXxnO/uy4rca0KXLrHXH9iu6iMprj8IsaSJ9ndkXs9XurCPxtda6xjk
+        Li8VkAtp3Bx1dhvC0lL4ioZjvPyIl+yto2Uwu0MNipOV0KV7dJ8dSwPtVKAQF3prEwWah6qucU5s
+        bUGyxh6tUXKXpHxlfDOhqapB4BJmrvi6my58fFttO5PpEZpMD3YHX/3Ve9+//stffnj3TUJ9tCOz
+        3Q18OsAnewOfbr9u7/69p2fAvmB6HDqM0uA6EEvUJ2/agNOmjqPRcP93/c9+ETE8DK1DczRyu2k7
+        3KMJA6BvdnyYna1RIP+UKHs3K5Jwqb0+9jP+zrSRh9vmcao0Od6PnDDlxw1UQs+c6gHGLZHV4T5Y
+        6e3C4Apyoz/7m3xj8xDrg2wmv7gWiuzELI4lI63LtmOWHbPUKdlTXcAOrmObmawhDGNymXNFP7Pf
+        XlxF6Xuw1iYmj4m9huGPpRfON+DddUb5eHLGfnj311dv2AwcGsUeCqw5f1QKJWN/qrFD7m4WlTkK
+        5zDxC3CWwu8evHiOiXruF4CfTw5xCfs3r1/rSOdBpU0xqrR9N36BNWcKrrwovD7n5egYkf0jqK1+
+        ahEc9yqXmnI6TXHgekt2RwPA8aY6QxUNelvdE5Jjf2g9X5njUafmH7N50JhQafKh8+XMXRnR5Zq+
+        R2uH7xhsx2AVUaQonsOCpH0CSApEu2Qq1ep3/HUFv87h8//odQL/LJ57YfBvsT2AIJ/R7qg2SZ2Q
+        fb9ZLtEIWChMI32ycCUogxkshWOnSxRivuZ0Jej9JELowy/wZn9mkaTYIRaUkb57rlU7unfJF9iR
+        /R+R7Ot0y5loNrxaUZzSeZtDAuh5Pj5jO+erRXTOqzLxGk7JP0M260Kb7pZRBRU+KOHayK0hEpkR
+        W4tcsAZSc80CK5Fc8vRpbjDRThsGFx9f8RDDjn5Zsv8pkZLfIuBlzA7htAvKSeyGyC7AFU4201c6
+        4gli+09YRTxMxv0AE5dmi2DpxzzUYJfTBwCYvsGftVGP3NMGLFgxwQBGPkoJPZH+8q2c2e8eV0qB
+        FCxbiCjej0psikpmQso1INneFHU5cl4SWMNGI/8IYu05W6xP3lRojEpmfOgckOzAiI3nvZ+hqbrj
+        r2fNXy+YHpRcx8FNsOTzuvPVDVZ7DsI9eYAKAu2PP37c1xDobMHjjkB2UCPLJkCjL4deuEXnnm4N
+        zEPvT+vWwPN8VQanSlx7sEa8OV/xsIc1Z8JxSuQsFee3leufeUse+p5ODx0L9mfARxnM6qr9VjZR
+        APYzAPBa/rwoHx0tMU9TQf88C1RBteaEVVWWLqNivG9b3b+0X1VCCn06MYMjA1jvuv82fu+Bv0PC
+        3hhmPVR/MiJuEFyxB5Szx+6iDQw+zBLaRTnTu0/ZwbTsIgRQijA5wADYJlbwoL/s0+PDIeZK/fpq
+        oQpLee7Stp+dWtRLzXEdogZ3RsOqy7yjkpVjbDs4MrG2B7FtDq4tDK8rwKfDwJYcqB0LPycWrq+/
+        f1CA8dKC13aEwN6AwCwF+kuixeGaE5t0qbzrxFHAVMqS+ptP8nvdu4mSHftth/2sDFZz74oLfz1W
+        Dq3mpcabWWycVHE9S18+ctbJyhUtMZR0R0ObK7hjsP62gD1BndWkqJeny6XKgdG+srABqyptIDBV
+        L/6sl0lgNVs45lityevtCMOWvG49iz5yRnBQaddGWG3tYp+HtycKW1OOQtDYp9q2u2JsXZUpLc/g
+        LdsY7favHptTI3Yhdi7N07CpOrg0fziLq7gD5yhuzO24rcubqxpTrE7a7OTITo7s5Ih6tgU58kL7
+        p7gNEy35OEmCeYg7N30ORBQgtampgU29vOn+7yas/nU16KqSvIenv+OYaYbiTA2GctWUdUL3hYF1
+        qyNKpQGKFwMehChsgr7QeMftPESR8l2rY3Qme6dM2h3RP1+ir8sXuDDaPvGcAcl/jWcjiizofESi
+        xIUdzkkcxNx7pnqmPQ2XKLUyPaueUB8RidsosiERq0iPrbKxmqmxVyJWEbcnT6SZCLqPYrpa69bV
+        c7UAs3n14P2XN3UJK7teJziQAhbik64NCkTdT18hJqXInlwEWXS0IG3BE43C1IOpD+fQKkjEB4ZX
+        6jIkrHbb9VakS3n5EZ7CiYOVF9+Jkr3gdvtAS8me9KcLD8GJly49ldoFlJ1moTQBNC0iJADDp1uY
+        nMY+gJh3ldbPLItRv02zo9Pc2lWWnsIwbvEzEv8DyiLlDDyoB/Bond12Lm4juTpaMztqfWLU2qQU
+        nrgmaOObtvZI+/uhT59VBrBKap3Pti7nY3U02x722YZTqUSQvJ7ej8DA3W45MMfzd3881/LN03Yt
+        t+6LPHUPRAqGpsPxQjK4l+p0MtUcS3MKR/7BS3LuDLqWnNRo0D19fdp4mF3wTYvSmm6M41JK83mY
+        bTuGeBoM8YLpkaxktoAv+8SyJIR2BTFlo/3fxY+f+V2vW4UFFEcWegqFH7Jp6YTqqYe3v8VYVkmx
+        U4ayOVX3w096TYd8ZAWm6k/1GPiWw7OpgPoAlyJj9+KW7jTskrixI+GnT8J1gn6iE+aAol4j+s7+
+        Rw6jZ8xLMVGrUpVKBXWNfEl6eAZ1tbpQpbtpYqfAB6ZZG5k1xL4UkbUoUVlPYq4VKiWUQh2bHdk5
+        UdEWwi/3Kfqawi6KKNuUJHQ3IFzKEcpR/OFqEG7bzrhn39PR0Hj6Ur4xIqNYqlV1wRY81VhZcGeS
+        71jlYVnlBdNjNXTDWZ9QjQBQFakhJPZ/l3lwX/fF18Bey6D3aRyyn4CWeZKIi9oSFiTJhvtsege2
+        FKW/qXoM6/XS9V4hiVkncsacvQMCoAUbtc7pb3GpXJBhm0YDBUn7ZBse+4B0cB3whHCkyZP7bePz
+        Y5UvKO7ru/GWG05H/aY8+7p3muL98Lmao73Sehd4fBgGHCV8tomD1G4A1kePJGfZgkdd2arGK/nA
+        U1hwsVmMlOpNo00qT3tmHFZisB037bjJhZvqFKDIF9iK/qtnv4aYgOQ/a0jAzoCdYgGUfk32Dhf3
+        OAtVJlIgAqBoWtKFp1E4exf7dO/znc4OjR7YjqLdKbot/W4pFFFBwKYNR8TYw4Sj9o4WXB97DWFs
+        kUSPiIIqnAm97wehoGHooYMZIVbXwYpoL71UyU+XlRUO1vuAL/0TL/ncaYUPotXKe5Vw7EHPGhRu
+        Dguh22TE8AKWa+wnYddxtMLlT3gWaMX7s695Cn/5Mq6VLKLN0hcHXqZCDN8uwKZYx9E/YQ6h7/8U
+        yLc8/JO37zTYXxdeihfJSLUgRwTCn7CvPpqj3cwz9ZJgpr0q33pT+EItk/7kerNc2mpe1N+Ccxjh
+        taTq3BHYkXcyuJ0tjaw2UkAfC1aKJoXPcSXVGmICAnQpjjMVCMsKy8tJwkuSaBYQ+dwG6UKfQ8sg
+        t3zGa7siK0PxJuC3lwPcuyQoj3T+4cnx6adfjo9+RewPz07G8Of51U8fjw8Y9qaPoYI4Sbx9wo9r
+        KdT2GcChpOBP680UrJ/21PmeBEBSGooVafPzprG2IqJtmiVXuboY2CjptzPScztYqLOKzWBhCVXE
+        Zms2fWdi09f0aGuifLa5faC16ODYiCms9mt6bGnygGSFsCWF60I3sqEAFn9oOf3s2+wAwHc768Gg
+        jns60MCOQX96MD74ZgVyOXglVmYvl/b5yplb1HswS3RYA+aA5gtWNkmBtRFW4cyG24hFo07jFdsI
+        Ypyyb/a+gB6MCIxgNRZcWloz+kK1uTTuFtQIVp8cMfCsVJkx+JZDBpYJ004jPsKWMAIgtgB3YcFO
+        VK8pGBamPMTz3t8G1+rlFAB+16BrfUPJFi41waMhn/kYpZD+cBOWP5T7a60VMwpKJlJwfEZj1KHS
+        20MpW+xvCTs2Sb10k7CDhRfOecWXV6FfC0ls2Km33WzD+zjqAxNCNhUu+5vXr0cMGiH5RrdoHyfM
+        qD/c6zTQn9ueBorQjPmpm2l8EC03KzoMhKUEUfYkUZxiPQY5BbWUTNEkw4vxVsHyDuWE/nQewOLS
+        w9aUem4Es6osxysR+RK9k4qxvSY05NtuhDbwuSvrmaud97vzfkvLLB53WeH/hy2Z+ArMJi+eLUZs
+        IqypaabNUV6x317+9nLEwH5bUxzRj2YbnARPaTsgFWU7+6BSl2BYY8iLDB5hPqNWeJX4n/czK3j/
+        5s3+fBMAUvui81eG7es2ejD+bqU+6manXZPBCGSNLn12hU6S8RwZU7oxbYj7a2+Z8JYYgxBV3mWv
+        WIC0k5Q+QispmYHNgasZoQeg/eWbPFpmxPHk4Oj08Pj0g06+h0fZ09YMOK7sHaPRxZfdSH8XVXka
+        UZUmx3xLWzcDR0ky5GT65USz+GVI8IU2Cs1UbwoElIz6yl3O8pctQizCFqexgtQn+5wqdT30rhBD
+        t970aR5kg7E22HSSzfx2aFViY1BQU3qyoB57crLb1lJtCrJwIQX/D5KAvFUqoiprx/4eC1IVEloR
+        emRmiSgMUVs0RbP4MdPaIw5sZqGGJqosxiQqRVrpQ3eJpgIIGM/UTLQtUiEmVwSW0N6Db243UJSa
+        qfuklKZMcEkn9jxwR/FVne2tCa+dVHruUunWSVHe1ihK8527CPrVU8EQYV6RHybC1oXtnd2mSj7i
+        3abKblPFOuLdpspuU2W3qaLR1MvdpspuU2W3qbLbVNltquw2VXabKrtNFc39rvTW0UAMeW4o5N4n
+        GQU/ku+u32Po5NMrqIUmT3uv5kU2lGxOtIM7dDBKe1A+25P7Ezq72OMPEtqo6FdUhkZlg/3f6Uf1
+        Za3m2Z8yV17wVUS3yImDXrqWNrCwX9dKjYxHbW84za4dnaIyQFx8o0nve1gtIbxWSLY4BdAZXfXr
+        q2XGLVehqiHtFRfCIjOGuHm0MMpubFjAsKRbirnljaxiZpk3s0oli+gxvPL6j32/K3c8Y9KzUFrt
+        NbtjY/W/6q3q7tatbPZkyNrM9m8k6oLX2ZWktdMAZbL6iFY2lecQUGSY05GoSwG8diTdO4hnM+5Y
+        MZCXq9780T+KICrNOiYJrzIsl31gRuYq+qo02/4wisoqLRr5nj8Fzh8ESm6j9gVXMHZNU6DB4NXF
+        VmHXrFFuGXtkDmZr8fs2GrlyXy0TaCUpuhNlO1H2MIZP0d928Lhb2Eem372Tk/clJ19o/2QZeYso
+        jYaKBwhg7uEA8f1+utispqGxEdQtHiDg7RyeOr4fjMOqvQejeEgTsWhVRIaglFofIjtTTODKucI7
+        Isn6r5PfuBt6jjP4qCV4WViWCHXtaC9KUl07movOxGokK1cFcQStGhuR7XKXd1St9V9p8tQS9WPg
+        h2oyLiamNtGxmaE6CCFfNcYiy2S8o09azmdLn4a5+YLp5eVueBxcyxqDB5Ffd0n5nIc8rs+7LkEb
+        ZY3UtlkVhZea7peauqfOfpBNWchv2dSbfd6smd4Bm2EP9pySXfG6LVTjDMIb8MAasvbL1KM1a08/
+        lsbuFHScNaZFgqHFGK7Z0dLD01JDAaQyFTkVeS0LQjvRONZ7VQQjs/GImByoxywMu6v5+iA1X38p
+        kUKht/sp//oC/vv64n8AlMkZ4IBzAgA=
+    headers:
+      Age: ['200']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['public, max-age=300, must-revalidate, no-transform']
+      Content-Encoding: [gzip]
+      Content-Length: ['16952']
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Sun, 22 Jan 2017 22:10:01 GMT']
+      ETag: ['"tbys6C40o18GZwyMen5GMkdK-3s/5JjoP3Vg5udAY4zd2Hcsn9dKASM"']
+      Expires: ['Sun, 22 Jan 2017 22:15:01 GMT']
+      Server: [GSE]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      accept: [application/json]
+      accept-encoding: ['gzip, deflate']
+      authorization: [Bearer ya29.Gn7bAxcRi6STSTCLYLqJ1t8XiTM5ML0c23J6jcbAgxDr7xF5Lu9W0g6ult7JoSQy1jk4AiThMk9Fi8KsTIJ8HB335xgjev222mFBT850zhuBgpvyBuyCOcxTcnTYn-sbXo2Gz9RQ0M92RewPz5H_8savQoN4uFUy9YVALxZx4yA]
+      content-length: ['0']
+      user-agent: [google-api-python-client/1.6.0 (gzip)]
+    method: GET
+    uri: https://www.googleapis.com/admin/directory/v1/users/london%40djangogirls.org?alt=json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAI2MsQ7CMAxE93yF5ZmBoVM/gAWJgRUxhMaqkNqcZDcDqvLvOAF2Fkvv3Z33QCyq
+        UB5pD/QFc7o5deUyYY3P7JLnBY+48OHjVaKh+4zthJLTL1nFLM7SoqsYik5CF2zUSyMVEz3Li1u5
+        +rm3GU9IbTEch45//6ihhjdeo/dDyQAAAA==
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['private, max-age=0']
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Sun, 22 Jan 2017 22:13:21 GMT']
+      Expires: ['Sun, 22 Jan 2017 22:13:21 GMT']
+      Server: [GSE]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 404, message: Not Found}
+- request:
+    body: grant_type=urn%3Aietf%3Aparams%3Aoauth%3Agrant-type%3Ajwt-bearer&assertion=eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiIsImtpZCI6ImYzMTAwOGJlYzU4YmM4OTc2MmYwNTk2NmI4ZjYyZGM2OWY2YTI3NTAifQ.eyJpYXQiOjE0ODUxMjMyMDEsInNjb3BlIjoiaHR0cHM6Ly93d3cuZ29vZ2xlYXBpcy5jb20vYXV0aC9hZG1pbi5kaXJlY3RvcnkudXNlciIsImV4cCI6MTQ4NTEyNjgwMSwic3ViIjoiaGVsbG9AZGphbmdvZ2lybHMub3JnIiwiaXNzIjoiZGphbmdvLWdpcmxzLXdlYnNpdGVAZGphbmdvZ2lybHMtd2Vic2l0ZS5pYW0uZ3NlcnZpY2VhY2NvdW50LmNvbSIsImF1ZCI6Imh0dHBzOi8vYWNjb3VudHMuZ29vZ2xlLmNvbS9vL29hdXRoMi90b2tlbiJ9.UJ4-sjdypkJ8_26lzyFFHKRzjAgHt20l_ruXEpM4r5Ka-igcJKSEIunySppiW8sQXYpv_HkSOft3wwQiucEvXXT7G7SlHTz-Lc_R1U_E5a_HARZHRhU3XzyH3vnMBrcNXw8obsnayWa4klxDGedqDrwP5wk6g9rl8k6PJ_5sC7LCQkQj1dkrr6lZhHMlc93XDOZ8z2p7P77mS-GgKjpyiRj8KPIwmMHXxJKkjeBJHkj-OarzmiL0frVqml5AExkmvz4O-Hk0U4nZR_Oc2Dgs0cUYezfz9DFouzMyZq4CpzMtIoOthP3n5hQooSp3UkYpV5RCtsawJhMGPdZss62dng
+    headers:
+      accept-encoding: ['gzip, deflate']
+      content-type: [application/x-www-form-urlencoded]
+      user-agent: [Python-httplib2/0.9.2 (gzip)]
+    method: POST
+    uri: https://accounts.google.com/o/oauth2/token
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAC/xzPzW6CMAAA4LtPQTi7hdEhsBvlR4cYRaJWLk1Xu1nkt1CsW/buy7h+t+9npmk6
+        oZT1PR6aG6t17U3TH8R0n5e1/eEBZAUCVYXR0qKTUi4/h3iT5xe+99Frw6tyX5sxPMFKwvV3ela4
+        j7yxoyq5nlabIghNWjKwrkZXFc3CzWQaUScZD7Ujb5injqs6tGuhefHvImo6fwjeD8pzPGAdTUAL
+        nGdk9eW93BHpk/i6PQubuwSnZbSNc8N+suywzUDY6PP/BlMtF6zHfEqAhWFMPLXw8GjZdIOMCCb0
+        2e8fAAAA//8DADYSAmr7AAAA
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Content-Disposition: [attachment; filename="json.txt"; filename*=UTF-8''json.txt]
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 22 Jan 2017 22:13:22 GMT']
+      Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [ESF]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      accept-encoding: ['gzip, deflate']
+      authorization: [Bearer ya29.Gn7bA3X5DrXmj0pcjquuuGftJMZZdiRCX4oimlRn2JBWBmuBKzQYx_sFAvqcxLhWHMjDE2cle3Kmv9xjo69SuQFc8LvUn8uk_iQ89xqXPpB2dCwrFoqCtDIUxA8A35V23cj_ZSaHgA1wXasLJhOYr7i9a_QlFOJZ07-57EpS3Eo]
+      user-agent: [Python-httplib2/0.9.2 (gzip)]
+    method: GET
+    uri: https://www.googleapis.com/discovery/v1/apis/admin/directory_v1/rest
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAO19a3PjNrLo9/kVqMmtu8kpjzyPbGo3t07dUmzPrE/Gj2vZSe092ZqiRFjijkRq
+        Scoeb2r+++luACRAgiT4kF9RVSojk0SjAfQbjcbvL9jLz0Hov/yRvfSDZBbd8Pjum5gn6SFPZnGw
+        ToMofLkHX/HUm+NXv71Mp3fJDwffv47e/OXD/7+9O+Hhnz+cfPZ/fvUu2f/zf/0zOn/3y/zPG3/8
+        9+//7b/92ywJ/+r/PJ6c/PaS4GS9/MLjBIEDzJs39CogNDx/FYQ/+kHMZ2kU332SL0NvxbPX9GTm
+        hVEYzLzlqXyVtaHXNzn8ErCY3wTq5dvXb3548/bN9/QiDdIlwRpjN+xQNWTj82OBvjYt8NnlgjPx
+        6eTwZ/NztuRpwu6iDbsJ+C3zQp+tvNCbc8bDlMfrOEg4g5mONvGMJyzZzBbMS9gmAbzp63kcbdbJ
+        HqMRB0kae2lww1kYpcE1DBtRgLcJn23iIL1j19xLNwBvT3QVxXxEGEe3IY8Po5UXEMbzKJov+WgW
+        rfK3agI/0Dt6vvZmnwHXcy9dmLMezKBbePT7C8ZefnnzA75dpOk6+XF///b2djRPUkBthh3sBysA
+        kexPY8AoCOf76zjyN7N0/82XfYHG/NObH/z1aB3OETbAe/e2J7x3byW8F+wrrVc026xgwmm6Pgbh
+        Zx2+z2/4MlrDhI/yadmnsb5K/M/7Gd3sizmJozSaRUsEgSxCD6dewq/iZQltguetgySHqcG7ebOf
+        tVZzXPlRHEVpcxf0KRDPTTAzl83abTpbqI/oD7noMVACEGe2wN4ylT+BN+7WRCVAiYFcsBI/HHqp
+        x66jeOWl+A9LF0Tja6AZQY7U5NrbENyX/0yEdIGnPNys4NF/4x/yBf78R/5Wk0hJ/uWFhJ6w2yBd
+        sIMImCtMX10Csiy6Zt56vZTMsl8EuozEC8TkXxsQSfjyKxHidcCXftJq6BO+pFlmyZrPgus7+JDd
+        LgLgagGMpRELwtly43P4l3kMZjsNvGVpfmrQ+szvWuGEYgjajNjfQcow+RcLfJghkCGcxFPMgK7/
+        CaiT3IDfN/BeCC6aUWzlzUBEgWT51yZKPSFgYr6O4jQZsQv+rw0QmM824RI+ooYSCnzIzsYbAPJ2
+        9BrG/5mHDoOMPGjxib5uNdhCTxn9gXyMYcAkWR26X8c8Te/OoZ8y6U+jCDgutPd/wUH+hkm2nmL6
+        QLkq8SPE+jIIOZvG3PucWDgijTe8GUdahysYTztquPGCpTddciRFmA2aIQLF1pt4HSET4SMUIjx+
+        ldAK5vwDa30ACzrFZb1jXjwNQCWBrhNdgu5KgnkIdADAPZrsPTbdpCxZRJulj2qL8S8zDh98/5rN
+        FiBqZihpRuwMOouJ5rDR8ZoF12wawdR5MVeU5DssnGjdakaOz0G7+jGSLcgKJJYkSGHhFhy6FrIL
+        OklSFsXBPAi9lAO+MO/wLkgQT+ISD4gLBs1DmLwZoAxzh7jASq+CNKnHXKopJHklc4n+32bjAHNp
+        zTNRVK9loKHQIqNM5o9mmySNVjmplGfhl4J9olrA6JcwZB9oWIj0QMpPMeE9cBkB+ftRuLxrQGp7
+        mIDqBz05mi1igB8l7pNDEvOAmrGzCRNwkj8x0JueD9pvULRc5+lekFpF04CM4zYzJRptFaMRCBKB
+        QgViJ5X4sOkdsivSFIkw09JOveRzMiSibVZzSxOn/ADHNUQZSCIYvSWcIhCTAoZQFYSq4tK+c0Vw
+        XSdJYaEkAwjgIZEh56vfPAn/jUWhQExOfX+sRiu+mraR59QKHMxpbj9vDSvX5bsfnNogM2z/hpfu
+        vlRGM6DtGQdB5A+KWRTPN2GQuuMEDbww+DfhxLDpsDMl8XFdqy1jowIyo5m35KHvtWAzmwxQULRA
+        z1axdTastowXuEliVjD20qiZfXCd5yTFCRDD5pp+GR4jZyWzfcQ2SRtRbqMxETEccvnIU/aWgddC
+        cpHHQ20GpqUcGddV2y4qLZDYQu8q3NvMUxiJE3EbNHFXQZKQTkHi3Q5uyWwBLNaflpkAtC0EW1FR
+        LSov5P+UEy8/Vn78WGcgubkhnu0ZAYpoitE3e4DivyZnpyzlqzUaubR2BIGJNqy4RaFiDTCtsOZp
+        oMcNivxsi49YYkaCkRgMLFiaSyB3hNrBO7r05irWkmkvEy7NVDuoV2Hwrw1nga9AC/Py2wtY6le4
+        1t+x0ie0vtoXJhJyU6wdGj9DIwSvBibDRCoEZEb6iEK/ySj0G7E+BhLrOFh58d0RzX1bZD7gFPwJ
+        mF8AEStoTgnMQN0HRTLfy6iaW+mat6bsLFSakTi4cUvwwDPx3ZrCuY3GvTj27qom6iP2h1sFGmdp
+        SxYAbhpMDWh4J2ZITNHW+eKBSJIndjpI1kUagCfu6487p/mqL7wUUBTxc8A4uAn8jbdk48k5+3Ys
+        lNhB5PPvSK3V0cAMvjq2TVMQpnwOplbFPCE6GyEijg/VQkD3+TyJwKME9e6tuTYzUCoI6jJY8dZr
+        RFMBDTHuHKqO2S0QI4Hl/ogdfVljlJoioCjKvogGAqcKHH/4fmB5TdPRnyRpuHJ7jsCeH+ckzy4F
+        fQI33np3CSuRZLJ2I10gRgPVpZekuDog9DqibF0hBIuqZKA1klkO7bHDhmpCtT0bwVlK3e3hrh3g
+        iAkIPsY+4UUgzMFjf0/kJcCLSjI0ccVmP/O7TuiWWI208e0igqVPNhjOM+mtJHtKCggf1Ugfm6zY
+        mgFjagw3LTQWeg8g46xnbnmNHvpfMb9Wctemhx6EOVGZujIofmtd3wMZnbiQHRfWuvS6jz2tgDEF
+        rYttjZTU3rbels4vrmG+fu9hwOXQzx59deMt0T4ur2r23TeqafJNcQmcltwFkDl81eLQGGD72ZjG
+        Ab9m2gs1NaXJGNkR6GaCX9LkS3Na2tcg8rLEhFLn7AMPeSwCTgkliFAQkYwL3J9ioS12V4Gz1Qxq
+        I5qr8czae2EYpcUgN6IgckJeqjQd6qsUtkyyuGUyCsANiKU4YOwfNoGmmp0OoSQtk4/cwb94IBz4
+        HruMwdHHSb+IohV7M37YIV+KMfaTA5YhozVE60wOMw43DwgHodmKVDSa0fG1lxNdveQuquny+2Fl
+        N/lyKiWsqyR/NDYBLmBpxsS6BCge5ly6diBwXSwFu7Adwmw4zlPKCDeQXh6bRUtMiZPitjSQRnPC
+        pi9mRSjOBocztIJFzr+k5zDTl3o+WisWnEUwNeFG2uMIZo88Box1rEUgFJhvvgBfIp5zuZws4Zhc
+        dy4T6WhSpYbG3EHcOMXUpDDNUpQAmvCgiQwR7TKFWFl2ARKNL4uMKp+6s+c4NHYvMcULIWRDvcU0
+        U2LbLBaBn8wzG9ce0xHpWZ0mXqV2iXQuc2sVc8t8vgxuyOMRmg6mWCJdYF7+ZR3EXifr4xBlFQa9
+        yReEtbDOUd7BHv6WbiQxUeZIJilopj1c/lWwBF+BA135mD5HfXlLRw+zQ3R1zK6u0FOLWRJA36gK
+        hI0gM//IxwwKEsA+k8MJF0dakyQmkhJzvfcLstKPxCnXwRdoJIfy20tvHXwjwf320i5Y8i8K4VpM
+        n7aRqs42lun1/UAsIcsTsElqxCBAEStJqHfZOKd84d0EUWxbfS8Dd17mp8o5LxMun8FK80QanRlm
+        GDZAO2pkVR5r724ZebYlNlJnbTT2k/hASjlKlvZxfSnoAgsVMwkcNQbmXGLMJR/+UCYwiLFo7UkL
+        uEzZuYKHRaAUbyQ1kaJh0D2bpJRq683iCGSQH1xfc0pDRo9ank1JKtC+ioMOTCqBvhL558EsRzzO
+        THmFbYWVknZScjBlpWzgXLbCSmLPKSq3NJfJmBvNPeBSg5HzZnhGqDCjFYud9rWNM/ZacewrSFZC
+        kFRphaL+xLTLs+SQMvVKatR42cvYlemdCRPAckJstUcyw9RGDIRekGBsa5JmmyUzkSKJWi0WIlbf
+        OWrcPDFFohVXE139cWVU3ybHNkKxFhWn3sQa2s8pjKDCMthRKMjRChOA9rbBHLN3S9CzXl8Y/5oC
+        Vnqf3B+DiZB2kW+inTylEgCZ+xviWB6iusHsGEZ0r2xSlPm5z/vSjs3HPLm9JToq/T5mKkFeeVIi
+        9RW1PXSSxav1JN0orkDnykyqcdxERv/W6NuEDhosPYn89rJGcC40/8wQBlsBkOqdZ9F1h5XNdrgz
+        qY9eV5YULqVGZb/b8nxJd4c8PfFm447GvDaBAIVlNBMyBRxslPQ2ij/n8YnqgV4H8eoWTJv8AGpn
+        bBQopXsfUz6BOkNgI2XctTrK+L3TpqXp2Gj8mu2KCYECjGtTDKbse4VAyihO7sLZFhBLACxMThj8
+        Gze70BChVKRoGczu0O/GWGsW/hJnYtl4vU5M0aMsdDBL0STvNMjVNnjiFpi/DT+seAef8EQcTzj6
+        1yZYk86wGJvvPqhTDDMv9tWEaohXowQSsn24XZ8SBFANHxVK+yk/xVZowTopoyj2eXy6KaTqtx4J
+        gWEhwakeUBTPQfyn8khvu87ORNs61RclAwhLsFx/aRKTaO4i1wzQnQLVLJsxzT5MUf13NocFCCVp
+        KNmQQjX4OafD6nIhgW5IBi2jOfIDiqht2M3c3K+qnkDLmGivq3gukpJP2blIHmC0nxVoO/fkSoFu
+        Eqmdvs2CNt20VhgVNzIoZ9rJXIYPA2/ZnwsFnEY2xFoFm/aCRTQr2L3VnWzWePT6KPQPDafEsbP3
+        AUaafJF2lStHcI3waK8E3lVrI5jxJo0ueMhv20eBfkUstGn3NhTVxgCUd42OiEQPbAtfDKEpXdF0
+        wMfGSUGrjy4/aempZ0F43WMH65B2bWfZ8SbVlTLGDc/9UJ5JdPDguzhaM7n/gKucenhAPtIVcoZU
+        z41O0+xM1OFM+aV1k9PnWRo4rGZSN7jmJS7tOBbetl7YYoYqriyJ/aJrBSu85nmwwTkkU5ixriqo
+        5Ok1Z7Jm+4JmlMq2Rs8nqbU43aZh2G+3j+pOqE0IefjC2IkjRMV2XEU0sXBaX1GxetwrgqhO0/dJ
+        dfKWIIexEkL3lBh1RPdPCRPBOIwbozcFskJmyUjrQ24RG8/AmUDBhGJMCrAE0zrEyQyMFqVaF4eW
+        oyPq3UHfnF1tHCr/V7PoWmrOAsY98VE5/XJWKPFFABixw4iKcahaNLQtcHsLTfh18EUkfxYzjlTZ
+        hkd7AKQicSmfEOnGA09GmzAd6UvUXx4dV+wQiSwINXlq07EkkAzebhBe6lsD6aUXzjcYXO5JNceT
+        M/bDu7++essURIb59MiFaCgSVnmeIA9fXU0K7tsiCnlHa7vIUVIeEEhleAMpH43e/PB9llRt9h6B
+        Ib0sB1QyNSehnxvfOTIUtclkkFaHpF6On9twKgh1Cz4dJXwBS9yn0Zi3RqiLBh+DkL9pb1ka87S4
+        S7Amny7BuS66UW7PohVWGyIdjqtLW4Qx51QbqbgpquH2tj1usmMquvQ2S5CXuFV29K5fR+/qO5Kk
+        3TmNMauKIwHBtGs78nkvIOjiu4MuOxZZYhZT1j6TZHMnk4hz4DovgD4XCgUlybs3P/ygPiQ5wviS
+        Tl8X5wM3fpbmmVbHgJyWz6mAjNg4VFmcggHUm1xykW7AJ/B+AiT5PvbCGdalHJWialmtge6rBcSO
+        BbNo1sRPPN9EISnLsgkW7rhqXEkAIbbHLIeWzQktq/zs38FarIyqPvnm9evXf80T89CgAo0Z+zA/
+        sp7ZK4ZHb3/c30c/HDMcJBEmo5Cn+34MfjplIIwW6Wr5jWSAT3LlS/kO8y6urL7sAkR50cXzfMlP
+        /55ZBRhtoa9OwbT5exR/tktwYYjZDvHqb/pIawGn+4ne3ofOTKtVhZ+kIU0n7vX4imOCmZ/PTmee
+        0XGwMcnz8Ua12SolkwHDCBLpPI8CiOEFZAfCjDmmrLokmgV09gAZXQoB1Ng8oPQrLPyXORZUJlD5
+        bjp8bEspqgW7o3NASRZ6csmWv+ExpTS0Dzwey1wzoRsEHJmNkIkLr5o1mgRIKSplvusdk1KnpnUE
+        Wx6e9m3Yto1BGTTlHn86LDLBsw0+mbNcTTV2ehlE3dy3ojmoVjI91cvAdOq2EedKs34/ya2LVHV8
+        5/4F6tYiPMm50CN9JHVg2CvCrDXDXgZ1PQrON7G4H301ss2DVei8tUudt8MpKAmxg2bqy+tttdEf
+        QxPZddAHvfilpAXxrI/+IQgds5YR+QNRhaADsyRaTSBZywATMURNN70izn8UIkIDFJRpmxitb3SW
+        9km7n4LWTlAbNZIKypUW5IQqeSYHGLpp3ZFYZQGIiZqgiYgCuen3QuaKK4vRDhEMTCPTzgpSlAN9
+        UP04UPbvh2IZrIeWOhaa61TyRAyMmprAovDIDygu1dNEDDG7WIIajpMtcrZo6suHvVVulqfwQVa3
+        7ZScsC0KnxtDb7s4QpS7q/QPOdkNcdq5Pws8trSDE6OktKRE+bCPzhcguin9nppA6J77P+8wlOzO
+        dnnKA2HWBjU1D/XPmubl/jlC1jM3sMBKu62xuIhE+N8GsGNq5iRLzVTzdrxabUgrFOat2zFEmdVa
+        CdzGpkWNoZ4OpzIkxEemMx6KMgvCemUuQlvdJZfaXXmdaNRc0F4PrzfofIf16KvxqpcOEWdIep16
+        9aeTKv5vOpjuT9m3V5OfmM+nm/kcpvM7xkNkUR83Qfwgkb/DxsRt/S6lzj6lBgOmAHdxZe/GNDVb
+        p44HCWB8sBJ3ZhyzmsQsmB8KCFkoUxuB7ZiAvHiwR4fnAoJzh1lxbHt/xrLUrMx5oci23q3Wurgg
+        lqFlb75a0JWnWcwEAR1I85FodQqHdv4LE6S1cjgVLZHpsVgKl9rFemH8a4pAvEFx6oV+1xNDpnT5
+        SUJrPjSEJ3mxGgWPB+o5g+fQN16A2bc/hFHTxSZY+h0z+QodIaTGkzNSCX/sk8moMhQp4YcLxSZT
+        hE2U6s5eiwtBRamJpKvSOFRwwIISorqjyhDvD6IViGeQLtyvxKjNksxyeEyePRr+OLrZpeMBKtHb
+        uZckt1HcdbCHFiA1fmCFm+mkjun6XDqP9qdCmvqAcV8ezuI76nqQ1T/KwLHGudmSJX8dxNs43U1g
+        H9Hx7oUX+1geoOeC/U2CqV4n1VFvNs26Oq7RDTDO9vWJzH6OT46OG4XBZyztsBxGvf5MsB5jnQZx
+        RL6qSsMfoAQCnRgei4MZx8lZeIYy9TyOrgNrCKhB9aoyYrJ6GB5iCaQjKw9/YKoA7oJhN/sqY2At
+        +kP9jIdjqisTeOHm2pvhTet9DSMd1HaqM8iOgNcOG5mtW8kFPRWXINRVEajY6WmvaBHQcOpVlso4
+        o1hX1HtVxV9IR7IERyQBs2+BED11B/N3NcUcOpSmMNZBYCBid0D/yV0C01LoA1M6JdMlx+F11Dkg
+        IWHIuhh2m7bP8gCH3sB4OvgEhyfjOQ/T3DGvKwEBQiPpXBKoGKIiYJmycShA0blcoTXE7+jtqLvE
+        zrEo4Ed0WXoOfCIBgj7A+ptLBNmgFSwZAL1qNhQQmpwiJ06E83G6neoNky7VG5JfQTR0VnLYOFNZ
+        eckGB4ey2y6FUSyxvoNN+DkEYT0R9ZS7OtBXAgpTNa87us+oL0gG9KQjcaMgATLgY6mlHnXNzE5+
+        Dd4H7GR8kJ2Wa0ow1yPs1soWlg9a7xFV17WYRSswYfykFHx+HGUt7PHwbhlBuo1eX9KieoVKu3bG
+        uwH37vRx77bwjKUrmrz6q472j0n5LXb19O0xu1n6wHt7p1ph3gLtGq/cSfdSJ9ZCCe/C3SJWqpxG
+        fvtDoj9BI0WVRo/3H/WKo1VXVaHOFyMMdrsIZovygALtxvDq4E1yFeKdNIN41qoytw2VDXUjHeq+
+        ZxaM4v0jMi/zTaXK7zZrvbCuNYNz2AuWXASSjmIxeTF/U+cKFKzl0O92ABRjQ14qiclYPQwTUZ23
+        ThGdZCNEQGs7WrRz5NVqWVVUtOa7jtLKvD2CzjIoHfxkrpPJU1v1sejXyTjordMS+T4qjtpCYiWZ
+        vBwkTkB3XRTuVjElTtEXQhFo0F9VUn3D9aTSdcUq4kKsGtyhTrbL8z52Nzu7stTkHFn9s8Az6mlL
+        s9SwRgEGo8KinVJ2psto9vk4BO0SpFh9oL2+miyizdJnBAi6ziEZazTgoQo1afdiTNy/JR3Zhtcp
+        e19FKw0q62wbAF4bgOJ0YEOOoUOg7divXOI+xXexUSVgcXz/rCfOsghAcw+9BmDtxSpqivo5ezyc
+        D3ymFW4hGbTzgyM1y0XSzSbKWJu2NgVFyNy9X4NM7LGT82LcX5JL/ryPcsp2FbppJzAGln6GSY/L
+        fglQjg1d+aZ+SzcZZpZiC1TM2mNpzPmIHeHVOfkgsEzHwrvBCh1VkP+PIBd6TTUV1+md7AG06HX+
+        pcPy5WtgE7LbOzV+tpnMojWGf9ubA8cCtjlnU+oMEJulMlICmlwXHqhZHvzSc8vS1HD62lyc0j7a
+        INenaigZvUhi7Xj3bDS93iQzOp+bXw2u6F94KdnyBcQf9u4HGaJTvxUyq6jjtBfDabmctx+Zdut5
+        Afp5STa7qJR6mfSATOumn/PPrZR1oZ2HkjRFj/roQDxj1fFo3tYk/GQDnY1xbi7sJ8AapPwFXYGa
+        gJbEXXHZWaTK3iUIXZ77x6fl7ilVYqiuVRHFdcxfwdIHIebbUg+23u+fRAUSDsRJp/EMZPHJYQ/X
+        ecySBRby900XWi1XsVAgPOri/xyaMK1xkWL6AX7aSX8YZQmN/jpeGQ4w3C4Jhw+726KXpOpI8GoK
+        hcrEYSLoPKarNkWNVtxhMEbW93hRhVFSPekVA6gzTfKZYnYDpXVvnc2UbOnywyzbppGyGhknSTAP
+        V1pWhKZQtJd9VUsOquOhPWrP/UtbblqbcuDarTE5DcuSh9QDEPdjLjDZW8bnK+Es7TU6MAbQI4Bm
+        KuNmt2tPXr6K9WWxZhTVFc6Lu5e+p6f8C49nQaLtcNv6s6iXfMA9FI3szzbfjTqno8tk6jghtzXS
+        dkQgAbeaX3bNDaPWyNtqY9rCYyN2HsFPrKZCRXnpCvYf2W/hK3ZwNbk8Ozm6wN9nFx8+XZ0eX1Ya
+        wfncFn2s4tvhHC1zTZ+Zt3VhF9UuLteFRVA8uN9VWKwOEq/bHmIVwdrIdGjifIYk2ZoQHxH5uRPd
+        cKQ2mS34yivQmnzYx5ITIB5XmOA64Eu/NX29p1ZU81+bljqyEt9Ru8mazxSF9TPZEwKaGe17NZ9s
+        K3+p10aSQK5oPuCzoY4vSJKrTqGn9518dAmadq0HXUbrGtk4NKcmG6vmb/vwbAYlX+GcldsVX90q
+        Cw9FMDTeugu/4XXvkA5B6RvTGZb5CaVuVrum3h7hwEA+gSPXI0cVbyAJru+KOao0VHGxCXVQyk7V
+        5B6GcR96015M2TdC32UaKMtfh1YBXSo29EypwDX18Ir8NV9Onpox027ZrDg418c4qwBJF28VQszi
+        Q8vGhJHKEBdwJYmyn+5UjY89cQUx/4JXhK3otBmIhRhvYCvfZEv5mzqkZMQm4oyzyOcrYw/W3TK6
+        BS/WC+c8Ay1OmWSA8yW0RjdfrrwvtDras3wyxHlcnVEKZ4O8L8Fqs5I32KjogpwIZYOuYAVTiZZK
+        y74BmevJdcTLO/B2phn6378ItzvapEngSzoU46MpS1I5cZI39th0k7KEezFM7goLOIlLF0GBwFgp
+        mqDFN4wAgx9tpplBngdfXwJx95iQIHwuE2ITeZjVOaZjGp0EOuo+Nj74mKjjT4JbDe6OKOXhJuC3
+        KgRTmEWYkMDXwjPst5fjjx8/HZ6djI9PP11Nji4mv72kwgLw4vDk+HTyaXx6+Gly9PH9by+tAq3Y
+        vMZ1KfrJ6ulwnrI0/h6Xq/xQSiWx2dSd07+uQOur6XVOAptonoTdZDb8YEkX4lkf8ziltO5uexJh
+        FN6toi5HWn/V7BCtypmITc9hHnmsanGIghvi6sT80jptR1tvv8BbRkOWYcYOlgEG8o4PixcC0vOO
+        YeYMqCJnHQX8W0wqUWGysQXZZSXBS/6l/dEQqu4l2lM9bn27rzUij4qTe8WaaKhOPE9fFjO3UTWO
+        1+t+pFyebkZnxFRlSm15HAk60AtbIjhMEvicRmu0PWVxC3Fos5j8hdsQPcKO3iZdRLHaUhLQbNjJ
+        LXGHXfCasha4G/kzb3+csW5rk7Z+xCqolbHnqZEMLSpc+XA4fUsIPLPQ9KWhO1y03GXOeg8enKYV
+        wbVxFxr4tZWGUOUXKIge9dHMV3kWecv6vrLmnm1hwzuTArx5zDGr4JLHVkpocwEVMR5pYAJKWTII
+        1npyEk38M3gCUFD2mUht76qZQrd9hNZsge6Rqqw4Tk9BmX+M5tb76jvW6ZLCLBGHt0SHbC17RKKg
+        03dL6tTErc8ldVeJ5ZZ4835U+/1wttOwLustqvtPKq3u+liJuDlcBjN0JaCF8Xw/wM+95bk1OKHE
+        E45cgNO+s669vI+ggwF5kDVVvkJr/vD5kruvbtdVoQqeTkJkQPXkhNgXECuwlsf2ba8idiCRFu83
+        YbeSKn+DxuxathamNp2YkTw4YpMssoYxgpPDP++xyd/Gr95QZIBqixZU7kBh/hLhmL3Y1XpxaoJw
+        ttz4/Dj8sIym3nKsLn1PbF5JJxlG8ouMWOqJhJbojKkqDppSVWitf12AREYzo08018QkWCMetxpg
+        s8+EEq0Hl91BUr5azYnKg+QQ2HyOiZVbw8xXPXTG8UgGEI/Dt5ObDvZDwt6+gsVYm9c2qrBkJ4Ti
+        CJ2l7ghxCQFJ1YZce5xOQJBOoy8Tnm46OJiA0koAwNTkwhVmLgjcf1Rtk2in9+tQw/qrZDP1MVSo
+        iCsZQVuwTQpnunVL4VTfOLejNsDeOs6lU+b7A1z3NqA1DVPj5rH0OWAuT9oq/Vl9/NcJE2UEdKXb
+        rP09Ech6EYVucywLAR91unQM8VExyStdEGx5eDFfuq9dsknWPPT7XTes2Tc5PEs3WPAUuCfpYH9O
+        MgAgiRGCtdPWKiFdbFbTEFb3fBGl0VFf+12WIl4jsJ64XMXtKY4aMmhphADb4nHLp0nQJIResGLY
+        ZzyNNsXDI/nzPgEggsC+Jcn4HQU25Mq3OZsfhSm4DZ22UUX/0Bq60c7UU8BNJLcHxs3bsi/6YMSO
+        U2rEA4qOTzmDgeHV0zFbpKulmb9AQ1TtxW4ryMbNSgSR5KEHCSAF968Qxrwx99FdhzdLN+CGZFvo
+        hIQ9REzraRar01davumz1jJoV7+UG1yK9gEH0a64ASaemlcntYNIdyYVwVJ0oxO5yTgOUU8hvgAO
+        P4q5rvUCj2R75XIW0+/INLS7mvWA36uW+fqZ5i1evhOk7dfso2xYgLeOfoq+tLd6iAPXXpxSeMyO
+        6jrCXaZO5HBOTW3UIO2IDjo2PzGsdIu8m0Bhz1CMMzBolIAS9a3wJoH4My5I1qR4vonPuwSCLqhZ
+        cZNNVCpPJqBM6O6CDuYEBXIwjWoZ5HQkqg5mUEcs70G7Uwfl5OnZpZbd5aVi3oQf9Pdow1bBfCEy
+        c9CYB2l6G4OS02Dn8EROD+g6lfVCmT/8BiYYBCXMNkCZLaPpFDfnizOBlVjSrgw6odYFkGkXIUKl
+        YNxUFhBt6Huxb+T/eFLhjRjwNqbUgYzm2apkRAbfLqIV32N0qQFPZ6DvQqbCzOJ8MM97wP73GOVb
+        FTCb5UJPRAzhFVZuzpcBQ4x4jgy/kBsB1BY7EIfFpAoDisnAeMskMrugJFcBsFLFlULfZV1X+qSX
+        0lNnreUs5FqPfRuMYORAdSquD5rfIxkWzDZLDziGdgukZVcf4C+ZceaoDS9HG6p43mt8obgGy2G3
+        rj2h0/1agW9ueAysiy/LungLIl3MUWeBfm9yAt/Wiglx59lDCIlcRiTbFhJH2e6LjWfyl30ZJ4Mk
+        Z7rOMt6G0dmJrIoJCcdFPdnNVclThSTcwK9eoOOVZWHgYZ8FoRwkcO1WaCiEc7EF5YX6NmvNyoBM
+        TqNZ1N6xP8j0ArW/D18jWLUGdlyanKC47FuQmsGqu8hcd10QtZKimL68Eq1EHOT8SzGEcjDM6Faa
+        WlS4/Tiji0uSWytvDbZOsApQvaNwJHkYpJq4K8iyMMvpFvEHsagUewTUTNpTJ3seqeoozeGDG5tb
+        VyQn0LOxs6mJq/xdS6llvaNF3uG3H/Ob6DNug4rdziS7q6hDYK3yfqT2m7Ihvy1hpEy6QYLnq2w2
+        5Sd1JzOzna3yquQbXh3VSHaxdfv5vvZAMNx1Orj4EfcHT+9xJ+56s1x2wvQ9NBSYGvDmAfjg3QDS
+        JbD3MvYyFemFhy3UZLzuaS0a9W+a7cUoSQ/gqw5Xql1SnBvmdEbtdVbFdAp0UEWpm+1bKnlvrYEe
+        Zk3pjIXU4/oklvrS27ftLPtTTVddT1S2v9O6iKYU48ruhDEIY8qXEV7lWjoFgXHaTmP7KBtaByYS
+        kENMhZWn41Aw3LF/bbwl5nFVRY17lZEvYjGcHQqWWMEErVnG5G417WBfTqiZA5mkQWotS9l0zQu0
+        Yt/C02AeEtjvjC3DZkZ4PBajQdm6rZjMFrCW27EWURMhIaDBiGTa3148cLYXzzF9waJHxPN+cUhK
+        jbiPQMP9RNTEcKyn0x8PAQski17Op2vvi6DdPXW+6dHTcJXP0yvmQ2Qtb6quZYo0sjMFPO/DFCKp
+        osP5k20dVlpw3MqyQG64Luhv1A6HsA6+8GXmXq3zKWJV1wOpoNC9JG0/TJ7mN2IeDExWwapbAcQT
+        vEftUguAWoDTo0Mv9VpD/8lL+A/fA5fjVrMv0418hFRexeldOozPQ704FWrplTV3rm+GNNPKbeBb
+        8x8beOFXbNaNFcqy50Im3FnET/aqn1pWKX0PpJk7bwFkeOubc2wSaXWZy/U/Qd1hosYeu/bEvwmd
+        g99j01i+WHmhN8cfWEeU4oV7tCUalrb+um8z6KfJ1TCq1c9VSGeRbGZZ9qpvBA94fCNhdQkcDZ8v
+        XJ6GX0XqoGUW1Jt+fCBTE5+PgaoG9MhNVIWmPRS/h9fpzf+g5qkk7GrRYMseGfJAPcEzz9OP1+vk
+        4e3UhzHjtnDXZ8sLsxX3xsEclNQnyhtrP783lEGM/CgBUQEH0ZkghW+p2pnagJx5or75+SZZsAv5
+        TcFY2ujkqKGyjcvccj1hD4z/oh0l07MtJZeUXvdRHMaxNbSZH0e5y2EvxW0q83BTmFEnjio2KtNT
+        /0u9rIVLirK5glqc+xyD9I/pMsoSMWSXBwjr9Di8wYpnhBq8IP6yEBAaqhjNjumCH5lkADaoti6a
+        TKin/aKKKL8fTl1YhvKsarGUl7dNXZaS2DEk2KPg28S5VIu1ZZEgX9CwXmaTJAf20kvWOVmueLqI
+        tCoDL01vJyPcPGaAzUe644NUJFwPoYb2f5fFjr7u47f7v+NaHftfs68Xabo+oX6xzeHRx6PLo+qt
+        NeEVgekzOVfljqZ30k3SSnJ6MViSqaEFcRvUL1z9UxVGsC9rSYAhEqLcpJiBvCqUGWzRzopawg35
+        G21bTkyifPNVfVIuHFVJlxbvRIXmktIGkKgjRH6oXqdLXpKpn3gzojZyO29PnJktPkShKmaMusKS
+        dA6zUzkHL4ypyJf4LPZpX/u/i3O0V1h38ec/FICsYFjWECkx+XF///b2djSnYjDeGizSWbTax+pg
+        +8R3IzNeNko4KBw88iLBGxJkztMm3sFPhmCcD0eXVVzzgWM0WJAdSkuPzrk9Iibasc3TYRtlcti0
+        6jhZvyz0dx9ctjTrt1jZjL5x4bP27CXK3QlKTlrz04403UmzHSkm90qLpuWPpctCvqyxrJI0WpeI
+        VvSnGo/omyLRCqT2M6Q+3bzZVy32jRYmBZ+fTSpJeIIFNm+xkjrmZ2Y2ItBJHG3m8lIv2cnLfPqJ
+        vGyzf2B+qq2tzOrL7NDtrFHecacVJuIfAsYIz99j+KYnsAxMLcnF0YpHiaiOWkN5XrEyWFFgFiCN
+        ZIMiIaqacGCZZCXevu7LRvsKyP7vaqnxbQGUO4VeUtq2qEoG/x0QdHY2YYfUX5PRYilf10bOrlYb
+        URwmP38mqwVSCFaWDOwlDDMCyadrEFyrZmq7ElubcNvASoK8RpIg+meJQH48y1P8hpQZsqKwotkO
+        tnyRZ2xmvSvDiCedTP0LDuTBb/hzZhA1PY+PPXJ1F0cYuTPEbAskL+R1pYbXlgUgqSq2PEic8CWn
+        a03l1SYaTB5uVhpPwJOfxpPjg/wL9vL91cePCvmMG2VTLYs5McEci9KGibiFBZd66iXBjAFVeZic
+        ok4wf8tH89EeU8u1h5ckB97ylDK89uTZjz3avUMl952OWdYHnoguALZhrC8JXthyN4zIykitheVp
+        Sqzty6rOlkUBUIWR4eZjFcWf1d1yk389hB4SS5Gh5Xkn1SP7du3NgxCj/t89I5m48r5c0EZEYsW1
+        MTKjLhwS6ZdyYxbBobQRkmcEE0ohaIxhv3n9WgNWHZpZiXt78NWbioiNya7ZiCLkz5+6+cUH0XKz
+        orwEECziRFwUp9K1oUmqE5MyeY776rCDLpiyl3qlNxqSl6STu3CmPxM1/rQHugQ0novDdfoTUeLk
+        KPQPtTQ8dyEt2GAaRZ+ZmmxGd4VI9DFAQbcboFAAZo29NIpHOgYaBPL2i62dWlKpygSmpeoDUQmr
+        M2YTmlB2KrOG7R+J2a18K2aacdBDuBs4aqdfNBe3lH3QgmRFBgJQrDrgm2cfyIiOLlIdMdpZIY/F
+        CsnWRDzushwTcfeY+EwRhVgYyqEKsRgS6kwwASRNSzOATIDMvfD2p0G474XJLXDM+u7/Lpb/ycP/
+        Lf7+zzc//PUv7969a0dnKFyVOdV+XNl9MkrRZKoHS+AkM+BLHDAIcWyY/eXjHr6oB0A5K3iBYcik
+        1hDbrAnJf7+WGseTg6PTw+PTD/q6Hx5lT1vT5biAowG3OIDtm7KdDdctRE8fxnJdY1izhekqvt+W
+        734+vjz4W5Uhe0U59yUTVqYOiECe0leYhYI3XyYcbx4MZknjxt0TMmd3Lv5OuRYxvncX3zEmWZST
+        jyk2YJOH8mCPu0CUDbYmEa8qHfsKebgTdDtBtxN0O0FXJeheMGNfVM5FzY5ow9aOAlC7qZPkchBz
+        SbpHMRMtWulq03VPIFESLouPinzGWCLj95Ihrem1ZZKHulpsePpSCHX3UbIl7OecZLRX75a4UZ+D
+        82FQ36B+x+A0KuySx0Ch1QK0gkAfmKi7mYUZKTYYhI602GT2PQo5uKOxQWjM1MiiblXhzqYOZw8M
+        OFWHEMpuCjgp1FBe9AQeSg4H09P6HE1Aoj0UZbkIXpGsXAl5m55Lv6TN3J40Z60TxqqIl6xkJpJO
+        CxbIPeWYljV+cYAFlhzAiBWl32zSuN4iNQnfLdWoK9U7WqzGCu6I/rkSfZ1SOcybbsHhE7zSfcuA
+        2tcb47Lapyvfyc9bs16H7Ndj6kpTLs+Uz9oTrrudVEOeD03VNmJsSLgySdEx3cqNEBuOuoizJrrw
+        4s+QEvPwp4enyQUV9Bb5VAmJAKoJxOQkUa+lMKN47lwohWsO/rapEgYMEXaU8FvZH96mjLe5IP2d
+        jw5uR2Z6DeFrSKJ5vuznD8N4eank/LD2w5pYj9KlaOtMONFyOw9iR8ptSPmB4vQuxNysSJ6aCmnn
+        JnRwEPq5Bs+VgbbvFHRwCB6hM9DaDRjAAXiGlv89WNDJ2ycm+UzjeR5Hm15FgwSAKtNZvN3/nf6t
+        2UFyKhX0AYE00KTqqBNNinsp8cq4jDjz3aS53vt2qTEbxOA2pRhEe5NSrrLNonRdYpdDX3/4Fa6T
+        Nx+0tRtQ2Jij7ta8p5ElqavCxpIiqr05dQBYlcRGjQFhneAHW5EOtoOcR6vpUDuLrgcyBRBxn7E0
+        UdufwdyquYDFjFVZ1dVmmQavBJ576GRR9E0fiKhQrRDbY9d4aTgVSKGUPrrZECg7d9XcAncFj6qX
+        i5jbZyP2voAeDAkkcjYYvJhS5j7CJ6rRZXYWp7iC+vyIoWcZE8bwWw76vs+vvt36+dXHdxywT6Wp
+        Wh0o6k5dKzqKEq5IJg9iI7rc3xM6k06riVbouK64XDTgxGuG2bVBdp3qipLN8NI2ycRaeeIuAfFG
+        0bwFx2772rIpjVAKeXsOoasx5nJ0iaZwmLzBLdtsLrRGH5aJ7UFsvCdsgTSmFkryrMgrdKbPxoMk
+        j8BV2JHd9snuRdZDqdwxPPLMvENLAMMSwqgmWs+aflhHvvtZChb9+Kq1qQtw2MzsVUQXXohsEFXe
+        vOiSWulcTYTxqJrQLRYKlmgwUpcQGd9oUkWxNTSrGSwVzNgKyza+e2eE1a+vljkvspo+qL3iWqi/
+        tcNAJQbpySLZVV6aYVj0tZuJ3fS6XYi9ksh1Z7y8fmPf70zfz5t4LLRSltaa+B0bFPZVb1WS2S7N
+        7oMwzdBFM1kWfKLuRKnFNspkQfV+0S9WqToiIrAjy0qybCQwvmUS2+sJoOh9mSJaOjiTzVRfJ5zs
+        giGmmScv1GaKcH777KZICM7bKfuywf7v4kfnLRZpf0hwi2D9wC7dMGka2aQMj6UAfc8mvWVgBSv/
+        kUQ45OwYprzTRpNiAKedphbU77z7xE6Mhd1R/1Oi/jqf9UQnyccWESzMZy8oAxQqH2JTT3Fy7a6e
+        hZk7bPShZ0GxZHV7JQXaA+7LOM0TZub2XFJiicqwj50jnjoP2Yi1Yd9UkWrNxqk7obrupUooYitO
+        hAnd91IfM8nmYnq3Ebj1jcA4WnL79DYX1l2tsF4PEhhW6kFI6kZv3CsPlkB04oo+Ne2R4/73AEKr
+        SQY91q29p6fIm/YblXB03HBsYZO7bELmDqmo/a3fi1RU87utygfwBOQFrI2DUokBD7ET5uI47Kyk
+        5r1dJQpcN3fbyILGDd82kmDH4zse3/G4weMvmBGpjqbBkve/XsyA0+1yMQFiO1eLnRDs51dqdOB7
+        xazTtF2+HexSMYH7vVwpJii1O3MaYBSz2BRx8zaRwXbOx9Yb2K7TxpE8m7PjtOfBaUMzi428G3aA
+        DNpuf/eeO2G7ROqeK13vKkHbKkGvIpCleQlonA1RCFo82faFMn80YVNrYGt6/Wlp9IGg9bnCz5Sh
+        HS7wMyem4w6HQX+7u/u2seXxnO/uy4rca0KXLrHXH9iu6iMprj8IsaSJ9ndkXs9XurCPxtda6xjk
+        Li8VkAtp3Bx1dhvC0lL4ioZjvPyIl+yto2Uwu0MNipOV0KV7dJ8dSwPtVKAQF3prEwWah6qucU5s
+        bUGyxh6tUXKXpHxlfDOhqapB4BJmrvi6my58fFttO5PpEZpMD3YHX/3Ve9+//stffnj3TUJ9tCOz
+        3Q18OsAnewOfbr9u7/69p2fAvmB6HDqM0uA6EEvUJ2/agNOmjqPRcP93/c9+ETE8DK1DczRyu2k7
+        3KMJA6BvdnyYna1RIP+UKHs3K5Jwqb0+9jP+zrSRh9vmcao0Od6PnDDlxw1UQs+c6gHGLZHV4T5Y
+        6e3C4Apyoz/7m3xj8xDrg2wmv7gWiuzELI4lI63LtmOWHbPUKdlTXcAOrmObmawhDGNymXNFP7Pf
+        XlxF6Xuw1iYmj4m9huGPpRfON+DddUb5eHLGfnj311dv2AwcGsUeCqw5f1QKJWN/qrFD7m4WlTkK
+        5zDxC3CWwu8evHiOiXruF4CfTw5xCfs3r1/rSOdBpU0xqrR9N36BNWcKrrwovD7n5egYkf0jqK1+
+        ahEc9yqXmnI6TXHgekt2RwPA8aY6QxUNelvdE5Jjf2g9X5njUafmH7N50JhQafKh8+XMXRnR5Zq+
+        R2uH7xhsx2AVUaQonsOCpH0CSApEu2Qq1ep3/HUFv87h8//odQL/LJ57YfBvsT2AIJ/R7qg2SZ2Q
+        fb9ZLtEIWChMI32ycCUogxkshWOnSxRivuZ0Jej9JELowy/wZn9mkaTYIRaUkb57rlU7unfJF9iR
+        /R+R7Ot0y5loNrxaUZzSeZtDAuh5Pj5jO+erRXTOqzLxGk7JP0M260Kb7pZRBRU+KOHayK0hEpkR
+        W4tcsAZSc80CK5Fc8vRpbjDRThsGFx9f8RDDjn5Zsv8pkZLfIuBlzA7htAvKSeyGyC7AFU4201c6
+        4gli+09YRTxMxv0AE5dmi2DpxzzUYJfTBwCYvsGftVGP3NMGLFgxwQBGPkoJPZH+8q2c2e8eV0qB
+        FCxbiCjej0psikpmQso1INneFHU5cl4SWMNGI/8IYu05W6xP3lRojEpmfOgckOzAiI3nvZ+hqbrj
+        r2fNXy+YHpRcx8FNsOTzuvPVDVZ7DsI9eYAKAu2PP37c1xDobMHjjkB2UCPLJkCjL4deuEXnnm4N
+        zEPvT+vWwPN8VQanSlx7sEa8OV/xsIc1Z8JxSuQsFee3leufeUse+p5ODx0L9mfARxnM6qr9VjZR
+        APYzAPBa/rwoHx0tMU9TQf88C1RBteaEVVWWLqNivG9b3b+0X1VCCn06MYMjA1jvuv82fu+Bv0PC
+        3hhmPVR/MiJuEFyxB5Szx+6iDQw+zBLaRTnTu0/ZwbTsIgRQijA5wADYJlbwoL/s0+PDIeZK/fpq
+        oQpLee7Stp+dWtRLzXEdogZ3RsOqy7yjkpVjbDs4MrG2B7FtDq4tDK8rwKfDwJYcqB0LPycWrq+/
+        f1CA8dKC13aEwN6AwCwF+kuixeGaE5t0qbzrxFHAVMqS+ptP8nvdu4mSHftth/2sDFZz74oLfz1W
+        Dq3mpcabWWycVHE9S18+ctbJyhUtMZR0R0ObK7hjsP62gD1BndWkqJeny6XKgdG+srABqyptIDBV
+        L/6sl0lgNVs45lityevtCMOWvG49iz5yRnBQaddGWG3tYp+HtycKW1OOQtDYp9q2u2JsXZUpLc/g
+        LdsY7favHptTI3Yhdi7N07CpOrg0fziLq7gD5yhuzO24rcubqxpTrE7a7OTITo7s5Ih6tgU58kL7
+        p7gNEy35OEmCeYg7N30ORBQgtampgU29vOn+7yas/nU16KqSvIenv+OYaYbiTA2GctWUdUL3hYF1
+        qyNKpQGKFwMehChsgr7QeMftPESR8l2rY3Qme6dM2h3RP1+ir8sXuDDaPvGcAcl/jWcjiizofESi
+        xIUdzkkcxNx7pnqmPQ2XKLUyPaueUB8RidsosiERq0iPrbKxmqmxVyJWEbcnT6SZCLqPYrpa69bV
+        c7UAs3n14P2XN3UJK7teJziQAhbik64NCkTdT18hJqXInlwEWXS0IG3BE43C1IOpD+fQKkjEB4ZX
+        6jIkrHbb9VakS3n5EZ7CiYOVF9+Jkr3gdvtAS8me9KcLD8GJly49ldoFlJ1moTQBNC0iJADDp1uY
+        nMY+gJh3ldbPLItRv02zo9Pc2lWWnsIwbvEzEv8DyiLlDDyoB/Bond12Lm4juTpaMztqfWLU2qQU
+        nrgmaOObtvZI+/uhT59VBrBKap3Pti7nY3U02x722YZTqUSQvJ7ej8DA3W45MMfzd3881/LN03Yt
+        t+6LPHUPRAqGpsPxQjK4l+p0MtUcS3MKR/7BS3LuDLqWnNRo0D19fdp4mF3wTYvSmm6M41JK83mY
+        bTuGeBoM8YLpkaxktoAv+8SyJIR2BTFlo/3fxY+f+V2vW4UFFEcWegqFH7Jp6YTqqYe3v8VYVkmx
+        U4ayOVX3w096TYd8ZAWm6k/1GPiWw7OpgPoAlyJj9+KW7jTskrixI+GnT8J1gn6iE+aAol4j+s7+
+        Rw6jZ8xLMVGrUpVKBXWNfEl6eAZ1tbpQpbtpYqfAB6ZZG5k1xL4UkbUoUVlPYq4VKiWUQh2bHdk5
+        UdEWwi/3Kfqawi6KKNuUJHQ3IFzKEcpR/OFqEG7bzrhn39PR0Hj6Ur4xIqNYqlV1wRY81VhZcGeS
+        71jlYVnlBdNjNXTDWZ9QjQBQFakhJPZ/l3lwX/fF18Bey6D3aRyyn4CWeZKIi9oSFiTJhvtsege2
+        FKW/qXoM6/XS9V4hiVkncsacvQMCoAUbtc7pb3GpXJBhm0YDBUn7ZBse+4B0cB3whHCkyZP7bePz
+        Y5UvKO7ru/GWG05H/aY8+7p3muL98Lmao73Sehd4fBgGHCV8tomD1G4A1kePJGfZgkdd2arGK/nA
+        U1hwsVmMlOpNo00qT3tmHFZisB037bjJhZvqFKDIF9iK/qtnv4aYgOQ/a0jAzoCdYgGUfk32Dhf3
+        OAtVJlIgAqBoWtKFp1E4exf7dO/znc4OjR7YjqLdKbot/W4pFFFBwKYNR8TYw4Sj9o4WXB97DWFs
+        kUSPiIIqnAm97wehoGHooYMZIVbXwYpoL71UyU+XlRUO1vuAL/0TL/ncaYUPotXKe5Vw7EHPGhRu
+        Dguh22TE8AKWa+wnYddxtMLlT3gWaMX7s695Cn/5Mq6VLKLN0hcHXqZCDN8uwKZYx9E/YQ6h7/8U
+        yLc8/JO37zTYXxdeihfJSLUgRwTCn7CvPpqj3cwz9ZJgpr0q33pT+EItk/7kerNc2mpe1N+Ccxjh
+        taTq3BHYkXcyuJ0tjaw2UkAfC1aKJoXPcSXVGmICAnQpjjMVCMsKy8tJwkuSaBYQ+dwG6UKfQ8sg
+        t3zGa7siK0PxJuC3lwPcuyQoj3T+4cnx6adfjo9+RewPz07G8Of51U8fjw8Y9qaPoYI4Sbx9wo9r
+        KdT2GcChpOBP680UrJ/21PmeBEBSGooVafPzprG2IqJtmiVXuboY2CjptzPScztYqLOKzWBhCVXE
+        Zms2fWdi09f0aGuifLa5faC16ODYiCms9mt6bGnygGSFsCWF60I3sqEAFn9oOf3s2+wAwHc768Gg
+        jns60MCOQX96MD74ZgVyOXglVmYvl/b5yplb1HswS3RYA+aA5gtWNkmBtRFW4cyG24hFo07jFdsI
+        Ypyyb/a+gB6MCIxgNRZcWloz+kK1uTTuFtQIVp8cMfCsVJkx+JZDBpYJ004jPsKWMAIgtgB3YcFO
+        VK8pGBamPMTz3t8G1+rlFAB+16BrfUPJFi41waMhn/kYpZD+cBOWP5T7a60VMwpKJlJwfEZj1KHS
+        20MpW+xvCTs2Sb10k7CDhRfOecWXV6FfC0ls2Km33WzD+zjqAxNCNhUu+5vXr0cMGiH5RrdoHyfM
+        qD/c6zTQn9ueBorQjPmpm2l8EC03KzoMhKUEUfYkUZxiPQY5BbWUTNEkw4vxVsHyDuWE/nQewOLS
+        w9aUem4Es6osxysR+RK9k4qxvSY05NtuhDbwuSvrmaud97vzfkvLLB53WeH/hy2Z+ArMJi+eLUZs
+        IqypaabNUV6x317+9nLEwH5bUxzRj2YbnARPaTsgFWU7+6BSl2BYY8iLDB5hPqNWeJX4n/czK3j/
+        5s3+fBMAUvui81eG7es2ejD+bqU+6manXZPBCGSNLn12hU6S8RwZU7oxbYj7a2+Z8JYYgxBV3mWv
+        WIC0k5Q+QispmYHNgasZoQeg/eWbPFpmxPHk4Oj08Pj0g06+h0fZ09YMOK7sHaPRxZfdSH8XVXka
+        UZUmx3xLWzcDR0ky5GT65USz+GVI8IU2Cs1UbwoElIz6yl3O8pctQizCFqexgtQn+5wqdT30rhBD
+        t970aR5kg7E22HSSzfx2aFViY1BQU3qyoB57crLb1lJtCrJwIQX/D5KAvFUqoiprx/4eC1IVEloR
+        emRmiSgMUVs0RbP4MdPaIw5sZqGGJqosxiQqRVrpQ3eJpgIIGM/UTLQtUiEmVwSW0N6Db243UJSa
+        qfuklKZMcEkn9jxwR/FVne2tCa+dVHruUunWSVHe1ihK8527CPrVU8EQYV6RHybC1oXtnd2mSj7i
+        3abKblPFOuLdpspuU2W3qaLR1MvdpspuU2W3qbLbVNltquw2VXabKrtNFc39rvTW0UAMeW4o5N4n
+        GQU/ku+u32Po5NMrqIUmT3uv5kU2lGxOtIM7dDBKe1A+25P7Ezq72OMPEtqo6FdUhkZlg/3f6Uf1
+        Za3m2Z8yV17wVUS3yImDXrqWNrCwX9dKjYxHbW84za4dnaIyQFx8o0nve1gtIbxWSLY4BdAZXfXr
+        q2XGLVehqiHtFRfCIjOGuHm0MMpubFjAsKRbirnljaxiZpk3s0oli+gxvPL6j32/K3c8Y9KzUFrt
+        NbtjY/W/6q3q7tatbPZkyNrM9m8k6oLX2ZWktdMAZbL6iFY2lecQUGSY05GoSwG8diTdO4hnM+5Y
+        MZCXq9780T+KICrNOiYJrzIsl31gRuYq+qo02/4wisoqLRr5nj8Fzh8ESm6j9gVXMHZNU6DB4NXF
+        VmHXrFFuGXtkDmZr8fs2GrlyXy0TaCUpuhNlO1H2MIZP0d928Lhb2Eem372Tk/clJ19o/2QZeYso
+        jYaKBwhg7uEA8f1+utispqGxEdQtHiDg7RyeOr4fjMOqvQejeEgTsWhVRIaglFofIjtTTODKucI7
+        Isn6r5PfuBt6jjP4qCV4WViWCHXtaC9KUl07movOxGokK1cFcQStGhuR7XKXd1St9V9p8tQS9WPg
+        h2oyLiamNtGxmaE6CCFfNcYiy2S8o09azmdLn4a5+YLp5eVueBxcyxqDB5Ffd0n5nIc8rs+7LkEb
+        ZY3UtlkVhZea7peauqfOfpBNWchv2dSbfd6smd4Bm2EP9pySXfG6LVTjDMIb8MAasvbL1KM1a08/
+        lsbuFHScNaZFgqHFGK7Z0dLD01JDAaQyFTkVeS0LQjvRONZ7VQQjs/GImByoxywMu6v5+iA1X38p
+        kUKht/sp//oC/vv64n8AlMkZ4IBzAgA=
+    headers:
+      Age: ['202']
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['public, max-age=300, must-revalidate, no-transform']
+      Content-Encoding: [gzip]
+      Content-Length: ['16952']
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Sun, 22 Jan 2017 22:10:01 GMT']
+      ETag: ['"tbys6C40o18GZwyMen5GMkdK-3s/5JjoP3Vg5udAY4zd2Hcsn9dKASM"']
+      Expires: ['Sun, 22 Jan 2017 22:15:01 GMT']
+      Server: [GSE]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: '{"primaryEmail": "kensinton@djangogirls.org", "name": {"familyName": "Kensington",
+      "givenName": "Django Girls", "fullName": "Django Girls Kensington #2"}, "changePasswordAtNextLogin":
+      true, "password": "aCgaExRPca"}'
+    headers:
+      accept: [application/json]
+      accept-encoding: ['gzip, deflate']
+      authorization: [Bearer ya29.Gn7bA3X5DrXmj0pcjquuuGftJMZZdiRCX4oimlRn2JBWBmuBKzQYx_sFAvqcxLhWHMjDE2cle3Kmv9xjo69SuQFc8LvUn8uk_iQ89xqXPpB2dCwrFoqCtDIUxA8A35V23cj_ZSaHgA1wXasLJhOYr7i9a_QlFOJZ07-57EpS3Eo]
+      content-length: ['215']
+      content-type: [application/json]
+      user-agent: [google-api-python-client/1.6.0 (gzip)]
+    method: POST
+    uri: https://www.googleapis.com/admin/directory/v1/users?alt=json
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAAG2RUU/CMBSF3/crmvIqsJbhgCcJEIIoIQFRCIkp7DIqXUvaThmE/+7WSXzQ13u+
+        ntt7zsVD+MBlhDsIsyjhshJxDVurdFZJDWh8lwPcyYTctwmlIWm3W5QErVbQajedDpbFBbHGotcU
+        9LTan+OMnJej1+6xz7dQ3U3eu/Vo2FwG2SJ8bATKX8zFZvy2W/QG1M7MGjufo+YJ09kgYVwUfgeQ
+        hkur5EP0wWSsYq6FqSkdO1qyBHLq4iGEY/4JclIOcN/BaFjQBYnwjiVcZDd97Gzj3PdHTYX47y36
+        BVGFYg9dXRimW+SUwzsmDJSjPgiImYXoj7bVwCxXcs7LBdQnYdUnVUrnlHZIo0MbNd/3V+6k7T7f
+        DlNmzJfSUddO4GSf8rMLR6vT0jA1ViWgR66Unk8OWQhBWUQezYvkdsrsvhDrZXvmOc9zo04zsOnx
+        9jfv6n0DDA15M/wBAAA=
+    headers:
+      Alt-Svc: ['quic=":443"; ma=2592000; v="35,34"']
+      Cache-Control: ['no-cache, no-store, max-age=0, must-revalidate']
+      Content-Encoding: [gzip]
+      Content-Type: [application/json; charset=UTF-8]
+      Date: ['Sun, 22 Jan 2017 22:13:25 GMT']
+      ETag: ['"lC5l2xZhzgy1zYIWApDice-fN_A/dG5Y4yV7J34o0VTlbKXfVCE2tSs"']
+      Expires: ['Mon, 01 Jan 1990 00:00:00 GMT']
+      Pragma: [no-cache]
+      Server: [GSE]
+      Vary: [Origin, X-Origin]
+      X-Content-Type-Options: [nosniff]
+      X-Frame-Options: [SAMEORIGIN]
+      X-XSS-Protection: [1; mode=block]
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.12.4]
+    method: POST
+    uri: https://slack.com/api/users.admin.invite?email=test%40test.com&set_active=True&first_name=Anna
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['53']
+      Content-Security-Policy: [referrer no-referrer;]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 22 Jan 2017 22:13:25 GMT']
+      Server: [Apache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains; preload]
+      Vary: [Accept-Encoding]
+      Via: [1.1 409a64e6cd31cf9171c6b6182a1b31e3.cloudfront.net (CloudFront)]
+      X-Accepted-OAuth-Scopes: [client]
+      X-Amz-Cf-Id: [Y4hzViG3MGu7Sq2BNJ4LSZMQcxufV_xhZXitQl02WUpvcVv2jc1q7g==]
+      X-Cache: [Miss from cloudfront]
+      X-Content-Type-Options: [nosniff]
+      X-Slack-Backend: [h]
+      X-Slack-Req-Id: [b7341b92-e453-47cf-9894-5b661e1f49cc]
+      X-XSS-Protection: ['0']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.12.4]
+    method: POST
+    uri: https://slack.com/api/users.admin.invite?email=anna%40test.com&set_active=True&first_name=Anna
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['53']
+      Content-Security-Policy: [referrer no-referrer;]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 22 Jan 2017 22:13:26 GMT']
+      Server: [Apache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains; preload]
+      Vary: [Accept-Encoding]
+      Via: [1.1 a166bdfa3ca81b2a53bf15ca38c5a418.cloudfront.net (CloudFront)]
+      X-Accepted-OAuth-Scopes: [client]
+      X-Amz-Cf-Id: [gNcGs5fpiAJEpm11F2Y2sAxbIegZHamzdS7Ecd3yF7o6NXmKTOMgTQ==]
+      X-Cache: [Miss from cloudfront]
+      X-Content-Type-Options: [nosniff]
+      X-Slack-Backend: [h]
+      X-Slack-Req-Id: [e9ceb379-f5e4-497d-8c9d-ef81b18a7839]
+      X-XSS-Protection: ['0']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [python-requests/2.12.4]
+    method: POST
+    uri: https://slack.com/api/users.admin.invite?email=robert%40test.com&set_active=True&first_name=Robert
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
+    headers:
+      Access-Control-Allow-Origin: ['*']
+      Connection: [keep-alive]
+      Content-Encoding: [gzip]
+      Content-Length: ['53']
+      Content-Security-Policy: [referrer no-referrer;]
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Sun, 22 Jan 2017 22:13:26 GMT']
+      Server: [Apache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains; preload]
+      Vary: [Accept-Encoding]
+      Via: [1.1 1feb77032a34552dda45f3c78a5c3dd7.cloudfront.net (CloudFront)]
+      X-Accepted-OAuth-Scopes: [client]
+      X-Amz-Cf-Id: [mgYr9Bq1ZH_LD-S5x4PWMAOCGRBESmgCoGLcTwRudmBLmyBmSoDEkg==]
+      X-Cache: [Miss from cloudfront]
+      X-Content-Type-Options: [nosniff]
+      X-Slack-Backend: [h]
+      X-Slack-Req-Id: [c284a77e-daa6-4908-a547-85105e722d19]
+      X-XSS-Protection: ['0']
+    status: {code: 200, message: OK}
+version: 1


### PR DESCRIPTION
If `EventApplication` has `previous_event` set we clone the event content.

- I copy sponors & coaches from old event (`copy_event` command had it broken)
- I don't manage organizers yet - it will be done in separate ticket
- I placed the code in `core/deploy_event.py` - in a separate ticket we will move `create_event` and `add_organizer` as well
