### PR TITLE
Removed email subject translations.

### DIFF
--- a/core/emails.py
+++ b/core/emails.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.mail import EmailMessage
 from django.template.loader import render_to_string
-from django.utils.translation import gettext_lazy as _
 
 
 def notify_existing_user(user, event):
@@ -12,7 +11,7 @@ def notify_existing_user(user, event):
         'user': user,
         'event': event
     })
-    subject = _('You have been granted access to new Django Girls event')
+    subject = 'You have been granted access to new Django Girls event'
     send_email(content, subject, [user.email])
 
 
@@ -26,7 +25,7 @@ def notify_new_user(user, event, password, errors=None):
         'password': password,
         'errors': errors,
     })
-    subject = _('Access to Django Girls website')
+    subject = 'Access to Django Girls website'
     send_email(content, subject, [user.email])
 
 

--- a/organize/emails.py
+++ b/organize/emails.py
@@ -1,5 +1,4 @@
 from django.template.loader import render_to_string
-from django.utils.translation import gettext_lazy as _
 
 from core.emails import send_email
 

--- a/organize/emails.py
+++ b/organize/emails.py
@@ -6,7 +6,7 @@ from core.emails import send_email
 
 def send_application_confirmation(event_application):
     subject = (
-        _("Confirmation of application to organise Django Girls %(city)s workshop") % {'city': event_application.city}
+        f"Confirmation of application to organise Django Girls {event_application.city} workshop"
     )
     content = render_to_string(
         'emails/organize/application_confirmation.html',
@@ -23,9 +23,7 @@ def send_application_notification(event_application):
     who applied
     """
     subject = (
-        _("New request to organise Django Girls %(city)s, %(country)s") % {
-            'city': event_application.city, 'country': event_application.get_country_display()
-        }
+        f"New request to organise Django Girls {event_application.city}, {event_application.get_country_display()}"
     )
     content = render_to_string(
         'emails/organize/application_notification.html', {
@@ -37,9 +35,7 @@ def send_application_notification(event_application):
 
 def send_application_deployed_email(event_application, event, email_password):
     subject = (
-        _("Congrats! Your application to organize Django Girls %(city)s has been accepted!") % {
-            'city': event_application.city
-        }
+        f"Congrats! Your application to organize Django Girls {event_application.city} has been accepted!"
     )
     content = render_to_string('emails/organize/event_deployed.html', {
         'event': event,
@@ -54,7 +50,7 @@ def send_application_rejection_email(event_application):
     """ Sends a rejection email to all organizers who created this application
     """
     subject = (
-        _("Application to organize Django Girls %(city)s has been reviewed") % {'city': event_application.city}
+        f"Application to organize Django Girls {event_application.city} has been reviewed"
     )
     content = render_to_string('emails/organize/rejection.html', {
         'application': event_application

--- a/requirements.in
+++ b/requirements.in
@@ -19,6 +19,7 @@ django-unused-media==0.1.13
 django>=2.2,<3
 django-sendgrid-v5==0.8.1
 easy-thumbnails==2.6
+flake8
 freezegun==0.3.11
 google-api-python-client==1.7.10
 icalendar==4.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -83,6 +83,8 @@ django-unused-media==0.1.13
     # via -r requirements.in
 easy-thumbnails==2.6
     # via -r requirements.in
+flake8==3.9.2
+    # via -r requirements.in
 freezegun==0.3.11
     # via -r requirements.in
 future==0.18.2
@@ -108,6 +110,7 @@ idna==3.2
     #   yarl
 importlib-metadata==4.7.1
     # via
+    #   flake8
     #   pep517
     #   pluggy
 jmespath==0.10.0
@@ -118,6 +121,8 @@ lxml==4.6.3
     # via pyquery
 markdown2==2.4.1
     # via django-markdown-deux
+mccabe==0.6.1
+    # via flake8
 more-itertools==8.8.0
     # via pytest
 multidict==5.1.0
@@ -151,6 +156,10 @@ pyasn1-modules==0.2.8
     # via
     #   google-auth
     #   oauth2client
+pycodestyle==2.7.0
+    # via flake8
+pyflakes==2.3.1
+    # via flake8
 pyparsing==2.4.7
     # via httplib2
 pyquery==1.4.0


### PR DESCRIPTION
This removes translated email subjects to fix sentry error DJANGO-GIRLS-WEBSITE-E

Translation of emails would require a more complex process of storing a preferred language for a user and then making use of that in sending that user emails. So the translated stings here are pointless without that functionality.