### PR TITLE
Add order_by to order list to fix unordered list error for sitemap

### DIFF
--- a/story/sitemap.py
+++ b/story/sitemap.py
@@ -7,7 +7,7 @@ class BlogSiteMap(Sitemap):
     priority = 0.5
 
     def items(self):
-        return Story.objects.all()
+        return Story.objects.all().order_by('-created')
 
     def location(self, item):
         url = item.post_url


### PR DESCRIPTION
Fixes #784. Currently the Story queryset is not ordered which results in an error on the website when the sitemap.xml URL is accessed. This PR fixes the error by ordering the queryset by `created` field.