### PR TITLE
Fix broken sitemap.xml url

### DIFF
--- a/core/sitemap.py
+++ b/core/sitemap.py
@@ -1,0 +1,21 @@
+from django.contrib.sitemaps import Sitemap
+from django.shortcuts import reverse
+
+
+class StaticViewSitemap(Sitemap):
+
+    def items(self):
+        return ['core:index',
+                'core:foundation',
+                'core:foundation-governing-document',
+                'core:contribute',
+                'core:year_2015',
+                'core:year_2016_2017',
+                'core:events',
+                'core:newsletter',
+                'core:resources',
+                'donations:index',
+                'organize:index']
+
+    def location(self, item):
+        return reverse(item)

--- a/core/urls.py
+++ b/core/urls.py
@@ -1,7 +1,15 @@
 from django.urls import path
 from django.views.generic import TemplateView
+from django.contrib.sitemaps.views import sitemap
 
 from . import views
+from .sitemap import StaticViewSitemap
+from story.sitemap import BlogSiteMap
+
+sitemaps = {
+    "website": StaticViewSitemap,
+    "blog": BlogSiteMap
+}
 
 app_name = "core"
 urlpatterns = [
@@ -29,4 +37,5 @@ urlpatterns = [
     path('', views.index, name='index'),
     path('google3ef9938c7b93b707.html', TemplateView.as_view(
         template_name="google3ef9938c7b93b707.html"), name="google_site_verification"),
+    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
 ]

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -39,7 +39,6 @@ INSTALLED_APPS = [
     'django.contrib.staticfiles',
     'django.contrib.sites',
     'django.contrib.flatpages',
-    'django.contrib.sitemaps',
 
     'adminsortable2',
     'django_date_extensions',
@@ -63,6 +62,7 @@ INSTALLED_APPS = [
     'contact',
     'pictures',
     'donations',
+    'django.contrib.sitemaps',
 ]
 
 MIDDLEWARE = [

--- a/story/sitemap.py
+++ b/story/sitemap.py
@@ -9,5 +9,13 @@ class BlogSiteMap(Sitemap):
     def items(self):
         return Story.objects.all()
 
+    def location(self, item):
+        url = item.post_url
+        return url.replace('https://', '')
+
     def lastmod(self, obj):
         return obj.created
+
+    def _urls(self, page, protocol, domain):
+        return super(BlogSiteMap, self)._urls(
+            page=page, protocol='https', domain='')

--- a/story/urls.py
+++ b/story/urls.py
@@ -1,15 +1,8 @@
 from django.urls import path
-from django.contrib.sitemaps.views import sitemap
 
 from story.views import StoryListView
-from story.sitemap import BlogSiteMap
-
-sitemaps = {
-    "blog": BlogSiteMap
-}
 
 app_name = "story"
 urlpatterns = [
     path('', StoryListView.as_view(), name='stories'),
-    path('sitemap.xml', sitemap, {'sitemaps': sitemaps}, name='sitemap'),
 ]

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -3,6 +3,7 @@ import pytest
 from coach.models import Coach
 from core.models import EventPageContent, EventPageMenu
 from sponsor.models import Sponsor
+from story.models import Story
 
 
 @pytest.fixture()
@@ -56,4 +57,17 @@ def past_event_menu(past_event):
         position=10,
         event=past_event,
         title="FAQ"
+    )
+
+
+@pytest.fixture
+def blog_posts(db):
+    return Story.objects.bulk_create(
+        [
+            Story(name='Post 1', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-1-url'),
+            Story(name='Post 2', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-2-url'),
+            Story(name='Post 3', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-3-url'),
+            Story(name='Post 4', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-4-url'),
+            Story(name='Post 5', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-5-url')
+        ]
     )

--- a/tests/story/conftest.py
+++ b/tests/story/conftest.py
@@ -1,7 +1,5 @@
 import pytest
 
-from story.models import Story
-
 
 @pytest.fixture
 def data_dict():
@@ -22,16 +20,3 @@ def data_dict():
         'is_story': True,
         'post_url': 'story-1-url',
     }
-
-
-@pytest.fixture
-def blog_posts(db):
-    return Story.objects.bulk_create(
-        [
-            Story(name='Post 1', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-1-url'),
-            Story(name='Post 2', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-2-url'),
-            Story(name='Post 3', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-3-url'),
-            Story(name='Post 4', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-4-url'),
-            Story(name='Post 5', content='Lorem ipsum dolor sit amet', is_story=False, post_url='post-5-url')
-        ]
-    )

--- a/tests/story/test_urls.py
+++ b/tests/story/test_urls.py
@@ -1,6 +1,0 @@
-from django.urls import reverse
-
-
-def test_blog_sitemap_url(client, blog_posts):
-    response = client.get(reverse('story:sitemap'))
-    assert response.status_code == 200


### PR DESCRIPTION
The sitemap.xml link is broken due to being in `story` app instead of `core`. This PR fixes this and sets up the sitemap properly, including sitemap for both our static pages and blog stories.