### PR TITLE
Fix date value error for event, revert to old settings

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -1,10 +1,10 @@
-from datetime import date
-
 import icalendar
 from django.conf import settings
 from django.http import HttpResponse, Http404
 from django.shortcuts import get_object_or_404, redirect, render
 from django.template import TemplateDoesNotExist
+from django.utils import timezone
+from django_date_extensions.fields import ApproximateDate
 
 from patreonmanager.models import FundraisingStatus
 
@@ -48,7 +48,8 @@ def resources(request):
 
 
 def event(request, city):
-    now_approx = date.today()
+    now = timezone.now()
+    now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
     event = get_object_or_404(Event, page_url=city.lower())
 
     if event.page_url != city:
@@ -63,7 +64,7 @@ def event(request, city):
         return render(
             request,
             'applications/event_not_live.html',
-            {'city': city, 'past': False}
+            {'city': city, 'past': event.date <= now_approx}
         )
 
     return render(request, "core/event.html", {

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -49,7 +49,6 @@ def test_event_unpublished(client, hidden_event):
     assert 'city' and 'past' in resp.context
 
 
-@pytest.mark.skip(reason="Pending fix of #590 — Template `past` hardcoded as False.")
 def test_event_unpublished_with_future_and_past_dates(client, no_date_event):
     future_date = timezone.now() + timedelta(days=1)
     past_date = timezone.now() - timedelta(days=1)


### PR DESCRIPTION
Reverted to old comparison of approximate dates for event and removed the fixed false setting. Tests pass locally but this has been failing in production. Am using Python 3.7 in my local environment and the virtual environment in production is using 3.4. Not sure if this where the issue is stemming from.