### PR TITLE
Update sentry-sdk and Pillow

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -1,5 +1,5 @@
 [pytest]
-DJANGO_SETTINGS_MODULE=djangogirls.settings
+DJANGO_SETTINGS_MODULE=djangogirls.local_settings2
 addopts = --ff --nomigrations
 env =
     RECAPTCHA_TESTING=True

--- a/requirements.txt
+++ b/requirements.txt
@@ -212,7 +212,7 @@ s3transfer==0.5.0
     # via boto3
 sendgrid==6.8.1
     # via django-sendgrid-v5
-sentry-sdk==1.3.1
+sentry-sdk==1.5.4
     # via -r requirements.in
 six==1.16.0
     # via


### PR DESCRIPTION
We are running an outdated versions of sentry-sdk and Pillow. This PR updates these requirements.