### PR TITLE
Copy event script

### DIFF
--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -50,14 +50,13 @@ def command():
     # Remove #{no} from name:
     name = event.name.split('#')[0].strip()
     number = int(number)
-    event_id = event.id
 
     # Change the name of previous event to {name} #{number-1}
     event.name = "{} #{}".format(name, number-1)
     event.save()
 
     # Copy event with a name {name} #{number}, new date and empty stats
-    new_event = event
+    new_event = Event.objects.get(id=event.id)
     new_event.pk = None
     new_event.name = "{} #{}".format(name, number)
     new_event.date = date
@@ -66,8 +65,9 @@ def command():
     new_event.applicants_count = None
     new_event.save()
 
-    # Copy or change organizers
+    # Edit team and previous email or keep them
     if new_team:
+        # Create a new team with a new main organizer
         main_organizer = get_main_organizer()
         team = get_team(main_organizer)
         members = create_users(team, new_event)
@@ -79,8 +79,6 @@ def command():
     event.page_title = "{} #{}".format(name, number-1)
     event.page_url = "{}{}".format(event.page_url, number-1)
     event.save()
-
-    event = Event.objects.get(id=event_id)
 
     # Copy all EventPageContent objects
     for obj in event.content.all():
@@ -100,7 +98,7 @@ def command():
         new_obj.save()
 
     # Brag on Slack
-    brag_on_slack_bang(new_event.city, new_event.country, [member for member in new_event.team.all()])
+    brag_on_slack_bang(new_event.city, new_event.country, new_event.team.all())
 
     click.echo(click.style("Website is ready here: http://djangogirls.org/{0}".format(new_event.page_url),
     bold=True, fg="green"))

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -72,6 +72,8 @@ def command():
         team = get_team(main_organizer)
         members = create_users(team, new_event)
         new_event.main_organizer = members[0]
+        # Edit previous email account
+        event.email = "{}{:02d}{}@djangogirls.org".format(event.email.split('@')[0], event.date.month, event.date.year)
     else:
         new_event.team = organizers
 

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -5,7 +5,7 @@ import djclick as click
 
 from core.command_helpers import gather_event_date_from_prompt
 from core.models import Event
-from core.utils import get_main_organizer, get_team, create_users
+from core.utils import get_main_organizer, get_team, create_users, brag_on_slack_bang
 
 
 def get_event(id_str):
@@ -98,6 +98,9 @@ def command():
         new_obj.pk = None
         new_obj.event = new_event
         new_obj.save()
+
+    # Brag on Slack
+    brag_on_slack_bang(new_event.city, new_event.country, [member for member in new_event.team.all()])
 
     click.echo(click.style("Website is ready here: http://djangogirls.org/{0}".format(new_event.page_url),
     bold=True, fg="green"))

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -5,7 +5,7 @@ import djclick as click
 
 from core.command_helpers import gather_event_date_from_prompt
 from core.models import Event
-from core.utils import get_main_organizer, get_team, create_users, brag_on_slack_bang
+from core.management_utils import get_main_organizer, get_team, create_users, brag_on_slack_bang
 
 
 def get_event(id_str):

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -5,7 +5,7 @@ import djclick as click
 
 from core.command_helpers import gather_event_date_from_prompt
 from core.models import Event
-from core.management.commands.new_event import get_main_organizer, get_team, create_users
+from core.utils import get_main_organizer, get_team, create_users
 
 
 def get_event(id_str):
@@ -19,25 +19,21 @@ def gather_information():
     click.echo("Hello there sunshine! We're gonna copy an event website now.")
 
     event = get_event(
-        click.prompt(
-            "First, give me the ID of the Event object we're gonna copy. "
-            "If there is more than one event in this city already, give me "
-            "ID of the latest one"
-        )
+        click.prompt(click.style("First, give me the latest ID of the Event "
+        "object you want to copy", bold=True, fg='yellow'))
     )
 
     while not event:
         event = get_event(click.prompt("Wrong ID! Try again"))
 
