### PR TITLE
Change date for future_event and hidden_event fixtures in tests/conftest.py to fix failing tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -123,7 +123,7 @@ def future_event(organizer_peter):
         country="the Neverlands",
         is_on_homepage=True,
         main_organizer=organizer_peter,
-        date="2020-12-00",
+        date="2080-01-01",
         page_url="bonn",
         is_page_live=True)
     event.team.add(organizer_peter)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -156,7 +156,7 @@ def hidden_event(superuser):
         country="Italy",
         is_on_homepage=False,
         main_organizer=superuser,
-        date="2020-09-02",
+        date="2080-09-02",
         page_url="rome",
         is_page_live=False)
     event.team.add(superuser)


### PR DESCRIPTION
The following tests were failing because they depend on the test fixture `future_event` in `tests/conftest.py` which a date that was now past.
* `test_organizer_can_only_add_to_their_event`
* `test_manage_organizers_view_for_superuser`
* `test_remove_organizer_as_superuser`
* `test_organizers_can_only_remove_from_their_events`
* `test_organizers_cannot_remove_themselves `
* `test_index`
* `test_adding_organizer_as_superuser` was failing because of `hidden_event` fixture which had date now in the past.

This pull request changes the date to be in the future to fix these tests.