### PR TITLE
Remove mandrill

### DIFF
--- a/applications/questions.py
+++ b/applications/questions.py
@@ -158,7 +158,7 @@ DEFAULT_QUESTIONS = [
             "Data collected through this form is used only for the "
             "purpose of Django Girls events. We're using Third Party Sites "
             "and Services to make it happen: for example, we're using "
-            "Mandrill to send you emails. Don't worry: We don't share your data with spammers, "
+            "Sendgrid to send you emails. Don't worry: We don't share your data with spammers, "
             "and we don't sell it! More info on our Privacy policy "
             "<a href='/privacy-cookies/'>here</a>."
         ),

--- a/contact/models.py
+++ b/contact/models.py
@@ -45,7 +45,6 @@ class ContactEmail(models.Model):
             [self.sent_to],
             reply_to=[f"{self.name} <{self.email}>"],
             headers={'Reply-To': f"{self.name} <{self.email}>"}
-            # Seems like this is needed for Mandrill
         )
         try:
             email.send(fail_silently=False)

--- a/templates/global/footer.html
+++ b/templates/global/footer.html
@@ -21,7 +21,7 @@
                     <li><a href="{% url 'donations:index' %}">{% trans "Make a donation" %}</a></li>
                     <li><a href="https://www.patreon.com/djangogirls">{% trans "Donate on Patreon" %}</a></li>
                     <li><a href="{% url 'core:contribute' %}">{% trans "Contribute" %}</a></li>
-                    <li><a href="https://goo.gl/P9YbdI">{% trans "Sponsor us" %}</a></li>
+                    <li><a href="https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing">{% trans "Sponsor us" %}</a></li>
                 </ul>
             </div>
             <div class="col-md-2">


### PR DESCRIPTION
There are still some references to Mandrill in the project and in the environment variables on the server. These sometimes break the website so this PR seeks to remove all references to Mandrill in the project to avoid confusion on the email backend in use.