### PR TITLE
Optimize applications page

### DIFF
--- a/applications/questions.py
+++ b/applications/questions.py
@@ -1,10 +1,7 @@
 from collections import OrderedDict
 
 from django import forms
-from django.db.models import Exists, OuterRef
 from django.urls import reverse
-
-from core.models import User
 
 
 def get_organiser_menu(city):
@@ -66,65 +63,6 @@ def generate_form_from_questions(questions):
     )
 
     return fields
-
-
-def get_applications_for_event(event, state=None, rsvp_status=None, order=None, user: User = None):
-    """
-    Return a QuerySet of Application objects for a given event.
-    Raises Form.DoesNotExist if Form for event does not yet exist.
-    """
-    from applications.models import Application, Score  # circular import
-
-    applications = (
-        Application.objects
-        .filter(form__event=event)
-        .order_by('id')
-        .select_related('form')
-        .prefetch_related('answer_set', 'scores', 'scores__user',
-                          'form__event', 'scores__application')
-    )
-
-    if user:
-        scores_subquery = Score.objects.filter(application=OuterRef("pk"), user=user)
-        applications = applications.annotate(was_scored_by_user=Exists(scores_subquery))
-
-    if rsvp_status:
-        applications = applications.filter(
-            state='accepted', rsvp_status__in=rsvp_status
-        )
-    elif state:
-        applications = applications.filter(state__in=state)
-
-    if order:
-        is_reversed = True if order[0] == '-' else False
-        order = order[1:] if order[0] == '-' else order
-        if order == 'average_score':
-            # here is an exception for the average_score, because we also want to get
-            # the standard deviation into account in this sorting
-            applications = sorted(
-                applications,
-                key=lambda app: (getattr(app, order), -app.stdev()), reverse=is_reversed)
-        else:
-            applications = sorted(
-                applications,
-                key=lambda app: getattr(app, order), reverse=is_reversed)
-
-    return applications
-
-
-def random_application(request, event, prev_application):
-    """
-    Get a new random application for a particular event,
-    that hasn't been scored by the request user.
-    """
-    from applications.models import Application  # circular import
-    return Application.objects.filter(
-        form__event=event
-    ).exclude(
-        pk=prev_application.id
-    ).exclude(
-        scores__user=request.user
-    ).order_by('?').first()
 
 
 DEFAULT_QUESTIONS = [

--- a/applications/services.py
+++ b/applications/services.py
@@ -19,9 +19,8 @@ def get_applications_for_event(event, state=None, rsvp_status=None, order=None, 
                           'form__event', 'scores__application')
     )
 
