### PR TITLE
Pass stripe error in the session and improve success and error templates (#478)

### DIFF
--- a/templates/donations/error.html
+++ b/templates/donations/error.html
@@ -2,13 +2,18 @@
 {% load i18n static %}
 
 {% block content %}
-	<div id="box">
-		<h4>{% trans "Error" %}</h4>
-		<p>
-            {% trans "Sorry, an error has occurred" %}
-        </p>
-		<hr>
-		<a class="myButton" href="{% url 'donations:index' %}">&#x2190;{% trans "Back to donation page" %}</a>
+	<div class="container">
+        <div class="row">
+            <h4>{% trans "Error" %}</h4>
+            <p>
+                {% trans "Sorry, an error has occurred" %}
+            </p>
+            {% if stripe_message %}
+                <p>{{ stripe_message }}</p>
+            {% endif %}
+            <hr>
+            <a class="myButton" href="{% url 'donations:index' %}">&#x2190;&nbsp;{% trans "Back to donation page" %}</a>
+        </div>
 	</div>
 
 {% endblock content %}

--- a/templates/donations/success.html
+++ b/templates/donations/success.html
@@ -2,14 +2,16 @@
 {% load i18n static %}
 
 {% block content %}
-	<div id="box">
-		<h4>
-            {% blocktrans trimmed with currency=currency amount=amount %}
-                Thank you for your contribution of {{ currency }}{{amount}}!
-            {% endblocktrans %}
-        </h4>
-		<hr>
-		<a class="myButton" href="{% url 'donations:index' %}">&#x2190;{% trans "Back to donation page" %}</a>
+	<div class="container">
+        <div class="row">
+            <h4>
+                {% blocktrans trimmed with currency=currency amount=amount %}
+                    Thank you for your contribution of {{ currency }}{{amount}}!
+                {% endblocktrans %}
+            </h4>
+            <hr>
+            <a class="myButton" href="{% url 'donations:index' %}">&#x2190;&nbsp;{% trans "Back to donation page" %}</a>
+        </div>
 	</div>
 
 {% endblock content %}


### PR DESCRIPTION
This passes stripe errors through to the error template using the session so that the user gets a more detailed response to explain what went wrong.

This will resolve;
#478 
https://sentry.io/share/issue/bdb8bdbee6d24bd3bdd808b7f502b0fd/