### PR TITLE
Use case insensitive matching for user creation

### DIFF
--- a/core/models.py
+++ b/core/models.py
@@ -268,7 +268,7 @@ class Event(models.Model):
             "is_active": True
         }
         user, created = User.objects.get_or_create(
-            email=email,
+            email__iexact=email,  # case insensitive match
             defaults=defaults
         )
         password = None


### PR DESCRIPTION
fixes #461 

Use case insensitive matching for user creation. Don't create a new user if the same email with case insensitive match exists