### PR TITLE
Fix 'past' date issue that's causing server error on website

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -63,7 +63,7 @@ def event(request, city):
         return render(
             request,
             'applications/event_not_live.html',
-            {'city': city, 'past': date(event.date.year, event.date.month, event.date.day) <= now_approx}
+            {'city': city, 'past': date(event.date.year, event.date.month, event.date.day) < now_approx}
         )
 
     return render(request, "core/event.html", {


### PR DESCRIPTION
There is a server error on the website when an organizer tries to submit a new application due to the line in `event` function in core/views.py where there is dates comparison to see if event date is past or not. This pull request removes the `<=` and replaces it with `<` to fix the bug.