### PR TITLE
Remove distinct from the coaches queryset to allow deletion. [#739]

### DIFF
--- a/coach/admin.py
+++ b/coach/admin.py
@@ -18,7 +18,7 @@ class CoachAdmin(admin.ModelAdmin):
         qs = super().get_queryset(request)
         if request.user.is_superuser:
             return qs
-        return qs.filter(eventpagecontent__event__team=request.user).distinct()
+        return qs.filter(eventpagecontent__event__team=request.user)
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)


### PR DESCRIPTION
In #739 we can see that non-superusers are unable to delete coaches due to the `.distinct()` on their queryset.

As long as they should be able to delete coaches, this removes the `.distinct()` which should therefore allow the deletion by no longer throwing an error.