### PR TITLE
remove Opbeat 😢

### DIFF
--- a/core/management/commands/add_organizer.py
+++ b/core/management/commands/add_organizer.py
@@ -3,7 +3,6 @@ import djclick as click
 
 from core.forms import AddOrganizerForm
 from core.models import Event
-from core.utils import opbeat_logging
 
 DELIMITER = "\n-------------------------------------------------------------\n"
 
@@ -39,7 +38,6 @@ def create_users(team, event):
 
 
 @click.command()
-@opbeat_logging()
 def command():
     """Creates new Django Girls organizer"""
     event_id = click.prompt(click.style(

--- a/core/management/commands/backup_postgres_to_s3.py
+++ b/core/management/commands/backup_postgres_to_s3.py
@@ -6,13 +6,10 @@ from boto3.session import Session
 from django.conf import settings
 from django.core.management.base import BaseCommand
 
-from core.utils import opbeat_logging
-
 
 class Command(BaseCommand):
     help = 'Backs up PostgreSQL database to AWS S3'
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         AWS_ACCESS_KEY_ID = os.environ.get('AWS_S3_ACCESS_KEY_ID')
         AWS_SECRET_ACCESS_KEY = os.environ.get('AWS_S3_SECRET_ACCESS_KEY')

--- a/core/management/commands/copy_event.py
+++ b/core/management/commands/copy_event.py
@@ -4,7 +4,6 @@ import djclick as click
 from core.command_helpers import gather_event_date_from_prompt
 from core.management_utils import get_main_organizer, get_team, create_users, brag_on_slack_bang
 from core.models import Event
-from core.utils import opbeat_logging
 
 
 def get_event(id_str):
@@ -45,7 +44,6 @@ def gather_information():
 
 
 @click.command()
-@opbeat_logging()
 def command():
     """Duplicates Django Girls event with a new date"""
 

--- a/core/management/commands/handle_emails.py
+++ b/core/management/commands/handle_emails.py
@@ -15,7 +15,7 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 
 from core.models import Event
-from core.utils import opbeat_logging
+
 
 def send_event_emails(
     events, subject_template, plain_template, html_template, timestamp_field, email_type,
@@ -125,7 +125,6 @@ def send_offer_help_emails():
         )
 
 @click.command()
-@opbeat_logging()
 def command():
     """Find and send out scheduled emails that need sending."""
     send_thank_you_emails()

--- a/core/management/commands/prepare_dispatch.py
+++ b/core/management/commands/prepare_dispatch.py
@@ -7,7 +7,6 @@ from django.contrib.humanize.templatetags.humanize import apnumber
 from django.utils import timezone
 
 from core.models import Event
-from core.utils import opbeat_logging
 
 
 def generate_html_content(event_list):
@@ -21,7 +20,6 @@ def generate_html_content(event_list):
 
 
 @click.command()
-@opbeat_logging()
 def command():
     """Generate "Next events" section for the Dispatch."""
     now = timezone.now()

--- a/core/management/commands/sync_events_dashboard.py
+++ b/core/management/commands/sync_events_dashboard.py
@@ -8,7 +8,6 @@ from django.core.management.base import BaseCommand
 from trello import ResourceUnavailable, TrelloClient
 
 from core.models import Event
-from core.utils import opbeat_logging
 
 
 # Create new command
@@ -23,7 +22,6 @@ class Command(BaseCommand):
     def add_arguments(self, parser):
         parser.add_argument('trello_token', type=str)
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         token = options['trello_token']
         events = event_list()

--- a/core/utils.py
+++ b/core/utils.py
@@ -1,14 +1,10 @@
-from contextlib import contextmanager
 from datetime import date, datetime, timedelta
-import logging
 
 import requests
 from django.utils import timezone
 from django_date_extensions.fields import ApproximateDate
 import djclick as click
 
-import opbeat
-from opbeat.handlers.logging import OpbeatHandler
 
 from .models import Event
 
@@ -82,18 +78,3 @@ def next_deadline():
         return next_sunday(next_sunday(today))
     else:
         return next_sunday(today)
-
-@contextmanager
-def opbeat_logging():
-    client = opbeat.Client()
-
-    handler = OpbeatHandler(client)
-
-    logger = logging.getLogger()
-    logger.addHandler(handler)
-
-    try:
-        yield
-    except Exception:
-        client.capture_exception()
-        raise

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -257,19 +257,6 @@ JOBS_EMAIL_PASSWORD = os.environ.get('JOBS_EMAIL_PASSWORD')
 MEETUPS_EMAIL_USER = os.environ.get('MEETUPS_EMAIL_USER')
 MEETUPS_EMAIL_PASSWORD = os.environ.get('MEETUPS_EMAIL_PASSWORD')
 
-if 'OPBEAT_SECRET_TOKEN' in os.environ:
-    INSTALLED_APPS += (
-        'opbeat.contrib.django',
-    )
-    OPBEAT = {
-        'ORGANIZATION_ID': os.environ['OPBEAT_ORGANIZATION_ID'],
-        'APP_ID': os.environ['OPBEAT_APP_ID'],
-        'SECRET_TOKEN': os.environ['OPBEAT_SECRET_TOKEN'],
-    }
-    MIDDLEWARE = [
-        'opbeat.contrib.django.middleware.OpbeatAPMMiddleware',
-    ] + MIDDLEWARE
-
 CODEMIRROR_PATH = "vendor/codemirror/"
 
 

--- a/githooks/post-merge
+++ b/githooks/post-merge
@@ -1,13 +1,2 @@
 #!/usr/bin/env bash
 
-# Get secret token values from https://opbeat.com/django-girls/djangogirlsorg/releases/setup/instructions/
-function notify_opbeat_release {
-    echo "Uploading release to opbeat..."
-    curl https://intake.opbeat.com/api/v1/organizations/<snip>/apps/<snip>/releases/ \
-        -H "Authorization: Bearer <snip>" \
-        -d rev=`git log -n 1 --pretty=format:%H` \
-        -d branch=`git rev-parse --abbrev-ref HEAD` \
-        -d status=completed
-}
-
-notify_opbeat_release

--- a/patreonmanager/management/commands/download_csv.py
+++ b/patreonmanager/management/commands/download_csv.py
@@ -5,7 +5,6 @@ from os import path
 from django.core.management.base import BaseCommand
 
 from ...utils.download import _download, gen_monthly_report_links, login
-from core.utils import opbeat_logging
 
 
 class Command(BaseCommand):
@@ -16,7 +15,6 @@ class Command(BaseCommand):
         parser.add_argument('-p', '--password', help="Patreon password")
         parser.add_argument('-d', '--directory', help="save CSV reports to DIRECTORY", default='.')
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         if not options['username']:
             options['username'] = input("Patreon username: ")

--- a/patreonmanager/management/commands/fundraising_status.py
+++ b/patreonmanager/management/commands/fundraising_status.py
@@ -7,7 +7,6 @@ from slacker import Error as SlackerError
 from core.slack_client import slack
 
 from ...models import FundraisingStatus
-from core.utils import opbeat_logging
 
 DJANGOGIRLS_USER_ID = 483065
 BASE_API_URL = 'http://api.patreon.com/'
@@ -16,7 +15,6 @@ BASE_API_URL = 'http://api.patreon.com/'
 class Command(BaseCommand):
     help = 'Fetch current amount of money raised on our Patreon'
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         logging.basicConfig(level=logging.INFO)
 

--- a/patreonmanager/management/commands/import_csv.py
+++ b/patreonmanager/management/commands/import_csv.py
@@ -6,7 +6,6 @@ from django.utils.timezone import make_aware
 
 from ...models import Patron, Payment, Reward
 from ...utils.csv import guess_month_from_filename, unflatten_csv
-from core.utils import opbeat_logging
 
 
 class Command(BaseCommand):
@@ -18,7 +17,6 @@ class Command(BaseCommand):
             '--create-rewards', help="create missing rewards if needed",
             action='store_true')
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         if options['verbosity'] > 0:
             logging.basicConfig(level=logging.INFO)

--- a/patreonmanager/management/commands/listpatrons.py
+++ b/patreonmanager/management/commands/listpatrons.py
@@ -3,13 +3,11 @@ from collections import Counter
 from django.core.management.base import BaseCommand
 
 from ...models import Payment
-from core.utils import opbeat_logging
 
 
 class Command(BaseCommand):
     help = 'List Patrons who need a reward to be sent to them'
 
-    @opbeat_logging()
     def handle(self, *args, **options):
         payments = Payment.objects.filter(
             status=Payment.STATUS.PROCESSED,

--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,6 @@ google-api-python-client
 httplib2
 icalendar
 lxml
-opbeat
 Pillow
 psycopg2
 py-trello

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@
 attrs==17.3.0             # via pytest
 boto3==1.4.8
 botocore==1.8.6           # via boto3, s3transfer
-certifi==2017.11.5        # via opbeat, requests
+certifi==2017.11.5        # via requests
 chardet==3.0.4            # via requests
 click==6.7
 coverage==4.4.2           # via pytest-cov
@@ -42,7 +42,6 @@ multidict==3.3.2          # via yarl
 oauth2client==4.1.2       # via google-api-python-client
 oauthlib==2.0.6           # via requests-oauthlib
 olefile==0.44             # via pillow
-opbeat==3.5.3
 pillow==4.3.0
 pluggy==0.6.0             # via pytest
 psycopg2==2.7.3.2
@@ -65,7 +64,7 @@ s3transfer==0.1.12        # via boto3
 six==1.11.0               # via django-click, freezegun, google-api-python-client, oauth2client, pytest, python-dateutil, vcrpy
 slacker==0.9.60
 uritemplate==3.0.0        # via google-api-python-client
-urllib3==1.22             # via opbeat, requests
+urllib3==1.22             # via requests
 vcrpy==1.11.1
 whitenoise==3.3.1
 wrapt==1.10.11            # via vcrpy

--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -7,7 +7,6 @@ from django.core.files.temp import NamedTemporaryFile
 from django.core.management.base import BaseCommand
 from pyquery import PyQuery as pq
 
-from core.utils import opbeat_logging
 from story.models import Story
 
 try:
@@ -19,7 +18,6 @@ except ImportError:
 class Command(BaseCommand):
     help = 'Fetch Django Girls stories from our blog'
 
-    @opbeat_logging()
     def handle(self, *args, **options):
 
         rss_url = 'http://blog.djangogirls.org/rss'


### PR DESCRIPTION
As you might have heard, Opbeat was acquired by Elastic a year ago, and on May 24 (this Thursday), Opbeat.com will finally shut down 😢

I removed all references to `opbeat` from the code base. This should ensure that no interruptions of service will occur once Opbeat.com is gone (there shouldn't be any catastrophic side effects even if you don't deploy this before May 24).

If y'all are interested, I can check if we can hook you up with a sponsored instance of Elastic APM, the product that the Opbeat team has been working on since joining Elastic. It comes with many of the same features as Opbeat (but not all, yet, we're working on that :) ).