### PR TITLE
Fix the homepage link to Sentry.

### DIFF
--- a/templates/includes/_main_supporters.html
+++ b/templates/includes/_main_supporters.html
@@ -8,7 +8,7 @@
         </a>
     </div>
     <div class="col-md-3">
-        <a href="https://www.sentry.com/">
+        <a href="https://sentry.io/welcome/">
             <img class="img-responsive center-block" src="{% static 'img/global/supporters/sentry.png' %}"
                  alt="Sentry" style="margin-top: 25px" />
         </a>


### PR DESCRIPTION
From the logo, I believe the link was intended to point to https://sentry.io/welcome/ rather than https://www.sentry.com/.