### PR TITLE
Add Google site verification to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ static/rev-manifest.json
 temp/
 .environment
 htmlcov
+google3ef9938c7b93b707.html


### PR DESCRIPTION
I have just registered djangogirls.org and need to add the HTML file I am adding to the project on the server to .gitignore so that future deployments don't fail because of the server containing a file not in the project.