### PR TITLE
Remove GitHub Sponsoring URL

### DIFF
--- a/djangogirls/urls.py
+++ b/djangogirls/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     path('contact/', include('contact.urls')),
     path('organize/', include('organize.urls')),
     path('story/', include('story.urls')),
-    path('', include('sponsor.urls')),
+    # path('', include('sponsor.urls')),
     path('', include('applications.urls')),
     path('', include('core.urls')),
 ]


### PR DESCRIPTION
GitHub cancelled its sponsoring programme with Django Girls. Since Django Girls closed the TypeForm account, the Typeform for this page is now broken. To close the issue, for now, we are removing links to this page as the arrangement is no longer in effect.