### PR TITLE
Upgrade to google-api-python-client 2.37.0 to fix errors

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -21,7 +21,7 @@ django-sendgrid-v5==0.8.1
 easy-thumbnails
 flake8
 freezegun
-google-api-python-client==1.7.10
+google-api-python-client==2.37.0
 icalendar==4.0.3
 oauth2client==4.1.3
 pillow==8.3.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,14 +86,19 @@ freezegun==1.1.0
     # via -r requirements.in
 future==0.18.2
     # via django-sendgrid-v5
-google-api-python-client==1.7.10
+google-api-core==1.28.0
+    # via google-api-python-client
+google-api-python-client==2.37.0
     # via -r requirements.in
-google-auth==2.1.0
+google-auth==1.35.0
     # via
+    #   google-api-core
     #   google-api-python-client
     #   google-auth-httplib2
 google-auth-httplib2==0.1.0
     # via google-api-python-client
+googleapis-common-protos==1.53.0
+    # via google-api-core
 httplib2==0.19.1
     # via
     #   google-api-python-client
@@ -105,6 +110,12 @@ idna==3.2
     # via
     #   requests
     #   yarl
+importlib-metadata==4.7.1
+    # via
+    #   flake8
+    #   pep517
+    #   pluggy
+    #   pytest
 iniconfig==1.1.1
     # via pytest
 jmespath==0.10.0
@@ -124,7 +135,9 @@ oauth2client==4.1.3
 oauthlib==3.1.1
     # via requests-oauthlib
 packaging==21.0
-    # via pytest
+    # via
+    #   google-api-core
+    #   pytest
 pep517==0.11.0
     # via pip-tools
 pillow==8.3.2
@@ -135,6 +148,10 @@ pip-tools==6.2.0
     # via -r requirements.in
 pluggy==1.0.0
     # via pytest
+protobuf==3.17.1
+    # via
+    #   google-api-core
+    #   googleapis-common-protos
 psycopg2-binary==2.8.3
     # via -r requirements.in
 py==1.10.0
@@ -192,12 +209,14 @@ python-http-client==3.3.2
 pytz==2021.1
     # via
     #   django
+    #   google-api-core
     #   icalendar
     #   py-trello
 pyyaml==5.4.1
     # via vcrpy
 requests==2.26.0
     # via
+    #   google-api-core
     #   py-trello
     #   requests-oauthlib
     #   slacker
@@ -212,15 +231,17 @@ s3transfer==0.5.0
     # via boto3
 sendgrid==6.8.1
     # via django-sendgrid-v5
-sentry-sdk==1.3.1
+sentry-sdk==1.5.4
     # via -r requirements.in
 six==1.16.0
     # via
     #   django-click
     #   django-unused-media
-    #   google-api-python-client
+    #   google-api-core
+    #   google-auth
     #   google-auth-httplib2
     #   oauth2client
+    #   protobuf
     #   python-dateutil
     #   vcrpy
 slacker==0.9.65
@@ -239,6 +260,11 @@ toml==0.10.2
     #   pytest-cov
 tomli==1.2.1
     # via pep517
+typing-extensions==3.10.0.0
+    # via
+    #   asgiref
+    #   importlib-metadata
+    #   yarl
 uritemplate==3.0.1
     # via google-api-python-client
 urllib3==1.26.6
@@ -248,12 +274,16 @@ urllib3==1.26.6
     #   sentry-sdk
 vcrpy==4.1.1
     # via -r requirements.in
-wheel==0.37.0
+wheel==0.37.1
     # via pip-tools
 wrapt==1.12.1
     # via vcrpy
 yarl==1.6.3
     # via vcrpy
+zipp==3.5.0
+    # via
+    #   importlib-metadata
+    #   pep517
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
This PR updates google-api-python-client from version 1.7.10 ([v1](https://github.com/googleapis/google-api-python-client/tree/v1))to version 2.37.0 ([v2](https://pypi.org/project/google-api-python-client/2.37.0/)) to fix #723 which is being caused by no cache mechanism when using oauth2client >= 4.0.0 or google-auth. This should fix the `file_cache is unavailable when using oauth2client >= 4.0.0 or google-auth`.