### PR TITLE
Restrict Event and Form admin list_filters by user

### DIFF
--- a/applications/admin.py
+++ b/applications/admin.py
@@ -54,10 +54,17 @@ class FormAdmin(admin.ModelAdmin):
     get_submissions_url.short_description = "Applications"
 
 
+class FormFilter(admin.SimpleListFilter):
+    def queryset(self, request, queryset):
+        if request.user.is_superuser:
+            return queryset
+        return queryset.filter(event__team__in=[request.user])
+
+
 class QuestionAdmin(SortableModelAdmin):
     list_display = ('form', 'title', 'question_type', 'is_required', 'order')
     sortable = 'order'
-    list_filter = ('form',)
+    list_filter = (FormFilter,)
 
     def get_queryset(self, request):
         qs = super(QuestionAdmin, self).get_queryset(request)

--- a/core/admin.py
+++ b/core/admin.py
@@ -262,9 +262,16 @@ class EventPageContentForm(ModelForm):
         )
 
 
+class EventFilter(admin.SimpleListFilter):
+    def queryset(self, request, queryset):
+        if request.user.is_superuser:
+            return queryset
+        return queryset.filter(team__in=[request.user])
+
+
 class EventPageContentAdmin(SortableModelAdmin):
     list_display = ('name', 'event', 'position', 'is_public')
-    list_filter = ('event', 'is_public')
+    list_filter = (EventFilter, 'is_public')
     search_fields = ('name', 'event__page_title', 'content', 'event__city',
                      'event__country', 'event__name')
     form = EventPageContentForm
@@ -300,7 +307,7 @@ class EventPageContentAdmin(SortableModelAdmin):
 
 class EventPageMenuAdmin(SortableModelAdmin):
     list_display = ('title', 'event', 'url', 'position')
-    list_filter = ('event',)
+    list_filter = (EventFilter,)
     sortable = 'position'
 
     def get_queryset(self, request):


### PR DESCRIPTION
If a user is not a superuser, only allow filtering by forms or events for any team they are a member of.