### PR TITLE
Remove 3.8 and 3.9 versions so CI passes

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -36,8 +36,6 @@ jobs:
         - 3.5
         - 3.6
         - 3.7
-        - 3.8
-        - 3.9
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Python 3.8 and 3.9 are failing for now since we are website is running on versions 3.4 and 3.5. Removing this for now until we are ready to bump versions to 3.8 or 3.9. For now, we can work with bumping version to 3.7.