### PR TITLE
Fix: users now have a password

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -71,6 +71,7 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
     def generate_password(self):
         password = User.objects.make_random_password()
         self.set_password(password)
+        self.save()
         return password
 
     def add_to_organizers_group(self):


### PR DESCRIPTION
New organizers didn't have a password: it was generated but not saved.