### PR TITLE
Organizers can see other workshops' pages that aren't live when logged in

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -205,6 +205,13 @@ class Event(models.Model):
                    for x in self.team.all()]
         return ", ".join(members)
 
+    def has_organizer(self, user):
+        """
+        Return whether a specific user is an organizer of the event
+        """
+        return self.main_organizer == user or self.team.filter(
+            id=user.id).exists()
+
     @property
     def has_stats(self):
         return bool(self.applicants_count and self.attendees_count)

--- a/core/views.py
+++ b/core/views.py
@@ -55,8 +55,11 @@ def event(request, city):
     if event.page_url != city:
         return redirect('core:event', city=event.page_url, permanent=True)
 
-    can_show = request.user.is_authenticated() or 'preview' in request.GET
-    if not event.is_page_live and not can_show:
+    user = request.user
+    user_is_organizer = user.is_authenticated() and event.has_organizer(user)
+    previewable = user_is_organizer or 'preview' in request.GET
+
+    if not (event.is_page_live or previewable):
         return render(
             request,
             'applications/event_not_live.html',

--- a/core/views.py
+++ b/core/views.py
@@ -57,7 +57,8 @@ def event(request, city):
 
     user = request.user
     user_is_organizer = user.is_authenticated() and event.has_organizer(user)
-    previewable = user_is_organizer or 'preview' in request.GET
+    is_preview = 'preview' in request.GET
+    previewable = user.is_superuser or user_is_organizer or is_preview
 
     if not (event.is_page_live or previewable):
         return render(

--- a/tests/core/test_models.py
+++ b/tests/core/test_models.py
@@ -82,3 +82,24 @@ def test_add_to_organizers_group(user):
     Group.objects.create(name="Organizers")
     user.add_to_organizers_group()
     assert user.groups.count() == 1
+
+
+def test_has_organizer_no_organizer(user, future_event):
+    future_event.main_organizer = None
+    future_event.team.clear()
+
+    assert not future_event.has_organizer(user)
+
+
+def test_has_organizer_in_team(user, future_event):
+    future_event.main_organizer = None
+    future_event.team.add(user)
+
+    assert future_event.has_organizer(user)
+
+
+def test_has_organizer_main_organizer(user, future_event):
+    future_event.main_organizer = user
+    future_event.team.clear()
+
+    assert future_event.has_organizer(user)

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -78,15 +78,49 @@ def test_event_unpublished_with_future_and_past_dates(client, no_date_event):
     assert 'has already happened' in str(resp.content)
 
 
-def test_event_unpublished_with_authenticated_user(admin_client, hidden_event):
+def test_event_unpublished_with_auth_superuser(admin_client, hidden_event):
     """ Test that an unpublished page can be accessed when the user is
-    authenticated """
+    authenticated and a superuser"""
 
     url = '/' + hidden_event.page_url + '/'
     resp = admin_client.get(url)
 
     assert resp.status_code == 200
     # Check if website is returning correct data
+    assert hidden_event.page_title in resp.content.decode('utf-8')
+
+
+def test_event_unpublished_with_auth_not_organizer(user, client, hidden_event):
+    """ Test that an unpublished page can be accessed when the user is
+    authenticated and a superuser"""
+
+    url = '/' + hidden_event.page_url + '/'
+    client.force_login(user)
+    resp = client.get(url)
+
+    assert resp.status_code == 200
+    assert 'city' and 'past' in resp.context
+
+
+def test_event_unpublished_with_auth_in_team(user, client, hidden_event):
+    hidden_event.team.add(user)
+
+    url = '/' + hidden_event.page_url + '/'
+    client.force_login(user)
+    resp = client.get(url)
+
+    assert resp.status_code == 200
+    assert hidden_event.page_title in resp.content.decode('utf-8')
+
+
+def test_event_unpublished_with_auth_organizer(user, client, hidden_event):
+    hidden_event.main_organizer = user
+
+    url = '/' + hidden_event.page_url + '/'
+    client.force_login(user)
+    resp = client.get(url)
+
+    assert resp.status_code == 200
     assert hidden_event.page_title in resp.content.decode('utf-8')
 
 

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -78,6 +78,18 @@ def test_event_unpublished_with_future_and_past_dates(client, no_date_event):
     assert 'has already happened' in str(resp.content)
 
 
+def test_event_unpublished_with_auth_normal(user, client, hidden_event):
+    """ Test that an unpublished page can not be accessed when the user is
+    authenticated and not a superuser"""
+
+    client.force_login(user)
+    url = '/' + hidden_event.page_url + '/'
+    resp = client.get(url)
+
+    assert resp.status_code == 200
+    assert 'city' and 'past' in resp.context
+
+
 def test_event_unpublished_with_auth_superuser(admin_client, hidden_event):
     """ Test that an unpublished page can be accessed when the user is
     authenticated and a superuser"""
@@ -86,16 +98,15 @@ def test_event_unpublished_with_auth_superuser(admin_client, hidden_event):
     resp = admin_client.get(url)
 
     assert resp.status_code == 200
-    # Check if website is returning correct data
     assert hidden_event.page_title in resp.content.decode('utf-8')
 
 
 def test_event_unpublished_with_auth_not_organizer(user, client, hidden_event):
-    """ Test that an unpublished page can be accessed when the user is
-    authenticated and a superuser"""
+    """ Test that an unpublished page can not be accessed if the user
+    is not an organizer"""
 
-    url = '/' + hidden_event.page_url + '/'
     client.force_login(user)
+    url = '/' + hidden_event.page_url + '/'
     resp = client.get(url)
 
     assert resp.status_code == 200
@@ -103,10 +114,12 @@ def test_event_unpublished_with_auth_not_organizer(user, client, hidden_event):
 
 
 def test_event_unpublished_with_auth_in_team(user, client, hidden_event):
+    """ Test that an unpublished page can be accessed if the user
+    is an organizer"""
     hidden_event.team.add(user)
 
-    url = '/' + hidden_event.page_url + '/'
     client.force_login(user)
+    url = '/' + hidden_event.page_url + '/'
     resp = client.get(url)
 
     assert resp.status_code == 200
@@ -114,10 +127,12 @@ def test_event_unpublished_with_auth_in_team(user, client, hidden_event):
 
 
 def test_event_unpublished_with_auth_organizer(user, client, hidden_event):
+    """ Test that an unpublished page can be accessed if the user
+    is the main organizer"""
     hidden_event.main_organizer = user
 
-    url = '/' + hidden_event.page_url + '/'
     client.force_login(user)
+    url = '/' + hidden_event.page_url + '/'
     resp = client.get(url)
 
     assert resp.status_code == 200


### PR DESCRIPTION
Users will only be able to preview an event page if they are superusers or organizers.

Closes #465 