-    if user:
-        scores_subquery = Score.objects.filter(application=OuterRef("pk"), user=user)
-        applications = applications.annotate(was_scored_by_user=Exists(scores_subquery))
+    scores_subquery = Score.objects.filter(application=OuterRef("pk"), user=user)
+    applications = applications.annotate(was_scored_by_user=Exists(scores_subquery))
 
     if rsvp_status:
         applications = applications.filter(
@@ -38,7 +37,8 @@ def get_applications_for_event(event, state=None, rsvp_status=None, order=None, 
             # the standard deviation into account in this sorting
             applications = sorted(
                 applications,
-                key=lambda app: (getattr(app, order), -app.stdev()), reverse=is_reversed)
+                key=lambda app: (app.was_scored_by_user, getattr(app, order), -app.stdev()),
+                reverse=is_reversed)
         else:
             applications = sorted(
                 applications,

--- a/applications/services.py
+++ b/applications/services.py
@@ -1,0 +1,62 @@
+from django.db.models import Exists, OuterRef
+
+from core.models import User
+
+
+def get_applications_for_event(event, state=None, rsvp_status=None, order=None, user: User = None):
+    """
+    Return a QuerySet of Application objects for a given event.
+    Raises Form.DoesNotExist if Form for event does not yet exist.
+    """
+    from applications.models import Application, Score  # circular import
+
+    applications = (
+        Application.objects
+        .filter(form__event=event)
+        .order_by('id')
+        .select_related('form')
+        .prefetch_related('answer_set', 'scores', 'scores__user',
+                          'form__event', 'scores__application')
+    )
+
+    if user:
+        scores_subquery = Score.objects.filter(application=OuterRef("pk"), user=user)
+        applications = applications.annotate(was_scored_by_user=Exists(scores_subquery))
+
+    if rsvp_status:
+        applications = applications.filter(
+            state='accepted', rsvp_status__in=rsvp_status
+        )
+    elif state:
+        applications = applications.filter(state__in=state)
+
+    if order:
+        is_reversed = True if order[0] == '-' else False
+        order = order[1:] if order[0] == '-' else order
+        if order == 'average_score':
+            # here is an exception for the average_score, because we also want to get
+            # the standard deviation into account in this sorting
+            applications = sorted(
+                applications,
+                key=lambda app: (getattr(app, order), -app.stdev()), reverse=is_reversed)
+        else:
+            applications = sorted(
+                applications,
+                key=lambda app: getattr(app, order), reverse=is_reversed)
+
+    return applications
+
+
+def get_random_application(request, event, prev_application):
+    """
+    Get a new random application for a particular event,
+    that hasn't been scored by the request user.
+    """
+    from applications.models import Application  # circular import
+    return Application.objects.filter(
+        form__event=event
+    ).exclude(
+        pk=prev_application.id
+    ).exclude(
+        scores__user=request.user
+    ).order_by('?').first()

--- a/applications/services.py
+++ b/applications/services.py
@@ -1,5 +1,6 @@
 from django.db.models import Exists, OuterRef
 
+from applications.models import Application, Score
 from core.models import User
 
 
@@ -8,7 +9,6 @@ def get_applications_for_event(event, state=None, rsvp_status=None, order=None, 
     Return a QuerySet of Application objects for a given event.
     Raises Form.DoesNotExist if Form for event does not yet exist.
     """
-    from applications.models import Application, Score  # circular import
 
     applications = (
         Application.objects

--- a/applications/services.py
+++ b/applications/services.py
@@ -1,6 +1,6 @@
 from django.db.models import Exists, OuterRef
 
-from applications.models import Application, Score
+from applications.models import Application, Score, Event
 from core.models import User
 
 
@@ -47,16 +47,15 @@ def get_applications_for_event(event, state=None, rsvp_status=None, order=None, 
     return applications
 
 
-def get_random_application(request, event, prev_application):
+def get_random_application(user: User, event: Event, prev_application: Application):
     """
     Get a new random application for a particular event,
-    that hasn't been scored by the request user.
+    that hasn't been scored by the user.
     """
-    from applications.models import Application  # circular import
     return Application.objects.filter(
         form__event=event
     ).exclude(
-        pk=prev_application.id
+        pk=prev_application.id,
     ).exclude(
-        scores__user=request.user
+        scores__user=user
     ).order_by('?').first()

--- a/applications/templatetags/applications_tags.py
+++ b/applications/templatetags/applications_tags.py
@@ -1,13 +1,7 @@
-# -*- encoding: utf-8 -*-
 from django import template
 from django.utils.safestring import mark_safe
 
 register = template.Library()
-
-
-@register.filter
-def scored_by_user(application, user):
-    return application.is_scored_by_user(user)
 
 
 @register.simple_tag

--- a/applications/views.py
+++ b/applications/views.py
@@ -86,7 +86,7 @@ def application_list(request, city):
 
     try:
         applications = get_applications_for_event(
-            event, state, rsvp_status, order)
+            event, state, rsvp_status, order, user=request.user)
     except Application.DoesNotExist:
         return redirect('core:event', city=city)
 

--- a/applications/views.py
+++ b/applications/views.py
@@ -12,10 +12,8 @@ from core.utils import get_event
 from .decorators import organiser_only
 from .forms import ApplicationForm, EmailForm, ScoreForm
 from .models import Application, Email, Form, Question, Score
-from .questions import (
-    get_applications_for_event, get_organiser_menu,
-    random_application
-)
+from .questions import get_organiser_menu
+from .services import get_applications_for_event, get_random_application
 
 
 def apply(request, city):
@@ -172,7 +170,7 @@ def application_detail(request, city, app_number):
 
         if request.POST.get('random'):
             # Go to a new random application.
-            new_app = random_application(request, event, application)
+            new_app = get_random_application(request, event, application)
             if new_app:
                 return redirect(
                     'applications:application_detail', city, new_app.number)

--- a/applications/views.py
+++ b/applications/views.py
@@ -170,7 +170,7 @@ def application_detail(request, city, app_number):
 
         if request.POST.get('random'):
             # Go to a new random application.
-            new_app = get_random_application(request, event, application)
+            new_app = get_random_application(request.user, event, application)
             if new_app:
                 return redirect(
                     'applications:application_detail', city, new_app.number)

--- a/requirements.in
+++ b/requirements.in
@@ -38,3 +38,5 @@ sentry-sdk==1.3.1
 slacker==0.9.65
 stripe
 vcrpy==2.0.1
+ipdb
+ipython

--- a/requirements.in
+++ b/requirements.in
@@ -38,5 +38,3 @@ sentry-sdk==1.3.1
 slacker==0.9.65
 stripe
 vcrpy==2.0.1
-ipdb
-ipython

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,17 +4,13 @@
 #
 #    pip-compile
 #
-appnope==0.1.2
-    # via ipython
 atomicwrites==1.4.0
     # via pytest
 attrs==21.2.0
     # via pytest
-backcall==0.2.0
-    # via ipython
-boto3==1.18.28
+boto3==1.18.29
     # via django-storages
-botocore==1.21.28
+botocore==1.21.29
     # via
     #   boto3
     #   s3transfer
@@ -35,10 +31,6 @@ coverage==5.5
     # via pytest-cov
 cssselect==1.1.0
     # via pyquery
-decorator==5.0.9
-    # via
-    #   ipdb
-    #   ipython
 dj-database-url==0.5.0
     # via -r requirements.in
 django==2.0.13
@@ -108,20 +100,10 @@ idna==3.2
     # via
     #   requests
     #   yarl
-importlib-metadata==4.6.4
+importlib-metadata==4.7.1
     # via
     #   pep517
     #   pluggy
-ipdb==0.13.9
-    # via -r requirements.in
-ipython==7.26.0
-    # via
-    #   -r requirements.in
-    #   ipdb
-ipython-genutils==0.2.0
-    # via traitlets
-jedi==0.18.0
-    # via ipython
 jmespath==0.10.0
     # via
     #   boto3
@@ -130,8 +112,6 @@ lxml==4.6.3
     # via pyquery
 markdown2==2.4.1
     # via django-markdown-deux
-matplotlib-inline==0.1.2
-    # via ipython
 more-itertools==8.8.0
     # via pytest
 multidict==5.1.0
@@ -140,28 +120,18 @@ oauth2client==4.1.3
     # via -r requirements.in
 oauthlib==3.1.1
     # via requests-oauthlib
-parso==0.8.2
-    # via jedi
 pep517==0.11.0
     # via pip-tools
-pexpect==4.8.0
-    # via ipython
-pickleshare==0.7.5
-    # via ipython
 pillow==8.2.0
     # via
     #   -r requirements.in
     #   easy-thumbnails
 pip-tools==6.2.0
     # via -r requirements.in
-pluggy==0.13.1
+pluggy==1.0.0
     # via pytest
-prompt-toolkit==3.0.20
-    # via ipython
 psycopg2-binary==2.8.3
     # via -r requirements.in
-ptyprocess==0.7.0
-    # via pexpect
 py==1.10.0
     # via pytest
 py-trello==0.13.0
@@ -175,8 +145,6 @@ pyasn1-modules==0.2.8
     # via
     #   google-auth
     #   oauth2client
-pygments==2.10.0
-    # via ipython
 pyparsing==2.4.7
     # via httplib2
 pyquery==1.4.0
@@ -226,7 +194,7 @@ rsa==4.7.2
     #   oauth2client
 s3transfer==0.5.0
     # via boto3
-sendgrid==6.8.0
+sendgrid==6.8.1
     # via django-sendgrid-v5
 sentry-sdk==1.3.1
     # via -r requirements.in
@@ -248,14 +216,8 @@ starkbank-ecdsa==1.1.1
     # via sendgrid
 stripe==2.60.0
     # via -r requirements.in
-toml==0.10.2
-    # via ipdb
 tomli==1.2.1
     # via pep517
-traitlets==5.0.5
-    # via
-    #   ipython
-    #   matplotlib-inline
 typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
@@ -269,8 +231,6 @@ urllib3==1.26.6
     #   sentry-sdk
 vcrpy==2.0.1
     # via -r requirements.in
-wcwidth==0.2.5
-    # via prompt-toolkit
 wheel==0.37.0
     # via pip-tools
 wrapt==1.12.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,13 +4,17 @@
 #
 #    pip-compile
 #
+appnope==0.1.2
+    # via ipython
 atomicwrites==1.4.0
     # via pytest
 attrs==21.2.0
     # via pytest
-boto3==1.18.22
+backcall==0.2.0
+    # via ipython
+boto3==1.18.28
     # via django-storages
-botocore==1.21.22
+botocore==1.21.28
     # via
     #   boto3
     #   s3transfer
@@ -31,6 +35,10 @@ coverage==5.5
     # via pytest-cov
 cssselect==1.1.0
     # via pyquery
+decorator==5.0.9
+    # via
+    #   ipdb
+    #   ipython
 dj-database-url==0.5.0
     # via -r requirements.in
 django==2.0.13
@@ -83,7 +91,7 @@ future==0.18.2
     # via django-sendgrid-v5
 google-api-python-client==1.7.10
     # via -r requirements.in
-google-auth==2.0.0
+google-auth==2.0.1
     # via
     #   google-api-python-client
     #   google-auth-httplib2
@@ -104,14 +112,26 @@ importlib-metadata==4.6.4
     # via
     #   pep517
     #   pluggy
+ipdb==0.13.9
+    # via -r requirements.in
+ipython==7.26.0
+    # via
+    #   -r requirements.in
+    #   ipdb
+ipython-genutils==0.2.0
+    # via traitlets
+jedi==0.18.0
+    # via ipython
 jmespath==0.10.0
     # via
     #   boto3
     #   botocore
 lxml==4.6.3
     # via pyquery
-markdown2==2.4.0
+markdown2==2.4.1
     # via django-markdown-deux
+matplotlib-inline==0.1.2
+    # via ipython
 more-itertools==8.8.0
     # via pytest
 multidict==5.1.0
@@ -120,8 +140,14 @@ oauth2client==4.1.3
     # via -r requirements.in
 oauthlib==3.1.1
     # via requests-oauthlib
+parso==0.8.2
+    # via jedi
 pep517==0.11.0
     # via pip-tools
+pexpect==4.8.0
+    # via ipython
+pickleshare==0.7.5
+    # via ipython
 pillow==8.2.0
     # via
     #   -r requirements.in
@@ -130,8 +156,12 @@ pip-tools==6.2.0
     # via -r requirements.in
 pluggy==0.13.1
     # via pytest
+prompt-toolkit==3.0.20
+    # via ipython
 psycopg2-binary==2.8.3
     # via -r requirements.in
+ptyprocess==0.7.0
+    # via pexpect
 py==1.10.0
     # via pytest
 py-trello==0.13.0
@@ -145,6 +175,8 @@ pyasn1-modules==0.2.8
     # via
     #   google-auth
     #   oauth2client
+pygments==2.10.0
+    # via ipython
 pyparsing==2.4.7
     # via httplib2
 pyquery==1.4.0
@@ -216,8 +248,14 @@ starkbank-ecdsa==1.1.1
     # via sendgrid
 stripe==2.60.0
     # via -r requirements.in
+toml==0.10.2
+    # via ipdb
 tomli==1.2.1
     # via pep517
+traitlets==5.0.5
+    # via
+    #   ipython
+    #   matplotlib-inline
 typing-extensions==3.10.0.0
     # via
     #   importlib-metadata
@@ -231,6 +269,8 @@ urllib3==1.26.6
     #   sentry-sdk
 vcrpy==2.0.1
     # via -r requirements.in
+wcwidth==0.2.5
+    # via prompt-toolkit
 wheel==0.37.0
     # via pip-tools
 wrapt==1.12.1

--- a/templates/applications/applications.html
+++ b/templates/applications/applications.html
@@ -111,7 +111,7 @@
                         {% endif %}
                       </td>
                       <td>
-                          {% if app|scored_by_user:request.user %}
+                          {% if app.was_scored_by_user %}
                               {{ app.average_score }}
                               <span class="num_votes">({{ app.scores.count }} vote{{ app.scores.count|pluralize }}, &sigma;={{ app.stdev|floatformat:"1" }})</span>
                           {% else %}

--- a/tests/applications/conftest.py
+++ b/tests/applications/conftest.py
@@ -1,0 +1,23 @@
+import pytest
+
+from applications.models import Application, Form, Score
+
+
+@pytest.fixture
+def future_event_form(future_event):
+    return Form.objects.create(event=future_event)
+
+
+@pytest.fixture
+def scored_applications(future_event_form, admin_user):
+    Application.objects.bulk_create(
+        Application(form=future_event_form, email=f"foo+{i}@email.com")
+        for i in range(5)
+    )
+
+    applications = Application.objects.filter(form=future_event_form)
+
+    for i, application in enumerate(applications):
+        Score.objects.create(user=admin_user, application=application, score=i + 1)
+
+    return applications

--- a/tests/applications/test_services.py
+++ b/tests/applications/test_services.py
@@ -1,0 +1,50 @@
+import pytest
+
+from applications.models import Application, Score
+from applications.services import get_applications_for_event
+from core.models import User
+
+
+@pytest.fixture
+def scores_by_other_users(future_event_form):
+    user = User.objects.create(email="user-1@test.com")
+    another_user = User.objects.create(email="user-2@test.com")
+    for i, app in enumerate(Application.objects.filter(form=future_event_form)):
+        # Add some randomization
+        Score.objects.create(application=app, user=user, score=1 if i % 2 == 0 else 4)
+        Score.objects.create(application=app, user=another_user, score=2 if i % 2 == 0 else 5)
+
+
+def test_it_sorts_applications_by_score_excluding_hidden(
+        future_event, scored_applications, admin_user, scores_by_other_users):
+    """Tests if, when the user sorts the applications by average score, we don't include the ones they
+    haven't scored yet.
+
+    For example, consider [these applications](https://cln.sh/JAoo8H) sorted by average score with the
+    previous implementation. We know #1 is higher than 4.375 and #3 is lower than 4.375 and higher than
+    4.25 just because of the sorting."""
+
+    # Delete some of the scores given by the admin user so we can test the sorting
+    Score.objects.filter(user=admin_user, application__in=scored_applications,
+                         pk__gt=scored_applications.count() / 2).delete()
+
+    apps = get_applications_for_event(event=future_event, user=admin_user, order="-average_score")
+    result = [(app.was_scored_by_user, round(app.average_score, 3)) for app in apps]
+    assert result == [
+        (True, 3.667),
+        (True, 1.333),
+        (False, 4.5),
+        (False, 1.5),
+        (False, 1.5),
+    ]
+
+    # Check if the sorting doesn't break if we don't pass `user`
+    apps = get_applications_for_event(event=future_event, order="-average_score")
+    result = [(app.was_scored_by_user, round(app.average_score, 3)) for app in apps]
+    assert result == [
+        (False, 4.5),
+        (False, 3.667),
+        (False, 1.5),
+        (False, 1.5),
+        (False, 1.333)
+    ]

--- a/tests/applications/views/conftest.py
+++ b/tests/applications/views/conftest.py
@@ -1,11 +1,6 @@
 import pytest
 
-from applications.models import Answer, Application, Form
-
-
-@pytest.fixture
-def future_event_form(future_event):
-    return Form.objects.create(event=future_event)
+from applications.models import Answer, Application
 
 
 @pytest.fixture

--- a/tests/applications/views/test_applications.py
+++ b/tests/applications/views/test_applications.py
@@ -1,12 +1,12 @@
 import random
 
 import pytest
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.urls import reverse
 
 from applications.models import Application, Score
 from applications.views import application_list
-from django.db import connection
-from django.test.utils import CaptureQueriesContext
 
 
 def test_access_applications_view(client, user_client, admin_client, future_event):

--- a/tests/applications/views/test_applications.py
+++ b/tests/applications/views/test_applications.py
@@ -1,5 +1,3 @@
-import random
-
 import pytest
 from django.db import connection
 from django.test.utils import CaptureQueriesContext
@@ -265,18 +263,8 @@ def test_changing_application_status_in_bulk(
 
 
 def test_application_scores_is_queried_once(
-        admin_client, future_event_form, future_event, admin_user):
+        admin_client, future_event, scored_applications):
     """Regression test to ensure the scored by user query on applications list page runs only once."""
-
-    # Seed some applications
-    Application.objects.bulk_create(
-        Application(form=future_event_form, email=f"foo+{i}@email.com")
-        for i in range(5)
-    )
-
-    # For every application, create a random score
-    for application in Application.objects.filter(form=future_event_form):
-        Score.objects.create(user=admin_user, application=application, score=random.randint(1, 5))
 
     with CaptureQueriesContext(connection) as queries:
         admin_client.get(

--- a/tests/applications/views/test_applications.py
+++ b/tests/applications/views/test_applications.py
@@ -270,7 +270,8 @@ def test_application_scores_is_queried_once(
         admin_client.get(
             reverse('applications:applications', kwargs={'city': future_event.page_url}))
 
-    score_queries = [q for q in queries.captured_queries if 'applications_score' in q['sql']]
+    score_table_name = Score._meta.db_table
+    score_queries = [q for q in queries.captured_queries if score_table_name in q['sql']]
 
     # The first query is for the annotation in get_applications_for_event, the second is for the scores themselves
     assert len(score_queries) == 2


### PR DESCRIPTION
This PR changes a few things:
* Optimize the applications scored_by_user query so we don't query if the user has scored a given application line by line
	* I added a test to make sure we're not doing any extra queries, but can remove if it's unnecessary
	* It's possible to optimize even further if we use annotations instead of properties in some places (e.g. `stdev`), paginate the applications, etc. but I didn't want to add more complexity to the PR, let me know if I should work on that
* Correctly anonymize sorting by `average_score` - now unscored applications will be at the end (added a test for that too)
* Move `get_applications_for_event` and `get_random_application` from `applications.questions` to `applications.services` (the `questions` module seemed to be more related to the form generation rather than anything else, but I don't have 100% context with the project so let me know if I should change it back)
* Add [ipdb](https://pypi.org/project/ipdb/) and [ipython](https://ipython.readthedocs.io/en/stable/) modules just for ease of local debugging/development (do we want to separate prod/dev requirements at some point?)
	* I think pip-tools ended up updating some of the libs when I ran `pip-compile -U`

### Sorting by average score

<table>
<tr>
	<td>Before
	<td>After
<tr>
<td>


https://user-images.githubusercontent.com/23136832/130745338-2e207b01-580a-40ad-85dc-6cb9a371ed3a.mp4
<td>

https://user-images.githubusercontent.com/23136832/130745159-4a4367a6-a14a-4b36-97e5-37208d8aa521.mp4
</table>

Tried to add comments to whatever I changed, but let me know if anything isn't clear enough, happy to improve if needed 🙂 

(Closes #382)