### PR TITLE
Add robots.txt and sitemap.xml routes on the website

### DIFF
--- a/core/urls.py
+++ b/core/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import TemplateView
 
 from . import views
 
@@ -23,5 +24,7 @@ urlpatterns = [
     # path(r'^crowdfunding-donors/$', views.crowdfunding_donors, name='crowdfunding-donors'),
     path('server-error/', views.server_error, name='server_error'),
     path('<slug:page_url>/', views.event, name='event'),
+    path('robots.txt', TemplateView.as_view(
+        template_name="core/txt/robots.txt", content_type='text/plain'), name="robots"),
     path('', views.index, name='index'),
 ]

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -39,6 +39,7 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'django.contrib.flatpages',
+    'django.contrib.sitemaps',
 
     'adminsortable2',
     'django_date_extensions',

--- a/story/models.py
+++ b/story/models.py
@@ -14,6 +14,9 @@ class Story(models.Model):
     def __str__(self):
         return self.name
 
+    def get_absolute_url(self):
+        return self.post_url
+
     class Meta:
         verbose_name = _("story")
         verbose_name_plural = _("stories")

--- a/story/sitemap.py
+++ b/story/sitemap.py
@@ -1,0 +1,13 @@
+from django.contrib.sitemaps import Sitemap
+
+from .models import Story
+
+
+class BlogSiteMap(Sitemap):
+    priority = 0.5
+
+    def items(self):
+        return Story.objects.all()
+
+    def lastmod(self, obj):
+        return obj.created

--- a/story/urls.py
+++ b/story/urls.py
@@ -1,8 +1,15 @@
 from django.urls import path
+from django.contrib.sitemaps.views import sitemap
 
 from story.views import StoryListView
+from story.sitemap import BlogSiteMap
+
+sitemaps = {
+    "blog": BlogSiteMap
+}
 
 app_name = "story"
 urlpatterns = [
     path('', StoryListView.as_view(), name='stories'),
+    path('/sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
 ]

--- a/templates/core/txt/robots.txt
+++ b/templates/core/txt/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+Disallow: /admin/
+Disallow: /accounts/

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -325,3 +325,8 @@ def test_crowdfunding_donors(client, visible_donors, hidden_donors):
     visible_donors = set(visible_donor.pk for visible_donor in visible_donors)
     assert donor_ids == visible_donors
 """
+
+
+def test_robots_txt_view(client):
+    response = client.get(reverse('core:robots'))
+    assert response.status_code == 200

--- a/tests/story/conftest.py
+++ b/tests/story/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from story.models import Story
+
 
 @pytest.fixture
 def data_dict():
@@ -20,3 +22,16 @@ def data_dict():
         'is_story': True,
         'post_url': 'story-1-url',
     }
+
+
+@pytest.fixture
+def blog_posts(db):
+    return Story.objects.bulk_create(
+        [
+            Story(name='Post 1', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-1-url'),
+            Story(name='Post 2', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-2-url'),
+            Story(name='Post 3', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-3-url'),
+            Story(name='Post 4', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-4-url'),
+            Story(name='Post 5', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-5-url')
+        ]
+    )


### PR DESCRIPTION
This PR adds a robots.txt and sitemap.xml to the website to enable our website to be crawled by robots and indexed by search engines such as Google. This is the first step in addressing issue #766. Would need to submit the website's sitemap to [Google](https://support.google.com/webmasters/answer/7451001?hl=en#zippy=%2Csubmit-a-sitemap) to enable our blog posts to be indexed and create more visibility for our blog and sponsors.