### PR TITLE
Change website contents min-width so CodeMirror does not overflow

### DIFF
--- a/static/source/css/admin.styl
+++ b/static/source/css/admin.styl
@@ -1,3 +1,7 @@
+// Make sure there is enough space for the fixed-width CodeMirror editor.
+.core-eventpagecontent
+    min-width: 1351px
+
 .save-box
     a.btn
         align-items: flex-start


### PR DESCRIPTION
Fixes #434. I went for the simpler solution – make the page scroll horizontally – because it's the simplest behaviour, and there is already a 960px min-width on the body for other pages so it's not a big difference.
