### PR TITLE
Make get_main_organizer_email() return a list

### DIFF
--- a/organize/models.py
+++ b/organize/models.py
@@ -274,7 +274,7 @@ class EventApplication(models.Model):
         return emails
 
     def get_main_organizer_email(self):
-        return self.main_organizer_email
+        return [self.main_organizer_email]
 
     def get_main_organizer_name(self):
         return f'{self.main_organizer_first_name} {self.main_organizer_last_name}'


### PR DESCRIPTION
Sendgrid `reply_to` can only take one email address while Django expects a list or tuple for `reply_to`. This PR makes `get_main_organizer_email()` return a list. Fixes #702 