### PR TITLE
Remove suit template tag

### DIFF
--- a/templates/admin/organize/eventapplication/view_change_status.html
+++ b/templates/admin/organize/eventapplication/view_change_status.html
@@ -1,6 +1,5 @@
 {% extends "admin/base_site.html" %}
 {% load i18n admin_urls %}
-{% load url from suit_compat %}
 
 
 {% block content %}


### PR DESCRIPTION
There is a `suit_compat` that is breaking the `templates/admin/organize/view_change_status.html` template. This PR removes it.