### PR TITLE
organizers can add stats

### DIFF
--- a/core/admin.py
+++ b/core/admin.py
@@ -60,6 +60,7 @@ class EventAdmin(admin.ModelAdmin):
             # Don't let change objects for events that already happened
             if not obj.is_upcoming():
                 fields.update({x.name for x in self.model._meta.fields})
+                fields.difference_update({'attendees_count', 'applicants_count'})
         return fields
 
     def get_fieldsets(self, request, obj=None):


### PR DESCRIPTION
Since the event is auto-archived when it's over, organizers were unable to add stats. It's now fixed ;)