### PR TITLE
Replaced `django-codemirror-widget` with `django-tinymce`

### DIFF
--- a/core/admin/forms/event_page_content.py
+++ b/core/admin/forms/event_page_content.py
@@ -1,40 +1,12 @@
-from codemirror import CodeMirrorTextarea
 from django import forms
-from django.utils.safestring import mark_safe
-
-
-class ResizableCodeMirror(CodeMirrorTextarea):
-
-    def __init__(self, **kwargs):
-        super().__init__(js_var_format='%s_editor', **kwargs)
-
-    @property
-    def media(self):
-        mine = forms.Media(
-            css={'all': ('vendor/jquery-ui/jquery-ui.min.css',)},
-            js=('vendor/jquery-ui/jquery-ui.min.js',))
-        return super().media + mine
-
-    def render(self, name, value, attrs=None):
-        output = super().render(name, value, attrs)
-        return output + mark_safe(
-            '''
-                <script type="text/javascript">
-                $('.CodeMirror').resizable({
-                  resize: function() {
-                    %s_editor.setSize($(this).width(), $(this).height());
-                  }
-                });
-                </script>
-            ''' % name
-        )
+from tinymce.widgets import AdminTinyMCE
 
 
 class EventPageContentForm(forms.ModelForm):
 
     class Meta:
         widgets = {
-            'content': ResizableCodeMirror(mode="xml")
+            'content': AdminTinyMCE()
         }
         fields = (
             'event',

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'captcha',
     'django_countries',
     'gulp_rev',
+    'tinymce',
 
     'core',
     'applications',
@@ -237,9 +238,6 @@ JOBS_EMAIL_PASSWORD = os.environ.get('JOBS_EMAIL_PASSWORD')
 
 MEETUPS_EMAIL_USER = os.environ.get('MEETUPS_EMAIL_USER')
 MEETUPS_EMAIL_PASSWORD = os.environ.get('MEETUPS_EMAIL_PASSWORD')
-
-CODEMIRROR_PATH = "vendor/codemirror/"
-
 
 GAPPS_ADMIN_SDK_SCOPES = 'https://www.googleapis.com/auth/admin.directory.user'
 GAPPS_PRIVATE_KEY_ID = os.environ.get('GAPPS_PRIVATE_KEY_ID', '')

--- a/djangogirls/urls.py
+++ b/djangogirls/urls.py
@@ -43,6 +43,7 @@ urlpatterns += i18n_patterns(
         RedirectView.as_view(url='/account/password_reset', permanent=True),
         name='admin_password_reset'
     ),
+    path('tinymce/', include('tinymce.urls')),
 
     # Regular links:
     path('admin/', admin.site.urls),

--- a/requirements.in
+++ b/requirements.in
@@ -3,7 +3,7 @@ dj-database-url==0.5.0
 django-admin-sortable2
 django-autoslug==1.9.4
 django-click==2.1.0
-django-codemirror-widget==0.4.1
+django-tinymce
 django-countries==5.3.3
 django-date-extensions==3.0
 django-debug-toolbar

--- a/requirements.txt
+++ b/requirements.txt
@@ -55,8 +55,6 @@ django-autoslug==1.9.4
     # via -r requirements.in
 django-click==2.1.0
     # via -r requirements.in
-django-codemirror-widget==0.4.1
-    # via -r requirements.in
 django-countries==5.3.3
     # via -r requirements.in
 django-date-extensions==3.0
@@ -78,6 +76,8 @@ django-recaptcha==1.4.0
 django-sendgrid-v5==0.8.1
     # via -r requirements.in
 django-storages[boto3]==1.7.1
+    # via -r requirements.in
+django-tinymce==3.3.0
     # via -r requirements.in
 django-unused-media==0.1.13
     # via -r requirements.in


### PR DESCRIPTION
This fixes #678 and replaces the widget for page content (HTML widget).

`django-codemirror-widget` doesn't appear to be maintained anymore so needed replacing and TinyMCE seems a suitable replacement.