### PR TITLE
Restrict slack action to pushes to main branch and PRs.

### DIFF
--- a/.github/workflows/slack-notify.yml
+++ b/.github/workflows/slack-notify.yml
@@ -1,5 +1,11 @@
-on: push
 name: Slack Notification
+
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+
 jobs:
   slackNotification:
     name: Slack Notification


### PR DESCRIPTION
This puts restrictions on the slack action, to stop it running on all pushes.