### PR TITLE
Remove Python versions 3.5 and 3.6

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -33,8 +33,6 @@ jobs:
       max-parallel: 4
       matrix:
         python-version:
-        - 3.5
-        - 3.6
         - 3.7
 
     steps:


### PR DESCRIPTION
We no longer need new builds to pass for versions 3.5 and 3.6 since we have upgraded the production environment to Python 3.7 and would need to add later versions. This is also to prevent blocking PRs that pass for 3.7 because of versions we no longer support.