### PR TITLE
Skip main organizer's name in confirmation email.

### DIFF
--- a/organize/emails.py
+++ b/organize/emails.py
@@ -11,7 +11,6 @@ def send_application_confirmation(event_application):
         'emails/organize/application_confirmation.html',
         {
             'city': event_application.city,
-            'main_organizer_name': event_application.get_main_organizer_name()
         })
     send_email(content, subject, event_application.get_organizers_emails())
 

--- a/templates/emails/organize/application_confirmation.html
+++ b/templates/emails/organize/application_confirmation.html
@@ -1,4 +1,4 @@
-<p>Hello {{ main_organizer_name }},</p>
+<p>Hello,</p>
 
 <p>
 Thank you for submitting the application to organize Django Girls in {{ city }}! Yay!


### PR DESCRIPTION
* We are sending confirmation e-mail to all organizers, so we should
skip first & last name of main organizers so it is not confusing for
other organizers.