### PR TITLE
Sending check-in emails summary to hello

### DIFF
--- a/core/management/commands/handle_emails.py
+++ b/core/management/commands/handle_emails.py
@@ -118,6 +118,15 @@ def send_offer_help_emails():
         email_type="offer help email",
     )
 
+    if events:
+        send_mail(
+            subject="Check-in email summary",
+            message="Hi there!\n Check-in emails were automatically send to events with no live website "
+                    "or application form open. If the organizers don't contact you back soon, you should "
+                    "remove those events from the events page:\n" + "\n".join(e.city for e in events),
+            from_email=settings.DEFAULT_FROM_EMAIL,
+            recipient_list=["hello@djangogirls.org"]
+        )
 
 @click.command()
 def command():


### PR DESCRIPTION
We now send automatic emails to events that are late. To be sure to remove events that don't answer us and won't happen, we need to have a list of emails sent.