### PR TITLE
This adds a cache layer to the django tests

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,10 +1,14 @@
 name: Tests
 
+#on:
+#  push:
+#    branches:
+#    - main
+#  pull_request:
+
 on:
-  push:
-    branches:
-    - main
   pull_request:
+  push:
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -1,14 +1,10 @@
 name: Tests
 
-#on:
-#  push:
-#    branches:
-#    - main
-#  pull_request:
-
 on:
-  pull_request:
   push:
+    branches:
+    - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -39,6 +39,11 @@ jobs:
       - name: psycopg2 prerequisites
         run: sudo apt-get install libpq-dev
 
+      - uses: actions/cache@v2
+        with:
+          path: ~/.cache/pip
+          key: ${{ hashFiles('package.json') }}-${{ hashFiles('requirements.txt') }}
+
       - name: Install Dependencies
         run: |
           python -m pip install --upgrade pip setuptools wheel
@@ -47,7 +52,6 @@ jobs:
       - name: Run migrations
         run: |
           python manage.py migrate
-
         env:
           POSTGRES_PASSWORD: postgres
 
@@ -57,6 +61,3 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
 
-# Can we restore this? Commented to get workflow running.
-#      - after_success:
-#          - bash <(curl -s https://codecov.io/bash)


### PR DESCRIPTION
Adding pip cache to `django.yml` to fix that step from #599

On the first few runs, it doesn't seem to speed things up very much - perhaps because the actions are split across separate files rather than linting, testing etc all in 1 action.