### PR TITLE
Remove deprecated flake8 repo to fix flake8 issues

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 repos:
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.9
+-   repo: https://github.com/PyCQA/flake8
+    rev: 6.0.0
     hooks:
     - id: flake8


### PR DESCRIPTION
GitHub Actions flake8 CI jobs are failing because pre-commit still pointed to `https://gitlab.com/pycqa/flake8` repo which is now deprecated instead of `https://github.com/pre-commit/pre-commit-hooks`. This fixes the problem of all PRs failing flake8 CI tests.