### PR TITLE
Patreon updates

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,10 @@
-from datetime import date
-
 import icalendar
 from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import TemplateDoesNotExist
+from django.utils import timezone
+from django_date_extensions.fields import ApproximateDate
 
 from patreonmanager.models import FundraisingStatus
 
@@ -48,7 +48,9 @@ def resources(request):
 
 
 def event(request, city):
-    now_approx = date.today()
+    now = timezone.now()
+    now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
+
     event = get_object_or_404(Event, page_url=city.lower())
 
     if event.page_url != city:
@@ -63,7 +65,7 @@ def event(request, city):
         return render(
             request,
             'applications/event_not_live.html',
-            {'city': city, 'past': date(event.date.year, event.date.month, event.date.day) < now_approx}
+            {'city': city, 'past': False}
         )
 
     return render(request, "core/event.html", {

--- a/templates/emails/organize/application_notification.html
+++ b/templates/emails/organize/application_notification.html
@@ -46,10 +46,17 @@
   <strong>Have you organized any other event before?</strong><br />
   {{ application.experience|linebreaksbr }}
 </p>
+{% if application.remote %}
+<p>
+<strong>How will you host your workshop remotely?</strong>
+{{ application.tools|linebreaksbr }}
+</p>
+{% else %}
 <p>
   <strong>Do you have a venue in mind?</strong><br />
   {{ application.venue|linebreaksbr }}
 </p>
+{% endif %}
 <p>
   <strong>Do you have a plan which companies will you approach for sponsorship?</strong><br />
   {{ application.sponsorship|linebreaksbr }}


### PR DESCRIPTION
Website is crashing when organizers try to apply to organize a new workshop because of a server error that is generated by a variable `past` which is part of the context for rendering an event. 