### PR TITLE
Fix email notification template to cater for remote workshops

### DIFF
--- a/templates/emails/organize/application_notification.html
+++ b/templates/emails/organize/application_notification.html
@@ -46,10 +46,17 @@
   <strong>Have you organized any other event before?</strong><br />
   {{ application.experience|linebreaksbr }}
 </p>
+{% if application.remote %}
+<p>
+<strong>How will you host your workshop remotely?</strong>
+{{ application.tools|linebreaksbr }}
+</p>
+{% else %}
 <p>
   <strong>Do you have a venue in mind?</strong><br />
   {{ application.venue|linebreaksbr }}
 </p>
+{% endif %}
 <p>
   <strong>Do you have a plan which companies will you approach for sponsorship?</strong><br />
   {{ application.sponsorship|linebreaksbr }}


### PR DESCRIPTION
The current email notification still refer to venue even for remote workshops when that is not required for remote workshops. Fixing this so that we know the failure is not resulting from this missing variable.