### PR TITLE
Change reply-to email to send to main organizer only

### DIFF
--- a/organize/emails.py
+++ b/organize/emails.py
@@ -29,7 +29,7 @@ def send_application_notification(event_application):
             'application': event_application,
         })
     send_email(content, subject, ['hello@djangogirls.org'],
-               reply_to=event_application.get_organizers_emails())
+               reply_to=event_application.get_main_organizer_email())
 
 
 def send_application_deployed_email(event_application, event, email_password):

--- a/organize/models.py
+++ b/organize/models.py
@@ -274,6 +274,9 @@ class EventApplication(models.Model):
         emails.append(self.main_organizer_email)
         return emails
 
+    def get_main_organizer_email(self):
+        return self.main_organizer_email
+
     def get_main_organizer_name(self):
         return '{} {}'.format(
             self.main_organizer_first_name,


### PR DESCRIPTION
Sendgrid only allows only 1 email address in the reply-to email. This is causing the email notifications to fail when a new event application is submitted. This pull request fixes this issue.