### PR TITLE
Remove `/` in the sitemap url

### DIFF
--- a/story/urls.py
+++ b/story/urls.py
@@ -11,5 +11,5 @@ sitemaps = {
 app_name = "story"
 urlpatterns = [
     path('', StoryListView.as_view(), name='stories'),
-    path('/sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
 ]


### PR DESCRIPTION
Just got a warning on the server about a trailing `/` after deploying #772 so this pull request addresses the warning.