### PR TITLE
Fix cache settings for GitHub Actions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,6 +13,12 @@ jobs:
 # - uncomment one-by-one, and open PR to test.
 #    notifications:
 #      slack: djangogirls:f5ZWSNUTwKp1C8L8rr3PYjg7
+    - name: Cache Python Modules
+        id: cache-pip
+        uses: actions/cache@v2
+        with:
+          path: $HOME/.cache/pip
+          key: ${{ runner.os }}-pip
 
     services:
       postgres:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -13,9 +13,6 @@ jobs:
 # - uncomment one-by-one, and open PR to test.
 #    notifications:
 #      slack: djangogirls:f5ZWSNUTwKp1C8L8rr3PYjg7
-#    cache:
-#      directories:
-#        - $HOME/.cache/pip
 
     services:
       postgres:


### PR DESCRIPTION
Remove cache settings copied from Travis file. They cause Github Actions to fail and seem unnecessary since builds pass without them.