### PR TITLE
Add core.gmail_accounts to codecov ignores

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,3 +14,4 @@ coverage:
     - tests/*
     - migrations/*
     - djangogirls/wsgi.py
+    - core/gmail_accounts.py


### PR DESCRIPTION
Since this file is not tested for pull requests, codecov falsely reports a
decreased coverage for every single pull request. Ignoring this file restores
meaningful reports in pull requests.