### PR TITLE
Change support us to donate to us on menu

### DIFF
--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -25,7 +25,7 @@
                 <li><a href="{% url 'core:contribute' %}">{% trans "Contribute" %}</a></li>
 
                  <li class="dropdown">
-                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{% trans "Support us 💕" %} <span class="caret"></span></a>
+                     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">{% trans "Donate to us 💕" %} <span class="caret"></span></a>
                      <ul class="dropdown-menu">
                          <li><a href="{% url 'donations:index' %}">{% trans "Donate" %}</a></li>
                          <li><a href="https://www.patreon.com/djangogirls">{% trans "Our Patreon page" %}</a></li>


### PR DESCRIPTION
Prospective donors are failing to find our donate page and the new stripe form because they visit the `Contribute` page instead of the `Support us` dropdown link to find the `Donate` link. This pull request renames the `Support us` link to `Donate to us` for easy visibility.