### PR TITLE
h4 tag mistakenly closed by h3 tag

### DIFF
--- a/templates/applications/compose_email.html
+++ b/templates/applications/compose_email.html
@@ -33,7 +33,7 @@
       </div>
       <div class="col-md-5">
           {% if not email.sent %}
-              <h4>Email preview</h3>
+              <h4>Email preview</h4>
               <div id="preview" style="white-space: pre-wrap;">{{ email.text|safe }}</div>
           {% else %}
               <p>


### PR DESCRIPTION
A simple fix for a small html mistake