### PR TITLE
Move deployment email logic out of atomic transaction

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .DS_Store
 *.sqlite3
 *.pyc
+.python-version
 staticfiles/
 uploads/
 local_settings.py

--- a/organize/admin.py
+++ b/organize/admin.py
@@ -144,7 +144,8 @@ class EventApplicationAdmin(admin.ModelAdmin):
                 if new_status == REJECTED:
                     application.reject()
                 else:
-                    application.deploy()
+                    event = application.deploy()
+                    application.send_deployed_email(event)
         else:
             messages.error(request, 'Invalid status provided for application')
             return redirect(

--- a/organize/models.py
+++ b/organize/models.py
@@ -146,12 +146,6 @@ class EventApplication(models.Model):
         else:
             event = self.create_event()
 
-        # sort out Gmail accounts
-        dummy_email, email_password = gmail_accounts.get_or_create_gmail(
-            event_application=self,
-            event=event
-        )
-
         # add main organizer of the Event
         main_organizer = event.add_organizer(
             self.main_organizer_email,
@@ -168,6 +162,14 @@ class EventApplication(models.Model):
                 organizer.first_name,
                 organizer.last_name
             )
+        return event
+
+    def send_deployed_email(self, event):
+        # sort out Gmail accounts
+        dummy_email, email_password = gmail_accounts.get_or_create_gmail(
+            event_application=self,
+            event=event
+        )
 
         # TODO: remove organizers, who are no longer in org team if cloned
         send_application_deployed_email(

--- a/tests/organize/test_models.py
+++ b/tests/organize/test_models.py
@@ -44,8 +44,8 @@ def test_deploy_event_from_previous_event(
 def test_send_deployed_email(
         get_or_create_gmail, base_application, mailoutbox, stock_pictures):
     get_or_create_gmail.return_value = (
-            '{}@djangogirls.org'.format(base_application.city),
-            'asd123ASD')
+        '{}@djangogirls.org'.format(base_application.city),
+        'asd123ASD')
 
     base_application.create_event()
     event = base_application.deploy()

--- a/tests/organize/test_models.py
+++ b/tests/organize/test_models.py
@@ -35,18 +35,27 @@ def test_reject_method(base_application, mailoutbox):
 @mock.patch('organize.models.gmail_accounts.get_or_create_gmail')
 def test_deploy_event_from_previous_event(
         get_or_create_gmail, base_application, mailoutbox, stock_pictures):
-    get_or_create_gmail.return_value = (
-        '{}@djangogirls.org'.format(base_application.city),
-        'asd123ASD')
     base_application.create_event()
     base_application.deploy()
 
     assert base_application.status == DEPLOYED
-    email_subjects = [e.subject for e in mailoutbox]
-    assert len(mailoutbox) == 2
-
     assert "Access to Django Girls website" in email_subjects
     assert "Congrats! Your application to organize Django Girls London has been accepted!" in email_subjects
+
+
+@mock.patch('organize.models.gmail_accounts.get_or_create_gmail')
+def test_send_deployed_email(
+        get_or_create_gmail, base_application, mailoutbox, stock_pictures):
+    get_or_create_gmail.return_value = (
+            '{}@djangogirls.org'.format(base_application.city),
+            'asd123ASD')
+
+    base_application.create_event()
+    event = base_application.deploy()
+    base_application.send_deployed_email(event)
+
+    email_subjects = [e.subject for e in mailoutbox]
+    assert len(mailoutbox) == 2
 
 
 @vcr.use_cassette('tests/organize/vcr/latlng.yaml')

--- a/tests/organize/test_models.py
+++ b/tests/organize/test_models.py
@@ -37,10 +37,7 @@ def test_deploy_event_from_previous_event(
         get_or_create_gmail, base_application, mailoutbox, stock_pictures):
     base_application.create_event()
     base_application.deploy()
-
     assert base_application.status == DEPLOYED
-    assert "Access to Django Girls website" in email_subjects
-    assert "Congrats! Your application to organize Django Girls London has been accepted!" in email_subjects
 
 
 @mock.patch('organize.models.gmail_accounts.get_or_create_gmail')
@@ -56,6 +53,8 @@ def test_send_deployed_email(
 
     email_subjects = [e.subject for e in mailoutbox]
     assert len(mailoutbox) == 2
+    assert "Access to Django Girls website" in email_subjects
+    assert "Congrats! Your application to organize Django Girls London has been accepted!" in email_subjects
 
 
 @vcr.use_cassette('tests/organize/vcr/latlng.yaml')


### PR DESCRIPTION
Closes https://github.com/DjangoGirls/djangogirls/issues/454

The deployment e-mails were being sent in the same function that deploys an event, but `transaction.atomic` decorates this function, so in case the e-mails somehow fail to be sent, the whole deployment will fail.

This moves the e-mail logic out of the atomic function.