### PR TITLE
Rename description block in registration templates to prevent name collision - Fix #445

### DIFF
--- a/templates/registration/base.html
+++ b/templates/registration/base.html
@@ -5,7 +5,7 @@
     <div class="row centered">
         <div class="col-md-6 col-md-offset-4">
             <h2>{% block title %}{% endblock title %}</h2>
-            <p>{% block description %}{% endblock description %}</p>
+            <p>{% block registration_message %}{% endblock registration_message %}</p>
             <form action="" method="post">
                 {% csrf_token %}
                 {% for field in form %}

--- a/templates/registration/password_reset_complete.html
+++ b/templates/registration/password_reset_complete.html
@@ -2,6 +2,6 @@
 
 {% block title %}Password Reset Complete{% endblock title %}
 
-{% block description %}
+{% block registration_message %}
 <p>&#x1F603; All done! Go ahead and get back to <a href="{% url 'admin:index' %}">being awesome now.</a> &#x1F496; Thanks for all you do!</p>
-{% endblock description %}
+{% endblock registration_message %}

--- a/templates/registration/password_reset_confirm.html
+++ b/templates/registration/password_reset_confirm.html
@@ -2,9 +2,9 @@
 
 {% block title %}Password Reset &#x23F0;{% endblock title %}
 
-{% block description %}
+{% block registration_message %}
 <p>Alright, the big event. Enter a new, super safe and super memorable (just to you!) password. &#x1F33C;</p>
-{% endblock description %}
+{% endblock registration_message %}
 
 {% block submit_button %}
 <input type="submit" value="Set my new password!" />

--- a/templates/registration/password_reset_done.html
+++ b/templates/registration/password_reset_done.html
@@ -2,6 +2,6 @@
 
 {% block title %}Check Your &#x1F4E5;{% endblock title %}
 
-{% block description %}
+{% block registration_message %}
 <p>We just sent reset instructions to your email. If you have any issues, <a href={% url 'password_reset' %}>try again</a> and if you still don't get anything, <a href="{% url 'contact:contact' %}">say hello</a>!</p>
-{% endblock description %}
+{% endblock registration_message %}

--- a/templates/registration/password_reset_form.html
+++ b/templates/registration/password_reset_form.html
@@ -2,9 +2,9 @@
 
 {% block title %}Forget your password?{% endblock title %}
 
-{% block description %}
+{% block registration_message %}
 <p>Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions. &#x1F64B; &#x1F370;</p>
-{% endblock description %}
+{% endblock registration_message %}
 
 {% block submit_button %}
 <input type="submit" value="Reset password link time!" />


### PR DESCRIPTION
Fixes #445.

This is just a search and replace following @lightstrike's suggestion. I tried it on all the password reset steps, all seems well.