### PR TITLE
Added crowdfunding donors page

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -21,7 +21,7 @@ urlpatterns = [
     url(r'^privacy-cookies/$', views.privacy_cookies, name='privacy-cookies'),
     url(r'^workshop-box/$', views.workshop_box, name='workshop-box'),
     url(r'^coc/(?:(?P<lang>[a-z-]+)/)?$', views.coc, name='coc'),
-
+    url(r'^crowdfunding-donors/$', views.crowdfunding_donors, name='crowdfunding-donors'),
     url(r'^(?P<city>[\w\d/]+)/$', views.event, name='event'),
     url(r'^$', views.index, name='index'),
 ]

--- a/donors.json
+++ b/donors.json
@@ -1,0 +1,1186 @@
+[
+  {
+  "pk": 1,
+  "fields": {
+    "name": "Danielle Topping",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 2,
+  "fields": {
+    "name": "Annette McCullough",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 3,
+  "fields": {
+    "name": "David Barragán Merino",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 4,
+  "fields": {
+    "name": "Alja Isaković",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 5,
+  "fields": {
+    "name": "Meri Williams",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 6,
+  "fields": {
+    "name": "Rebecca M Long",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 7,
+  "fields": {
+    "name": "Oliver Andrich",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 8,
+  "fields": {
+    "name": "Patrick Arminio",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 9,
+  "fields": {
+    "name": "Aleksandra Kunysz",
+    "amount": 15
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 10,
+  "fields": {
+    "name": "HackSoft",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 11,
+  "fields": {
+    "name": "Katherine Allen",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 12,
+  "fields": {
+    "name": "Nathalie Steinmetz",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 13,
+  "fields": {
+    "name": "Maartje Eyskens",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 14,
+  "fields": {
+    "name": "Joanna Tustanowska",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 15,
+  "fields": {
+    "name": "mikeymay972",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 16,
+  "fields": {
+    "name": "Sjoerd Job Postmus",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 17,
+  "fields": {
+    "name": "Taiga",
+    "amount": 1000
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 18,
+  "fields": {
+    "name": "Nik Haldimann",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 19,
+  "fields": {
+    "name": "Jessamyn Smith",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 20,
+  "fields": {
+    "name": "Kaitlyn Redies",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 21,
+  "fields": {
+    "name": "Ola Sendecka",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 22,
+  "fields": {
+    "name": "Julien Poissonnier",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 23,
+  "fields": {
+    "name": "Kathy Cuevas",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 24,
+  "fields": {
+    "name": "D R Jones",
+    "amount": 44
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 25,
+  "fields": {
+    "name": "Michelle Garrett",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 26,
+  "fields": {
+    "name": "jdpower",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 27,
+  "fields": {
+    "name": "Michelle Carroll",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 28,
+  "fields": {
+    "name": "Camille Fabreguettes",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 29,
+  "fields": {
+    "name": "Bojan Mihelac",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 30,
+  "fields": {
+    "name": "Joachim Jablon",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 31,
+  "fields": {
+    "name": "jeremy",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 32,
+  "fields": {
+    "name": "Alexandra Noronha",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 33,
+  "fields": {
+    "name": "sitouh",
+    "amount": 5
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 34,
+  "fields": {
+    "name": "Baptiste Mispelon",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 35,
+  "fields": {
+    "name": "Derek Mortimer",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 36,
+  "fields": {
+    "name": "Sasha Romijn",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+   {
+  "pk": 37,
+  "fields": {
+    "name": "Peter Kropf",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 38,
+  "fields": {
+    "name": "Norma Driske",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 39,
+  "fields": {
+    "name": "Rachell Calhoun",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 40,
+  "fields": {
+    "name": "Brad Wright",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 41,
+  "fields": {
+    "name": "Tom Christie",
+    "amount": 500
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 42,
+  "fields": {
+    "name": "Sibylle Sehl",
+    "amount": 15
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 43,
+  "fields": {
+    "name": "Phillip Oldham",
+    "amount": 150
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 44,
+  "fields": {
+    "name": "Michael Herman",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 45,
+  "fields": {
+    "name": "lukasaoz",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 46,
+  "fields": {
+    "name": "RIGUET Sébastien",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 47,
+  "fields": {
+    "name": "Robert Kirberich",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 48,
+  "fields": {
+    "name": "Daniel Moisset",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 49,
+  "fields": {
+    "name": "mailmattcollins",
+    "amount": 5
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 50,
+  "fields": {
+    "name": "Michael Blatherwick",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 51,
+  "fields": {
+    "name": "Jannis Leidel",
+    "amount": 100
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 52,
+  "fields": {
+    "name": "Felicitas Kugland",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 53,
+  "fields": {
+    "name": "Katja  Durrani",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 54,
+  "fields": {
+    "name": "Nicole Beisiegel",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 55,
+  "fields": {
+    "name": "Frederic Tschannen",
+    "amount": 100
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 56,
+  "fields": {
+    "name": "Read the Docs",
+    "amount": 1000
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 57,
+  "fields": {
+    "name": "Andrew Tork Baker",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 58,
+  "fields": {
+    "name": "mara",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 59,
+  "fields": {
+    "name": "David Beazley",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 60,
+  "fields": {
+    "name": "amjith.r",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 61,
+  "fields": {
+    "name": "Paul McLanahan",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 62,
+  "fields": {
+    "name": "Michael Trythall",
+    "amount": 15
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 63,
+  "fields": {
+    "name": "Carol Willing",
+    "amount": 300
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 64,
+  "fields": {
+    "name": "Kelsey Leftwich",
+    "amount": 25
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 65,
+  "fields": {
+    "name": "Jonathan Moss",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 66,
+  "fields": {
+    "name": "Jose Padilla",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 67,
+  "fields": {
+    "name": "Kiran Booth-Patel",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 68,
+  "fields": {
+    "name": "Samantha McGahan",
+    "amount": 100
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 69,
+  "fields": {
+    "name": "Dan Rundle",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 70,
+  "fields": {
+    "name": "pydanny",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 71,
+  "fields": {
+    "name": "Robert Roskam",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 72,
+  "fields": {
+    "name": "Dane Hillard",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 73,
+  "fields": {
+    "name": "Daniël Franke",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 74,
+  "fields": {
+    "name": "Aisha Bello",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 75,
+  "fields": {
+    "name": "Shabda Raaj",
+    "amount": 5
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 76,
+  "fields": {
+    "name": "piquadrat",
+    "amount": 500
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 77,
+  "fields": {
+    "name": "Betsy Alpert",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 78,
+  "fields": {
+    "name": "WSP Digital",
+    "amount": 2000
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 79,
+  "fields": {
+    "name": "Heather Markell",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 80,
+  "fields": {
+    "name": "Williams Mendez",
+    "amount": 25
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 81,
+  "fields": {
+    "name": "Aymeric Augustin",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 82,
+  "fields": {
+    "name": "Luke Higgott",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 83,
+  "fields": {
+    "name": "Josh Berekus",
+    "amount": 25
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 84,
+  "fields": {
+    "name": "meili.tr",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 85,
+  "fields": {
+    "name": "Alexandra Noronha",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 86,
+  "fields": {
+    "name": "Lacey Henschel",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 87,
+  "fields": {
+    "name": "Joan Ngatia",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 88,
+  "fields": {
+    "name": "Tom Mortimer-Jones",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 89,
+  "fields": {
+    "name": "Natasha Queen",
+    "amount": 15
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 90,
+  "fields": {
+    "name": "Chip Warden",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 91,
+  "fields": {
+    "name": "Raphael Pierzina",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 92,
+  "fields": {
+    "name": "D L Roseman",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 93,
+  "fields": {
+    "name": "Eric Palakovich Carr",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 94,
+  "fields": {
+    "name": "Liz B",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 95,
+  "fields": {
+    "name": "Sarah Pérez",
+    "amount": 5
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 96,
+  "fields": {
+    "name": "Simon Willison",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 97,
+  "fields": {
+    "name": "Ian Feather",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 98,
+  "fields": {
+    "name": "Trey Hunner",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 99,
+  "fields": {
+    "name": "brigidmcmahon",
+    "amount": 25
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 100,
+  "fields": {
+    "name": "Ed Rivas",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 101,
+  "fields": {
+    "name": "alasdair",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 102,
+  "fields": {
+    "name": "Julie Nelson",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 103,
+  "fields": {
+    "name": "luciano",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 104,
+  "fields": {
+    "name": "Eleanor Stribling",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 105,
+  "fields": {
+    "name": "Charlotte Mays",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 106,
+  "fields": {
+    "name": "Jan Krämer",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 107,
+  "fields": {
+    "name": "Mudranik Technologies Pvt Ltd",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 108,
+  "fields": {
+    "name": "Stefan Foulis",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 109,
+  "fields": {
+    "name": "Brenton",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 110,
+  "fields": {
+    "name": "Sylvain Fankhauser",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 111,
+  "fields": {
+    "name": "Lisa Ballard",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 112,
+  "fields": {
+    "name": "Eduardo Cuducos",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 113,
+  "fields": {
+    "name": "Greg Turner",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 114,
+  "fields": {
+    "name": "Don Arnold",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 115,
+  "fields": {
+    "name": "Matus Moravcik",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 116,
+  "fields": {
+    "name": "James Gill",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 117,
+  "fields": {
+    "name": "89grad GmbH",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 118,
+  "fields": {
+    "name": "Russell Keith-Magee",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 119,
+  "fields": {
+    "name": "Julia Kupa",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 120,
+  "fields": {
+    "name": "Benjamin Rousch",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 121,
+  "fields": {
+    "name": "Hailee Kenney",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 122,
+  "fields": {
+    "name": "hjwp2",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 123,
+  "fields": {
+    "name": "Mich Ornella",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 124,
+  "fields": {
+    "name": "Selin Prasad",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 125,
+  "fields": {
+    "name": "Ayany Alvarado Graveran",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 126,
+  "fields": {
+    "name": "go.for.dover",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 127,
+  "fields": {
+    "name": "Alison Spittel",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 128,
+  "fields": {
+    "name": "debracupitt",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 129,
+  "fields": {
+    "name": "Łukasz Wójcik",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 130,
+  "fields": {
+    "name": "daisywheel22+generosity",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 131,
+  "fields": {
+    "name": "George London",
+    "amount": 10
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 132,
+  "fields": {
+    "name": "Clizia Di Biase",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 133,
+  "fields": {
+    "name": "Mark Phillips",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 134,
+  "fields": {
+    "name": "Mizue Kurokawa",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 135,
+  "fields": {
+    "name": "Andrew Tork Baker",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 136,
+  "fields": {
+    "name": "Jeremy Price",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 137,
+  "fields": {
+    "name": "Adrien Brunet",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 138,
+  "fields": {
+    "name": "J Pellerin",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 139,
+  "fields": {
+    "name": "Juliano Binder",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 140,
+  "fields": {
+    "name": "glasnt",
+    "amount": 50
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 141,
+  "fields": {
+    "name": "hazardous.narayan",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 142,
+  "fields": {
+    "name": "Paul Grau",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 143,
+  "fields": {
+    "name": "Vitor Freitas",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 144,
+  "fields": {
+    "name": "Jack Reid",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 145,
+  "fields": {
+    "name": "Yuri Kunde Schlesner",
+    "amount": 200
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 146,
+  "fields": {
+    "name": "Marc-Anthony Taylor",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 147,
+  "fields": {
+    "name": "Lisa Rakic",
+    "amount": 75
+  },
+  "model": "sponsor.donor"
+},
+  {
+  "pk": 148,
+  "fields": {
+    "name": "Rebecca Speirs",
+    "amount": 20
+  },
+  "model": "sponsor.donor"
+}
+]

--- a/sponsor/admin.py
+++ b/sponsor/admin.py
@@ -1,7 +1,7 @@
 from django.contrib import admin
 
 from core.models import EventPageContent
-from .models import Sponsor
+from .models import Sponsor, Donor
 
 
 class SponsorInline(admin.TabularInline):
@@ -31,3 +31,4 @@ class SponsorAdmin(admin.ModelAdmin):
 
 
 admin.site.register(Sponsor, SponsorAdmin)
+admin.site.register(Donor)

--- a/sponsor/models.py
+++ b/sponsor/models.py
@@ -24,3 +24,16 @@ class Sponsor(models.Model):
             return "No logo"
 
     logo_display_for_admin.allow_tags = True
+
+
+class Donor(models.Model):
+    name = models.CharField(max_length=200, null=True, blank=True)
+    amount = models.FloatField()
+    visible = models.BooleanField(default=False)
+
+    def __str__(self):
+        return self.name
+
+
+    class Meta:
+        ordering = ("amount",)

--- a/templates/core/crowdfunding_donors.html
+++ b/templates/core/crowdfunding_donors.html
@@ -1,0 +1,49 @@
+{% extends 'global/base.html' %}
+{% load staticfiles %}
+
+{% block content %}
+<div class="row">
+    <div class="col-md-1"></div>
+    <div class="col-md-10">
+    <h2>Special thanks to all our amazing supporters!</h2>
+        <div class="row">
+        <div class="col-md-6">
+            <p>This year we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January
+                to the 29th of March with the aim of raising US $10,000 to help us cover our staff and
+                operational costs for the year.
+                We are truly grateful to all our amazing supporters who helped reach and surpass our target goal.
+                We managed to raise a total of $13,314!</p>
+
+            <p>If you missed our campaign but will still like to support our work, you can donate to us via
+                PayPal or credit/debit card for once off donations. Alternatively, you can sign up on <a href="http://patreon.com/djangogirls">Patreon
+                </a> for monthly donations. Thank you for supporting our work.</p>
+
+            <p>Thank you. Your support means the world to us.</p>
+        </div>
+        <div class="col-md-6">
+                    <img class="img-responsive center-block" alt="Django Girls Gliwice #1." src="{% static 'img/global/donate/tnr.jpg' %}">
+                </div>
+        </div>
+
+        <div class="row">
+            <h2>They Support Us</h2>
+            {% for donor in donors %}
+                 {% if forloop.first %}<div class="row">{% endif %}
+                <div class="col-md-3">
+                    <p>{{ donor.name }}</p>
+                </div>
+                {% if forloop.counter|divisibleby:4 %}</div><div class="row">{% endif %}
+                {% if forloop.last %}</div>{% endif %}
+            {% endfor %}
+
+            <div class="pager">
+                {% for page in donors.paginator.page_range %}
+                {% if forloop.counter != 1 %} | {% endif %}
+                <a href="?page={{ page }}">{{ page }}</a>
+                {% endfor %}
+            </div>
+        </div>
+    </div>
+    <div class="col-md-1"></div>
+</div>
+{% endblock %}

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -42,37 +42,6 @@
                 </div>
             </div>
 
-            <!-- Crowdfunding Campaign -->
-            <div class="row">
-                <div class="col-md-6">
-                    <h2>We are fundraising!</h2>
-                    <p>
-                         Help Django Girls to grow in 2018!
-                    </p>
-                    <p>
-                        We are running a crowdfunding campaign to help us raise the funds we need to continue
-                        our work on <a href="https://www.generosity.com/community-fundraising/django-girls-fundraising-campaign/x/17493288"
-                                        target="_blank">Indiegogo's Generosity website.</a>
-                    </p>
-                    <p>
-                        We have been to 386 countries in 86 countries so far and we don't want to
-                        stop here. We would like to empower more women to organize workshops and continue to support our
-                        volunteers.
-                    </p>
-                    <p>
-                        Help us to scale in 2018. Please support <a href="https://www.generosity.com/community-fundraising/django-girls-fundraising-campaign/x/17493288"
-                                                                    target="_blank">our campaign</a>.
-                    </p>
-                </div>
-                <div class="col-md-6">
-                    <a href="https://www.generosity.com/community-fundraising/django-girls-fundraising-campaign/x/17493288"
-                       target="_blank"><h2>Django Girls Fundraising Campaign </h2>
-                    <img src="https://c1.iggcdn.com/indiegogo-media-prod-cld/image/upload/c_fill,f_auto,h_440,w_704/v1512071903/g1gct4awp2llvhjtcgma.png"
-                            alt="Django Girls Campaign"
-                            width="500" height="300"></a>
-                </div>
-            </div>
-            
             <div class="row">
                 <div class="col-md-6">
                     <h2>Django Girls impact</h2>

--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -27,9 +27,10 @@
                  <li class="dropdown">
           <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Support us 💕 <span class="caret"></span></a>
           <ul class="dropdown-menu">
-            <li><a href="{% url 'core:donate' %}">Donate</a></li>
-            <li><a href="https://store.djangogirls.org/">Buy a t-shirt</a></li>
-            <li><a href="https://www.patreon.com/djangogirls">Our Patreon page</a></li>
+              <li><a href="{% url 'core:donate' %}">Donate</a></li>
+              <li><a href="https://store.djangogirls.org/">Buy a t-shirt</a></li>
+              <li><a href="https://www.patreon.com/djangogirls">Our Patreon page</a></li>
+              <li><a href="{% url 'core:crowdfunding-donors' %}">Our Supporters</a></li>
           </ul>
         </li>
             </ul>


### PR DESCRIPTION
Added a page to list all our crowdfunding donors. The link to the page is on Support Us dropdown. Donors can be added to the database using the ```./manage loaddata donors.json``` command. The json file does not contain the "visible" field so that will have to be entered manually based on the donors preferences in the admin section for a donor to appear on the page.

Ping me for any questions.