### PR TITLE
Fix triaging options for a deployed event [#758]

### DIFF
--- a/organize/admin.py
+++ b/organize/admin.py
@@ -4,7 +4,7 @@ from django.urls import path
 from django.utils.translation import gettext_lazy as _
 
 from .models import EventApplication, Coorganizer
-from .constants import ON_HOLD, IN_REVIEW, REJECTED, ACCEPTED
+from .constants import ON_HOLD, IN_REVIEW, REJECTED, ACCEPTED, DEPLOYED
 
 
 class InlineCoorganizerAdmin(admin.TabularInline):
@@ -146,7 +146,13 @@ class EventApplicationAdmin(admin.ModelAdmin):
         """
         application = get_object_or_404(EventApplication, id=application_id)
 
-        if new_status in [IN_REVIEW, ON_HOLD]:
+        if application.status is DEPLOYED:
+            messages.error(request, _('The application is already deployed'))
+            return redirect(
+                'admin:organize_eventapplication_change',
+                application.id
+            )
+        elif new_status in [IN_REVIEW, ON_HOLD]:
             application.change_status_to(new_status)
         elif new_status in [REJECTED, ACCEPTED]:
             if request.method == 'GET':
@@ -161,12 +167,15 @@ class EventApplicationAdmin(admin.ModelAdmin):
                     application.reject()
                 else:
                     event = application.deploy()
-                    application.send_deployed_email(event)
+                    if event:
+                        # deploy returns None if it is already deployed
+                        application.send_deployed_email(event)
         else:
             messages.error(request, _('Invalid status provided for application'))
             return redirect(
                 'admin:organize_eventapplication_change',
-                application.id)
+                application.id
+            )
 
         messages.success(
             request,

--- a/organize/models.py
+++ b/organize/models.py
@@ -221,7 +221,6 @@ class EventApplication(models.Model):
 
         self.change_status_to(DEPLOYED)
 
-        event = None
         previous_event = (
             Event.objects
             .filter(city=self.city, country=self.get_country_display())

--- a/templates/admin/organize/eventapplication/change_form.html
+++ b/templates/admin/organize/eventapplication/change_form.html
@@ -10,7 +10,7 @@
     <div class="row mb-3">
         <h4 class="italic-title">{% trans "Triaging" %}</h4>
         <div class="box save-box">
-          {% if original.status != 'rejected' and original.status != 'accepted' %}
+          {% if original.status != 'rejected' and original.status != 'accepted' and original.status != 'deployed' %}
             <a class="btn btn-outline-success" href="{% url 'admin:organize_eventapplication_change_application_status' original.pk 'accepted' %}">
               {% trans "Accept application" %}
             </a>
@@ -23,6 +23,8 @@
             <a class="btn btn-outline-danger" href="{% url 'admin:organize_eventapplication_change_application_status' original.pk 'rejected' %}">
               {% trans "Reject application" %}
             </a>
+          {% elif original.status == 'deployed' %}
+              {% trans "Application deployed." %}
           {% else %}
             {% trans "Application closed." %}
           {% endif %}


### PR DESCRIPTION
Correct me if I'm wrong, but based on the error in #758 the triaging options shouldn't be available to deployed events.

This change will hide the triaging buttons for a deployed event and instead display "Application deployed."