### PR TITLE
Fix AttributeError: 'str' object has no attribute 'year'

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,10 @@
+from datetime import date
+
 import icalendar
 from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import TemplateDoesNotExist
-from django.utils import timezone
-from django_date_extensions.fields import ApproximateDate
 
 from patreonmanager.models import FundraisingStatus
 
@@ -48,8 +48,7 @@ def resources(request):
 
 
 def event(request, city):
-    now = timezone.now()
-    now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
+    now_approx = date.today()
     event = get_object_or_404(Event, page_url=city.lower())
 
     if event.page_url != city:
@@ -64,7 +63,7 @@ def event(request, city):
         return render(
             request,
             'applications/event_not_live.html',
-            {'city': city, 'past': event.date <= now_approx}
+            {'city': city, 'past': date(event.date.year, event.date.month, event.date.day) <= now_approx}
         )
 
     return render(request, "core/event.html", {


### PR DESCRIPTION
There is a consistent server error on the Django Girls website as shown below that needs fixing. The error is shown below:

```
Internal Server Error: /maceio/
Traceback (most recent call last):
  File "/home/djangogirls2/.virtualenvs/djangogirls.com/lib/python3.5/site-packages/django/core/handlers/exception.py", line 35, in inner
    response = get_response(request)
  File "/home/djangogirls2/.virtualenvs/djangogirls.com/lib/python3.5/site-packages/django/core/handlers/base.py", line 128, in _get_response
    response = self.process_exception_by_middleware(e, request)
  File "/home/djangogirls2/.virtualenvs/djangogirls.com/lib/python3.5/site-packages/django/core/handlers/base.py", line 126, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/home/djangogirls2/djangogirls.com/core/views.py", line 67, in event
    {'city': city, 'past': event.date <= now_approx}
  File "/usr/lib/python3.5/functools.py", line 111, in _ge_from_lt
    op_result = self.__lt__(other)
  File "/home/djangogirls2/.virtualenvs/djangogirls.com/lib/python3.5/site-packages/django_date_extensions/fields.py", line 85, in __lt__
    return (self.year, self.month, self.day) < (other.year, other.month, other.day)
AttributeError: 'str' object has no attribute 'year'
```