### PR TITLE
Provide response for GET request to donation charge view. 

### DIFF
--- a/donations/views.py
+++ b/donations/views.py
@@ -1,4 +1,5 @@
 import stripe
+from django.http import HttpResponseForbidden
 from stripe.error import StripeError
 from django.conf import settings
 from django.shortcuts import render, redirect
@@ -58,6 +59,9 @@ def charge(request):
                     )
                 )
         return redirect(reverse('donations:error'))
+
+    else:
+        return HttpResponseForbidden()
 
 
 def success(request, currency, amount):

--- a/tests/donations/test_views.py
+++ b/tests/donations/test_views.py
@@ -29,8 +29,8 @@ def test_index(client):
 
 
 def test_charge_get(client):
-    with pytest.raises(ValueError):
-        client.get(reverse('donations:charge'))
+    resp = client.get(reverse('donations:charge'))
+    assert resp.status_code == 403
 
 
 def test_charge_post(client):


### PR DESCRIPTION
The donation charge view currently only responds to `POST` requests. It seems someone has managed to hit it with a `GET` request so we need to handle them.

It's now throwing a 403

Fixes DJANGO-GIRLS-WEBSITE-5
Fixes #656 