### PR TITLE
Add code plugin to tinymce widget

### DIFF
--- a/core/admin/forms/event_page_content.py
+++ b/core/admin/forms/event_page_content.py
@@ -1,12 +1,26 @@
+import copy
+
+import tinymce
+
 from django import forms
 from tinymce.widgets import AdminTinyMCE
+
+
+default_tinymce_config = copy.deepcopy(tinymce.settings.DEFAULT_CONFIG)
+default_tinymce_config['plugins'] += ' | code'
+default_tinymce_config['toolbar'] += ' | code'
 
 
 class EventPageContentForm(forms.ModelForm):
 
     class Meta:
         widgets = {
-            'content': AdminTinyMCE()
+            'content': AdminTinyMCE(
+                mce_attrs={
+                    'plugins': default_tinymce_config['plugins'],
+                    'toolbar': default_tinymce_config['toolbar'],
+                },
+            )
         }
         fields = (
             'event',

--- a/core/admin/forms/event_page_content.py
+++ b/core/admin/forms/event_page_content.py
@@ -1,14 +1,7 @@
-import copy
-
 import tinymce
 
 from django import forms
 from tinymce.widgets import AdminTinyMCE
-
-
-default_tinymce_config = copy.deepcopy(tinymce.settings.DEFAULT_CONFIG)
-default_tinymce_config['plugins'] += ' | code'
-default_tinymce_config['toolbar'] += ' | code'
 
 
 class EventPageContentForm(forms.ModelForm):
@@ -17,8 +10,8 @@ class EventPageContentForm(forms.ModelForm):
         widgets = {
             'content': AdminTinyMCE(
                 mce_attrs={
-                    'plugins': default_tinymce_config['plugins'],
-                    'toolbar': default_tinymce_config['toolbar'],
+                    'plugins': tinymce.settings.DEFAULT_CONFIG['plugins'] + ' | code',
+                    'toolbar': tinymce.settings.DEFAULT_CONFIG['toolbar'] + ' | code',
                 },
             )
         }


### PR DESCRIPTION
Closes #688 

It was a bit tricky because of the way `django-tinymce` allows to modify the default settings..
If I just add the `code` plugin it overwrites the default `plugins` setting, same thing for `toolbar`, which results on an empty toolbar with the code widget.

Might not be the most beautiful implementation, but works as expected.

![image](https://user-images.githubusercontent.com/5559120/134598069-f914b784-dc7e-4eef-95a3-c4f9351a0cad.png)
![image](https://user-images.githubusercontent.com/5559120/134598078-92730852-6981-460b-ad8d-67a2b0c2b068.png)