-    number = click.prompt(
-        "What is the number of the event in this city? "
-        "If this is a second event, write 2. If third, then 3. You got it"
+    number = click.prompt(click.style("What is the number of the event in this city? "
+        "If this is a second event, write 2. If third, then 3. You got it", bold=True, fg='yellow')
     )
 
     date = gather_event_date_from_prompt()
 
-    new_team = click.prompt(
-        "Do you need to change the whole team? [y, N]", default=False
+    new_team = click.confirm(click.style(
+        "Do you need to change the whole team?", bold=True, fg='yellow'), default=False
     )
 
     return (event, number, date, new_team)
@@ -50,9 +46,6 @@ def command():
     # Gather data
     (event, number, date, new_team) = gather_information()
     organizers = event.team.all()
-
-    # Print stuff
-    click.echo("OK! That's it. Now I'll copy your event.")
 
     # Remove #{no} from name:
     name = event.name.split('#')[0].strip()
@@ -74,7 +67,7 @@ def command():
     new_event.save()
 
     # Copy or change organizers
-    if new_team == "y":
+    if new_team:
         main_organizer = get_main_organizer()
         team = get_team(main_organizer)
         members = create_users(team, new_event)
@@ -106,5 +99,6 @@ def command():
         new_obj.event = new_event
         new_obj.save()
 
-    click.echo("Website is ready here: http://djangogirls.org/{0}".format(new_event.page_url))
+    click.echo(click.style("Website is ready here: http://djangogirls.org/{0}".format(new_event.page_url),
+    bold=True, fg="green"))
     click.echo("Congrats on yet another event!")

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -73,7 +73,7 @@ def command():
     new_event.applicants_count = None
     new_event.save()
 
-    # Copy or change the organizers
+    # Copy or change organizers
     if new_team == "y":
         main_organizer = get_main_organizer()
         team = get_team(main_organizer)

--- a/core/management/commands/new_event.py
+++ b/core/management/commands/new_event.py
@@ -7,11 +7,11 @@ from django.template.loader import render_to_string
 from slacker import Error as SlackerError
 
 from ...command_helpers import gather_event_date_from_prompt
-from ...forms import AddOrganizerForm, EventForm
+from ...forms import EventForm
 from ...models import Event
 from pictures.models import StockPicture
 from ...slack_client import slack
-from ...utils import get_coordinates_for_city
+from ...utils import get_coordinates_for_city, get_main_organizer, get_team, create_users
 
 DELIMITER = "\n-------------------------------------------------------------\n"
 
@@ -45,63 +45,6 @@ def get_basic_info():
         city, country, date))
 
     return (city, country, date, url, event_mail)
