### PR TITLE
Revert "Add core.gmail_accounts to codecov ignores"

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -14,4 +14,3 @@ coverage:
     - tests/*
     - migrations/*
     - djangogirls/wsgi.py
-    - core/gmail_accounts.py


### PR DESCRIPTION
Changes didn't do what we expected. Revert for now :(