### PR TITLE
Fix homepage broken link on logo

### DIFF
--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -10,7 +10,7 @@
                 <span class="icon-bar"></span>
             </button>
             <div class="logo">
-                <a href="/">
+                <a href="{% url 'core:index' %}">
                     <img src="{% static 'img/global/logo.png' %}" alt="Django Girls" />
                 </a>
             </div>


### PR DESCRIPTION
This pull request fixes #686 by using `{% URL 'core:index'  %}` to refer to homepage link instead of `/` on the logo in `template/global/menu.html`.