-
-
-def get_main_organizer():
-    """
-        We're asking user for name and address of main organizer, and return
-        a list of dictionary.
-    """
-    team = []
-    click.echo("Now let's talk about the team. First the main organizer:")
-    main_name = click.prompt(click.style(
-        "First and last name", bold=True, fg='yellow'))
-    main_email = click.prompt(click.style(
-        "E-mail address", bold=True, fg='yellow'))
-
-    team.append({'name': main_name, 'email': main_email})
-
-    click.echo(u"All right, the main organizer is {0} ({1})".format(
-        main_name, main_email))
-
-    return team
-
-
-def get_team(team):
-    """
-        We're asking user for names and address of the rest of the team,
-        and append that to a list we got from get_main_organizer
-    """
-    add_team = click.confirm(click.style(
-        "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
-    i = 1
-    while add_team:
-        i += 1
-        name = click.prompt(click.style(
-            "First and last name of #{0} member".format(i), bold=True, fg='yellow'))
-        email = click.prompt(click.style(
-            "E-mail address of #{0} member".format(i), bold=True, fg='yellow'))
-        if len(name) > 0:
-            team.append({'name': name, 'email': email})
-            click.echo("All right, the #{0} team member of Django Girls is {1} ({2})".format(
-                i, name, email))
-        add_team = click.confirm(click.style(
-            "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
-
-    return team
-
-
-def create_users(team, event):
-    """
-        Create or get User objects based on team list
-    """
-    members = []
-    for member in team:
-        member['event'] = event.pk
-        form = AddOrganizerForm(member)
-        user = form.save()
-        members.append(user)
-    return members
 
 
 def brag_on_slack_bang(city, country, team):

--- a/core/management/commands/new_event.py
+++ b/core/management/commands/new_event.py
@@ -9,7 +9,8 @@ from ...command_helpers import gather_event_date_from_prompt
 from ...forms import EventForm
 from ...models import Event
 from pictures.models import StockPicture
-from ...utils import get_coordinates_for_city, get_main_organizer, get_team, create_users, brag_on_slack_bang
+from ...utils import get_coordinates_for_city
+from core.management_utils import get_main_organizer, get_team, create_users, brag_on_slack_bang
 
 DELIMITER = "\n-------------------------------------------------------------\n"
 

--- a/core/management/commands/new_event.py
+++ b/core/management/commands/new_event.py
@@ -4,14 +4,12 @@ from __future__ import unicode_literals
 import djclick as click
 from django.conf import settings
 from django.template.loader import render_to_string
-from slacker import Error as SlackerError
 
 from ...command_helpers import gather_event_date_from_prompt
 from ...forms import EventForm
 from ...models import Event
 from pictures.models import StockPicture
-from ...slack_client import slack
-from ...utils import get_coordinates_for_city, get_main_organizer, get_team, create_users
+from ...utils import get_coordinates_for_city, get_main_organizer, get_team, create_users, brag_on_slack_bang
 
 DELIMITER = "\n-------------------------------------------------------------\n"
 
@@ -45,22 +43,6 @@ def get_basic_info():
         city, country, date))
 
     return (city, country, date, url, event_mail)
-
-
-def brag_on_slack_bang(city, country, team):
-    """
-        This is posting a message about Django Girls new event to #general channel on Slack!
-    """
-    text = ':django_pony: :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls {city}, {country}. Congrats {team}!'.format(
-        city=city, country=country, team=', '.join(
-            ['{} {}'.format(x.first_name, x.last_name) for x in team])
-    )
-    slack.chat.post_message(
-        channel='#general',
-        text=text,
-        username='Django Girls',
-        icon_emoji=':django_heart:'
-    )
 
 
 @click.command()

--- a/core/management_utils.py
+++ b/core/management_utils.py
@@ -1,0 +1,79 @@
+from slacker import Error as SlackerError
+
+import djclick as click
+
+from .forms import AddOrganizerForm
+from .models import Event
+from .slack_client import slack
+
+# Get organizers info functions used in 'new_event' and 'copy_event' management commands.
+
+def get_main_organizer():
+    """
+        We're asking user for name and address of main organizer, and return
+        a list of dictionary.
+    """
+    team = []
+    click.echo("Let's talk about the team. First the main organizer:")
+    main_name = click.prompt(click.style(
+        "First and last name", bold=True, fg='yellow'))
+    main_email = click.prompt(click.style(
+        "E-mail address", bold=True, fg='yellow'))
+
+    team.append({'name': main_name, 'email': main_email})
+
+    click.echo(u"All right, the main organizer is {0} ({1})".format(
+        main_name, main_email))
+
+    return team
+
+def get_team(team):
+    """
+        We're asking user for names and address of the rest of the team,
+        and append that to a list we got from get_main_organizer
+    """
+    add_team = click.confirm(click.style(
+        "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
+    i = 1
+    while add_team:
+        i += 1
+        name = click.prompt(click.style(
+            "First and last name of #{0} member".format(i), bold=True, fg='yellow'))
+        email = click.prompt(click.style(
+            "E-mail address of #{0} member".format(i), bold=True, fg='yellow'))
+        if len(name) > 0:
+            team.append({'name': name, 'email': email})
+            click.echo("All right, the #{0} team member of Django Girls is {1} ({2})".format(
+                i, name, email))
+        add_team = click.confirm(click.style(
+            "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
+
+    return team
+
+
+def create_users(team, event):
+    """
+        Create or get User objects based on team list
+    """
+    members = []
+    for member in team:
+        member['event'] = event.pk
+        form = AddOrganizerForm(member)
+        user = form.save()
+        members.append(user)
+    return members
+
+def brag_on_slack_bang(city, country, team):
+    """
+        This is posting a message about Django Girls new event to #general channel on Slack!
+    """
+    text = ':django_pony: :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls {city}, {country}. Congrats {team}!'.format(
+        city=city, country=country, team=', '.join(
+            ['{} {}'.format(x.first_name, x.last_name) for x in team])
+    )
+    slack.chat.post_message(
+        channel='#general',
+        text=text,
+        username='Django Girls',
+        icon_emoji=':django_heart:'
+    )

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,11 +4,9 @@ import requests
 from django.utils import timezone
 from django_date_extensions.fields import ApproximateDate
 import djclick as click
-from slacker import Error as SlackerError
 
 from .models import Event
-from .forms import AddOrganizerForm
-from .slack_client import slack
+
 
 NOMINATIM_URL = 'http://nominatim.openstreetmap.org/search'
 
@@ -79,75 +77,3 @@ def next_deadline():
         return next_sunday(next_sunday(today))
     else:
         return next_sunday(today)
-
-# Get organizers info functions used in 'new_event' and 'copy_event' management commands.
-
-def get_main_organizer():
-    """
-        We're asking user for name and address of main organizer, and return
-        a list of dictionary.
-    """
-    team = []
-    click.echo("Let's talk about the team. First the main organizer:")
-    main_name = click.prompt(click.style(
-        "First and last name", bold=True, fg='yellow'))
-    main_email = click.prompt(click.style(
-        "E-mail address", bold=True, fg='yellow'))
-
-    team.append({'name': main_name, 'email': main_email})
-
-    click.echo(u"All right, the main organizer is {0} ({1})".format(
-        main_name, main_email))
-
-    return team
-
-def get_team(team):
-    """
-        We're asking user for names and address of the rest of the team,
-        and append that to a list we got from get_main_organizer
-    """
-    add_team = click.confirm(click.style(
-        "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
-    i = 1
-    while add_team:
-        i += 1
-        name = click.prompt(click.style(
-            "First and last name of #{0} member".format(i), bold=True, fg='yellow'))
-        email = click.prompt(click.style(
-            "E-mail address of #{0} member".format(i), bold=True, fg='yellow'))
-        if len(name) > 0:
-            team.append({'name': name, 'email': email})
-            click.echo("All right, the #{0} team member of Django Girls is {1} ({2})".format(
-                i, name, email))
-        add_team = click.confirm(click.style(
-            "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
-
-    return team
-
-
-def create_users(team, event):
-    """
-        Create or get User objects based on team list
-    """
-    members = []
-    for member in team:
-        member['event'] = event.pk
-        form = AddOrganizerForm(member)
-        user = form.save()
-        members.append(user)
-    return members
-
-def brag_on_slack_bang(city, country, team):
-    """
-        This is posting a message about Django Girls new event to #general channel on Slack!
-    """
-    text = ':django_pony: :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls {city}, {country}. Congrats {team}!'.format(
-        city=city, country=country, team=', '.join(
-            ['{} {}'.format(x.first_name, x.last_name) for x in team])
-    )
-    slack.chat.post_message(
-        channel='#general',
-        text=text,
-        username='Django Girls',
-        icon_emoji=':django_heart:'
-    )

--- a/core/utils.py
+++ b/core/utils.py
@@ -4,9 +4,11 @@ import requests
 from django.utils import timezone
 from django_date_extensions.fields import ApproximateDate
 import djclick as click
+from slacker import Error as SlackerError
 
 from .models import Event
 from .forms import AddOrganizerForm
+from .slack_client import slack
 
 NOMINATIM_URL = 'http://nominatim.openstreetmap.org/search'
 
@@ -134,3 +136,18 @@ def create_users(team, event):
         user = form.save()
         members.append(user)
     return members
+
+def brag_on_slack_bang(city, country, team):
+    """
+        This is posting a message about Django Girls new event to #general channel on Slack!
+    """
+    text = ':django_pony: :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls {city}, {country}. Congrats {team}!'.format(
+        city=city, country=country, team=', '.join(
+            ['{} {}'.format(x.first_name, x.last_name) for x in team])
+    )
+    slack.chat.post_message(
+        channel='#general',
+        text=text,
+        username='Django Girls',
+        icon_emoji=':django_heart:'
+    )

--- a/core/utils.py
+++ b/core/utils.py
@@ -3,8 +3,10 @@ from datetime import date, datetime, timedelta
 import requests
 from django.utils import timezone
 from django_date_extensions.fields import ApproximateDate
+import djclick as click
 
 from .models import Event
+from .forms import AddOrganizerForm
 
 NOMINATIM_URL = 'http://nominatim.openstreetmap.org/search'
 
@@ -75,3 +77,60 @@ def next_deadline():
         return next_sunday(next_sunday(today))
     else:
         return next_sunday(today)
+
+# Get organizers info functions used in 'new_event' and 'copy_event' management commands.
+
+def get_main_organizer():
+    """
+        We're asking user for name and address of main organizer, and return
+        a list of dictionary.
+    """
+    team = []
+    click.echo("Let's talk about the team. First the main organizer:")
+    main_name = click.prompt(click.style(
+        "First and last name", bold=True, fg='yellow'))
+    main_email = click.prompt(click.style(
+        "E-mail address", bold=True, fg='yellow'))
+
+    team.append({'name': main_name, 'email': main_email})
+
+    click.echo(u"All right, the main organizer is {0} ({1})".format(
+        main_name, main_email))
+
+    return team
+
+def get_team(team):
+    """
+        We're asking user for names and address of the rest of the team,
+        and append that to a list we got from get_main_organizer
+    """
+    add_team = click.confirm(click.style(
+        "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
+    i = 1
+    while add_team:
+        i += 1
+        name = click.prompt(click.style(
+            "First and last name of #{0} member".format(i), bold=True, fg='yellow'))
+        email = click.prompt(click.style(
+            "E-mail address of #{0} member".format(i), bold=True, fg='yellow'))
+        if len(name) > 0:
+            team.append({'name': name, 'email': email})
+            click.echo("All right, the #{0} team member of Django Girls is {1} ({2})".format(
+                i, name, email))
+        add_team = click.confirm(click.style(
+            "Do you want to add additional team members?", bold=True, fg='yellow'), default=False)
+
+    return team
+
+
+def create_users(team, event):
+    """
+        Create or get User objects based on team list
+    """
+    members = []
+    for member in team:
+        member['event'] = event.pk
+        form = AddOrganizerForm(member)
+        user = form.save()
+        members.append(user)
+    return members


### PR DESCRIPTION
I've moved  "brag_on_slack_bang", "get_main_organizer", "get_team, create_users" functions to `core/utils.py`.
"Copy_event" script can now copy a previous event with a different team, brag on slack and update previous event email.
I also fixed the issue #387 ;)
I know we're working on the new deploy features but I would like to maintain this management command while I'm testing the new deploy feature.