### PR TITLE
Set value of past to false in event view

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -63,7 +63,7 @@ def event(request, city):
         return render(
             request,
             'applications/event_not_live.html',
-            {'city': city, 'past': date(event.date.year, event.date.month, event.date.day) <= now_approx}
+            {'city': city, 'past': False}
         )
 
     return render(request, "core/event.html", {


### PR DESCRIPTION
The website is crashing and giving a server error due to the `past` variable and preventing organizers from submitting new applications.  This pull request is a patch to prevent the website from crashing while a permanent fix is looked into.