### PR TITLE
Update Slack integration to use SDK

### DIFF
--- a/core/management_utils.py
+++ b/core/management_utils.py
@@ -2,8 +2,8 @@ import djclick as click
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
-from .forms import AddOrganizerForm
-from .slack_client import slack
+from core.forms import AddOrganizerForm
+from core.slack_client import post_message_to_slack
 
 # "Get organizers info" functions used in 'new_event' and 'copy_event' management commands.
 
@@ -72,4 +72,4 @@ def brag_on_slack_bang(city, country, team):
             f"Congrats {', '.join(['{} {}'.format(x.first_name, x.last_name) for x in team])}!"
         )
 
-        slack.chat.post_message(channel="#general", text=text, username="Django Girls", icon_emoji=":django_heart:")
+        post_message_to_slack("#general", text)

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,4 +1,4 @@
 from .event import Event, EventPageContent, EventPageMenu
-from .user import User, user_invite
+from .user import User, user_invite_to_slack
 
-__all__ = ["Event", "EventPageContent", "EventPageMenu", "User", "user_invite"]
+__all__ = ["Event", "EventPageContent", "EventPageMenu", "User", "user_invite_to_slack"]

--- a/core/models/__init__.py
+++ b/core/models/__init__.py
@@ -1,4 +1,4 @@
 from .event import Event, EventPageContent, EventPageMenu
-from .user import User, user_invite_to_slack
+from .user import User, invite_user_to_slack
 
-__all__ = ["Event", "EventPageContent", "EventPageMenu", "User", "user_invite_to_slack"]
+__all__ = ["Event", "EventPageContent", "EventPageMenu", "User", "invite_user_to_slack"]

--- a/core/models/event.py
+++ b/core/models/event.py
@@ -6,15 +6,14 @@ from django.template.loader import render_to_string
 from django.utils import timezone
 from django.utils.safestring import mark_safe
 from django_date_extensions.fields import ApproximateDate, ApproximateDateField
-from slacker import Error as SlackerError
+from slack_sdk.errors import SlackApiError
 
+from core.default_eventpage_content import get_default_eventpage_data, get_default_menu
+from core.emails import notify_existing_user, notify_new_user
+from core.models.managers.event import EventManager
+from core.models.user import User
+from core.validators import validate_approximatedate
 from pictures.models import StockPicture
-
-from ..default_eventpage_content import get_default_eventpage_data, get_default_menu
-from ..emails import notify_existing_user, notify_new_user
-from ..validators import validate_approximatedate
-from .managers.event import EventManager
-from .user import User
 
 
 class Event(models.Model):
@@ -168,7 +167,7 @@ class Event(models.Model):
             errors = []
             try:
                 user.invite_to_slack()
-            except (ConnectionError, SlackerError) as e:
+            except (ConnectionError, SlackApiError) as e:
                 errors.append(f"Slack invite unsuccessful, reason: {e}")
             notify_new_user(user, event=self, password=password, errors=errors)
         else:

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -3,7 +3,7 @@ from django.contrib.auth.models import Group
 from django.db import models
 
 from core.models.managers.user import UserManager
-from core.slack_client import user_invite_to_slack
+from core.slack_client import invite_user_to_slack
 
 
 class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
@@ -24,7 +24,7 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
         verbose_name_plural = "Organizers"
 
     def invite_to_slack(self):
-        user_invite_to_slack(self.email, self.first_name)
+        invite_user_to_slack(self.email, self.first_name)
 
     def generate_password(self):
         password = User.objects.make_random_password()

--- a/core/models/user.py
+++ b/core/models/user.py
@@ -2,8 +2,8 @@ from django.contrib.auth import models as auth_models
 from django.contrib.auth.models import Group
 from django.db import models
 
-from ..slack_client import user_invite
-from .managers.user import UserManager
+from core.models.managers.user import UserManager
+from core.slack_client import user_invite_to_slack
 
 
 class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
@@ -24,7 +24,7 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
         verbose_name_plural = "Organizers"
 
     def invite_to_slack(self):
-        user_invite(self.email, self.first_name)
+        user_invite_to_slack(self.email, self.first_name)
 
     def generate_password(self):
         password = User.objects.make_random_password()

--- a/core/slack_client.py
+++ b/core/slack_client.py
@@ -1,13 +1,12 @@
 from django.conf import settings
 from slack_sdk import WebClient
 
-slack_client = WebClient(token=settings.SLACK_API_KEY)
+slack_client = WebClient(token=settings.SLACK_BOT_TOKEN)
 
 
 def user_invite_to_slack(email, first_name):
     return slack_client.admin_users_invite(
-        # TODO
-        channel_ids=[],
+        channel_ids=settings.SLACK_INVITE_CHANNEL_IDS,
         team_id=settings.SLACK_TEAM_ID,
         email=email,
         first_name=first_name,

--- a/core/slack_client.py
+++ b/core/slack_client.py
@@ -4,7 +4,7 @@ from slack_sdk import WebClient
 slack_client = WebClient(token=settings.SLACK_BOT_TOKEN)
 
 
-def user_invite_to_slack(email, first_name):
+def invite_user_to_slack(email, first_name):
     return slack_client.admin_users_invite(
         channel_ids=settings.SLACK_INVITE_CHANNEL_IDS,
         team_id=settings.SLACK_TEAM_ID,

--- a/core/slack_client.py
+++ b/core/slack_client.py
@@ -1,8 +1,21 @@
 from django.conf import settings
-from slacker import Slacker
+from slack_sdk import WebClient
 
-slack = Slacker(settings.SLACK_API_KEY)
+slack_client = WebClient(token=settings.SLACK_API_KEY)
 
 
-def user_invite(email, first_name):
-    return slack.users.post("users.admin.invite", params={"email": email, "first_name": first_name, "set_active": True})
+def user_invite_to_slack(email, first_name):
+    return slack_client.admin_users_invite(
+        # TODO
+        channel_ids=[],
+        team_id=settings.SLACK_TEAM_ID,
+        email=email,
+        first_name=first_name,
+        set_active=True,
+    )
+
+
+def post_message_to_slack(channel: str, message: str):
+    return slack_client.chat_postMessage(
+        channel=channel, text=message, username="Django Girls", icon_emoji=":django_heart:"
+    )

--- a/djangogirls/settings.py
+++ b/djangogirls/settings.py
@@ -188,7 +188,9 @@ EMAIL_BACKEND = os.environ.get("EMAIL_BACKEND", "django.core.mail.backends.conso
 DEFAULT_FROM_EMAIL = "hello@djangogirls.org"
 
 ENABLE_SLACK_NOTIFICATIONS = sanitize(os.environ.get("ENABLE_SLACK_NOTIFICATIONS", False), bool)
-SLACK_API_KEY = os.environ.get("SLACK_API_KEY")
+SLACK_BOT_TOKEN = os.environ.get("SLACK_BOT_TOKEN")
+SLACK_TEAM_ID = os.environ.get("SLACK_TEAM_ID")
+SLACK_INVITE_CHANNEL_IDS = os.environ.get("SLACK_INVITE_CHANNEL_IDS", "").split(",")
 
 RECAPTCHA_PUBLIC_KEY = os.environ.get("RECAPTCHA_PUBLIC_KEY", "")
 RECAPTCHA_PRIVATE_KEY = os.environ.get("RECAPTCHA_PRIVATE_KEY", "")

--- a/patreonmanager/management/commands/fundraising_status.py
+++ b/patreonmanager/management/commands/fundraising_status.py
@@ -3,11 +3,11 @@ import logging
 import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
-from slacker import Error as SlackerError
+from slack_sdk.errors import SlackApiError
 
-from core.slack_client import slack
+from core.slack_client import post_message_to_slack
 
-from ...models import FundraisingStatus
+from patreonmanager.models import FundraisingStatus
 
 DJANGOGIRLS_USER_ID = 483065
 BASE_API_URL = "https://api.patreon.com/"
@@ -35,8 +35,6 @@ class Command(BaseCommand):
 
         if settings.ENABLE_SLACK_NOTIFICATIONS:
             try:
-                slack.chat.post_message(
-                    channel="#notifications", text=message, username="Django Girls", icon_emoji=":django_heart:"
-                )
-            except SlackerError:
-                logging.warning("Slack message not sent.")
+                post_message_to_slack("#notifications", message)
+            except SlackApiError:
+                logging.exception("[Daily Patreon Update] Slack message not sent.")

--- a/requirements.in
+++ b/requirements.in
@@ -20,6 +20,7 @@ django-unused-media==0.1.13
 django>=3.2,<4
 dnspython
 easy-thumbnails
+easydict==1.10
 pillow==9.3.0
 psycopg2-binary==2.8.3
 pyquery==1.4.0
@@ -40,8 +41,9 @@ isort==5.8.0
 freezegun
 pytest-cov==2.12.1
 pytest-django==4.4.0
-pytest-dotenv
+pytest-dotenv==0.5.2
 pytest-env==0.6.2
+pytest-mock==3.10.0
 pytest==6.2.5
 vcrpy
 

--- a/requirements.in
+++ b/requirements.in
@@ -53,5 +53,5 @@ icalendar==4.0.3
 oauth2client==4.1.3
 py-trello==0.13.0
 sentry-sdk
-slacker==0.9.65
+slack_sdk==3.19.5
 stripe

--- a/requirements.in
+++ b/requirements.in
@@ -13,6 +13,7 @@ django-gulp-rev==0.2
 django-leaflet==0.24.0
 django-markdown-deux==1.0.5
 django-recaptcha
+django-sendgrid-v5==0.8.1
 django-storages[boto3]==1.7.1
 django-tinymce
 django-unused-media==0.1.13

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,6 +99,8 @@ dnspython==2.3.0
     # via -r requirements.in
 easy-thumbnails==2.8.5
     # via -r requirements.in
+easydict==1.10
+    # via -r requirements.in
 filelock==3.9.0
     # via
     #   urlextract
@@ -219,6 +221,7 @@ pytest==6.2.5
     #   pytest-django
     #   pytest-dotenv
     #   pytest-env
+    #   pytest-mock
 pytest-cov==2.12.1
     # via -r requirements.in
 pytest-django==4.4.0
@@ -226,6 +229,8 @@ pytest-django==4.4.0
 pytest-dotenv==0.5.2
     # via -r requirements.in
 pytest-env==0.6.2
+    # via -r requirements.in
+pytest-mock==3.10.0
     # via -r requirements.in
 python-dateutil==2.8.2
     # via

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,9 @@
 #    pip-compile --output-file=requirements.txt --resolver=backtracking requirements.in
 #
 asgiref==3.6.0
-    # via django
+    # via
+    #   django
+    #   django-countries
 attrs==22.2.0
     # via pytest
 autoflake==1.4
@@ -14,15 +16,15 @@ black==22.3.0
     # via -r requirements.in
 bleach[css]==5.0.1
     # via django-bleach
-boto3==1.26.50
+boto3==1.26.85
     # via django-storages
-botocore==1.29.50
+botocore==1.29.85
     # via
     #   boto3
     #   s3transfer
 build==0.10.0
     # via pip-tools
-cachetools==5.2.1
+cachetools==5.3.0
     # via google-auth
 certifi==2022.12.7
     # via
@@ -30,14 +32,14 @@ certifi==2022.12.7
     #   sentry-sdk
 cfgv==3.3.1
     # via pre-commit
-charset-normalizer==3.0.1
+charset-normalizer==3.1.0
     # via requests
 click==8.1.3
     # via
     #   black
     #   django-click
     #   pip-tools
-coverage==7.0.5
+coverage==7.2.1
     # via pytest-cov
 cssselect==1.2.0
     # via pyquery
@@ -67,7 +69,7 @@ django-bleach==3.0.1
     # via -r requirements.in
 django-click==2.3.0
     # via -r requirements.in
-django-countries==7.5
+django-countries==7.5.1
     # via -r requirements.in
 django-date-extensions==3.1.2
     # via -r requirements.in
@@ -75,7 +77,7 @@ django-debug-toolbar==3.8.1
     # via -r requirements.in
 django-extensions==3.2.1
     # via -r requirements.in
-django-formtools==2.3.0
+django-formtools==2.3
     # via -r requirements.in
 django-gulp-rev==0.2
     # via -r requirements.in
@@ -93,7 +95,7 @@ django-tinymce==3.5.0
     # via -r requirements.in
 django-unused-media==0.1.13
     # via -r requirements.in
-dnspython==2.2.1
+dnspython==2.3.0
     # via -r requirements.in
 easy-thumbnails==2.8.5
     # via -r requirements.in
@@ -111,7 +113,7 @@ google-api-core==2.11.0
     # via google-api-python-client
 google-api-python-client==2.37.0
     # via -r requirements.in
-google-auth==2.16.0
+google-auth==2.16.2
     # via
     #   google-api-core
     #   google-api-python-client
@@ -127,7 +129,7 @@ httplib2==0.21.0
     #   oauth2client
 icalendar==4.0.3
     # via -r requirements.in
-identify==2.5.13
+identify==2.5.18
     # via pre-commit
 idna==3.4
     # via
@@ -144,13 +146,13 @@ jmespath==1.0.1
     #   botocore
 lxml==4.9.2
     # via pyquery
-markdown2==2.4.6
+markdown2==2.4.8
     # via django-markdown-deux
 mccabe==0.6.1
     # via flake8
 multidict==6.0.4
     # via yarl
-mypy-extensions==0.4.3
+mypy-extensions==1.0.0
     # via black
 nodeenv==1.7.0
     # via pre-commit
@@ -162,7 +164,7 @@ packaging==23.0
     # via
     #   build
     #   pytest
-pathspec==0.10.3
+pathspec==0.11.0
     # via black
 pillow==9.3.0
     # via
@@ -170,7 +172,7 @@ pillow==9.3.0
     #   easy-thumbnails
 pip-tools==6.12.1
     # via -r requirements.in
-platformdirs==2.6.2
+platformdirs==3.1.0
     # via
     #   black
     #   urlextract
@@ -179,7 +181,7 @@ pluggy==1.0.0
     # via pytest
 pre-commit==2.21.0
     # via -r requirements.in
-protobuf==4.21.12
+protobuf==4.22.0
     # via
     #   google-api-core
     #   googleapis-common-protos
@@ -253,7 +255,6 @@ requests==2.28.2
     #   google-api-core
     #   py-trello
     #   requests-oauthlib
-    #   slacker
     #   stripe
 requests-oauthlib==1.3.1
     # via py-trello
@@ -265,7 +266,7 @@ s3transfer==0.6.0
     # via boto3
 sendgrid==6.9.7
     # via django-sendgrid-v5
-sentry-sdk==1.13.0
+sentry-sdk==1.16.0
     # via -r requirements.in
 six==1.16.0
     # via
@@ -276,7 +277,7 @@ six==1.16.0
     #   oauth2client
     #   python-dateutil
     #   vcrpy
-slacker==0.9.65
+slack-sdk==3.19.5
     # via -r requirements.in
 sqlparse==0.4.3
     # via
@@ -284,7 +285,7 @@ sqlparse==0.4.3
     #   django-debug-toolbar
 starkbank-ecdsa==2.2.0
     # via sendgrid
-stripe==5.0.0
+stripe==5.2.0
     # via -r requirements.in
 tinycss2==1.1.1
     # via bleach
@@ -292,7 +293,12 @@ toml==0.10.2
     # via
     #   pytest
     #   pytest-cov
-typing-extensions==4.4.0
+tomli==2.0.1
+    # via
+    #   black
+    #   build
+    #   pyproject-hooks
+typing-extensions==4.5.0
     # via django-countries
 uritemplate==4.1.1
     # via google-api-python-client
@@ -307,7 +313,7 @@ urllib3==1.26.14
     #   sentry-sdk
 vcrpy==4.2.1
     # via -r requirements.in
-virtualenv==20.17.1
+virtualenv==20.20.0
     # via pre-commit
 webencodings==0.5.1
     # via
@@ -315,7 +321,7 @@ webencodings==0.5.1
     #   tinycss2
 wheel==0.38.4
     # via pip-tools
-wrapt==1.14.1
+wrapt==1.15.0
     # via vcrpy
 yarl==1.8.2
     # via vcrpy

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,6 +9,16 @@ from globalpartners.models import GlobalPartner
 from pictures.models import StockPicture
 from sponsor.models import Donor
 
+from tests.mocks import *  # noqa
+
+
+@pytest.fixture(autouse=True)
+def default_mocks(slack_mock):
+    """
+    Add mocks that should be accessible for all tests in this function signature.
+    """
+    pass
+
 
 @pytest.fixture(autouse=True)
 def enable_db_access_for_all_tests(db):

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -54,10 +54,6 @@ def test_add_organizer(click_runner, future_event):
 
 def test_new_event_with_one_organizer(click_runner, random_day, events, slack_mock, settings):
     settings.ENABLE_SLACK_NOTIFICATIONS = True
-<<<<<<< HEAD
-=======
-
->>>>>>> 2d9c7a6 (Enable Slack mock for testing)
     assert Event.objects.count() == 4
 
     command_input = (

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -54,6 +54,10 @@ def test_add_organizer(click_runner, future_event):
 
 def test_new_event_with_one_organizer(click_runner, random_day, events, slack_mock, settings):
     settings.ENABLE_SLACK_NOTIFICATIONS = True
+<<<<<<< HEAD
+=======
+
+>>>>>>> 2d9c7a6 (Enable Slack mock for testing)
     assert Event.objects.count() == 4
 
     command_input = (

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -1,6 +1,5 @@
 import random
 from datetime import date
-from unittest import mock
 
 import pytest
 import vcr
@@ -43,8 +42,7 @@ def test_update_coordinates(click_runner, past_event):
     assert past_event.latlng == latlng
 
 
-@mock.patch("core.models.User.invite_to_slack")
-def test_add_organizer(_, click_runner, future_event):
+def test_add_organizer(click_runner, future_event):
     assert future_event.team.count() == 1
 
     command_input = f"{future_event.pk}\n" "Jan Kowalski\n" "jan@kowalski.example.org\n" "N\n"
@@ -54,8 +52,8 @@ def test_add_organizer(_, click_runner, future_event):
     assert future_event.team.count() == 2
 
 
-@vcr.use_cassette("tests/core/vcr/new_event_with_one_organizer.yaml")
-def test_new_event_with_one_organizer(click_runner, random_day, events):
+def test_new_event_with_one_organizer(click_runner, random_day, events, slack_mock, settings):
+    settings.ENABLE_SLACK_NOTIFICATIONS = True
     assert Event.objects.count() == 4
 
     command_input = (
@@ -66,10 +64,12 @@ def test_new_event_with_one_organizer(click_runner, random_day, events):
     assert Event.objects.count() == 5
     event = Event.objects.order_by("pk").last()
     assert event.team.count() == 1
+    slack_mock.chat_postMessage.assert_called_once()
 
 
-@vcr.use_cassette("tests/core/vcr/new_event_with_two_organizers.yaml")
-def test_new_event_with_two_organizers(click_runner, random_day, events):
+def test_new_event_with_two_organizers(click_runner, random_day, events, slack_mock, settings):
+    settings.ENABLE_SLACK_NOTIFICATIONS = True
+
     assert Event.objects.count() == 4
 
     command_input = (
@@ -90,10 +90,12 @@ def test_new_event_with_two_organizers(click_runner, random_day, events):
     assert Event.objects.count() == 5
     event = Event.objects.order_by("pk").last()
     assert event.team.count() == 2
+    slack_mock.chat_postMessage.assert_called_once()
 
 
-@vcr.use_cassette("tests/core/vcr/new_event_short.yaml")
-def test_new_event_short(click_runner, random_day, events, stock_pictures):
+def test_new_event_short(click_runner, random_day, events, stock_pictures, slack_mock, settings):
+    settings.ENABLE_SLACK_NOTIFICATIONS = True
+
     assert Event.objects.count() == 4
 
     command_input = (
@@ -104,6 +106,7 @@ def test_new_event_short(click_runner, random_day, events, stock_pictures):
     assert Event.objects.count() == 5
     short_email_body = "Event e-mail is: oz@djangogirls.org\n" "Event website address is: https://djangogirls.org/oz"
     assert short_email_body in result.output
+    slack_mock.chat_postMessage.assert_called_once()
 
 
 def test_copy_event(click_runner, random_day, events, past_event):

--- a/tests/core/test_commands.py
+++ b/tests/core/test_commands.py
@@ -43,7 +43,7 @@ def test_update_coordinates(click_runner, past_event):
     assert past_event.latlng == latlng
 
 
-@mock.patch("core.models.user_invite")
+@mock.patch("core.models.User.invite_to_slack")
 def test_add_organizer(_, click_runner, future_event):
     assert future_event.team.count() == 1
 

--- a/tests/core/vcr/new_event_short.yaml
+++ b/tests/core/vcr/new_event_short.yaml
@@ -1,121 +1,213 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
-  response:
-    body:
-      string: '[]'
-    headers:
-      Access-Control-Allow-Methods:
-      - OPTIONS,GET
-      Access-Control-Allow-Origin:
-      - '*'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 17:13:49 GMT
-      Keep-Alive:
-      - timeout=20
-      Server:
-      - nginx
-      Transfer-Encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: https://slack.com/api/users.admin.invite?email=jan%40kowalski.example.org&first_name=Jan&set_active=True
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
-    headers:
-      access-control-allow-headers:
-      - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
-        x-b3-sampled, x-b3-flags
-      access-control-allow-origin:
-      - '*'
-      access-control-expose-headers:
-      - x-slack-req-id, retry-after
-      cache-control:
-      - private, no-cache, no-store, must-revalidate
-      content-encoding:
-      - gzip
-      content-length:
-      - '53'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 04 Jan 2023 17:13:50 GMT
-      expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      pragma:
-      - no-cache
-      referrer-policy:
-      - no-referrer
-      server:
-      - Apache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      vary:
-      - Accept-Encoding
-      via:
-      - envoy-www-iad-f9tl, envoy-edge-gru-b6r1
-      x-accepted-oauth-scopes:
-      - client
-      x-backend:
-      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
-        main_control_with_overflow main_bedrock_control_with_overflow
-      x-content-type-options:
-      - nosniff
-      x-edge-backend:
-      - envoy-www
-      x-envoy-upstream-service-time:
-      - '124'
-      x-powered-by:
-      - HHVM/4.153.1
-      x-robots-tag:
-      - noindex,nofollow
-      x-server:
-      - slack-www-hhvm-main-iad-bwuz
-      x-slack-backend:
-      - r
-      x-slack-edge-shared-secret-outcome:
-      - no-match
-      x-slack-req-id:
-      - 625692836a18ea22704351a6ec29eb1e
-      x-slack-shared-secret-outcome:
-      - no-match
-      x-slack-unique-id:
-      - Y7Wzzhwy5LEWhHIz-tT29AAAEBI
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.26.0
+      method: GET
+      uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
+    response:
+      body:
+        string: "[]"
+      headers:
+        Access-Control-Allow-Methods:
+          - OPTIONS,GET
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Sun, 01 Jan 2023 02:18:09 GMT
+        Keep-Alive:
+          - timeout=20
+        Server:
+          - nginx
+        Transfer-Encoding:
+          - chunked
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: first_name=Jan&set_active=1&team_id=T024ABSJLVD&email=jan%40kowalski.example.org&channel_ids=C024ABSJZGF
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "104"
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/admin.users.invite
+    response:
+      body:
+        string: '{"ok":false,"error":"not_allowed_token_type"}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:18:10 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-wb0c, envoy-edge-gru-kyzn
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "242"
+        x-powered-by:
+          - HHVM/4.153.1
+        x-robots-tag:
+          - noindex,nofollow
+        x-server:
+          - slack-www-hhvm-main-iad-cnht
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - 8eeb67aede023aed40c034d26ba7ce87
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DtYhvyTi6SVSdz7cnfNgAAACs
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"channel": "#general", "text": ":django_pony: :zap: Woohoo! :tada: New
+        Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski!",
+        "icon_emoji": ":django_heart:", "username": "Django Girls"}'
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "212"
+        Content-Type:
+          - application/json;charset=utf-8
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/chat.postMessage
+    response:
+      body:
+        string:
+          '{"ok":true,"channel":"C024ABSJZGF","ts":"1672539490.915939","message":{"type":"message","subtype":"bot_message","text":":django_pony:
+          :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls Oz, Neverland.
+          Congrats Jan Kowalski!","ts":"1672539490.915939","username":"Django Girls","icons":{"emoji":":django_heart:"},"bot_id":"B024R555BFC","app_id":"A024ABWABGX","blocks":[{"type":"rich_text","block_id":"PYg","elements":[{"type":"rich_text_section","elements":[{"type":"emoji","name":"django_pony"},{"type":"text","text":"
+          "},{"type":"emoji","name":"zap","unicode":"26a1"},{"type":"text","text":"
+          Woohoo! "},{"type":"emoji","name":"tada","unicode":"1f389"},{"type":"text","text":"
+          New Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski!"}]}]}]}}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:18:10 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-s5op, envoy-edge-gru-a7hg
+        x-accepted-oauth-scopes:
+          - chat:write
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "285"
+        x-oauth-scopes:
+          - chat:write,chat:write.public,channels:read,bookmarks:read,chat:write.customize
+        x-powered-by:
+          - HHVM/4.153.1
+        x-server:
+          - slack-www-hhvm-main-iad-cvrr
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - 0b6e9e82b19067763838cbcb6ac8416b
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DtYmScXRpfLQZ0A8Q_SAAAAAs
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/core/vcr/new_event_with_one_organizer.yaml
+++ b/tests/core/vcr/new_event_with_one_organizer.yaml
@@ -1,169 +1,213 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
-  response:
-    body:
-      string: '[]'
-    headers:
-      Access-Control-Allow-Methods:
-      - OPTIONS,GET
-      Access-Control-Allow-Origin:
-      - '*'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 17:13:46 GMT
-      Keep-Alive:
-      - timeout=20
-      Server:
-      - nginx
-      Transfer-Encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://www.flickr.com/services/rest/?method=flickr.people.getPublicPhotos&api_key=None&user_id=None&extras=o_dims&format=json&nojsoncallback=1
-  response:
-    body:
-      string: '{"stat":"fail","code":100,"message":"Invalid API Key (Key has invalid
-        format)"}'
-    headers:
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '79'
-      Content-Type:
-      - application/json
-      Date:
-      - Wed, 04 Jan 2023 17:13:47 GMT
-      Via:
-      - 1.1 a9099ea1e29fa928ad562a5af3831b88.cloudfront.net (CloudFront)
-      X-Amz-Cf-Id:
-      - i6eYZ6ckGdI-rRC46AEREvH2FpYyrfWO2Hvx6XpMlyhj_XT3omDmVQ==
-      X-Amz-Cf-Pop:
-      - GRU3-C2
-      X-Cache:
-      - Miss from cloudfront
-      server:
-      - Apache/2.4.54 (Ubuntu)
-      set-cookie:
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A0%7D%7D%7D;
-        expires=Fri, 03-Feb-2023 17:13:46 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      - ccc=%7B%22needsConsent%22%3Atrue%2C%22managed%22%3A0%2C%22changed%22%3A0%2C%22info%22%3A%7B%22cookieBlock%22%3A%7B%22level%22%3A0%2C%22blockRan%22%3A1%7D%7D%7D;
-        expires=Fri, 03-Feb-2023 17:13:46 GMT; Max-Age=2592000; path=/; domain=.flickr.com
-      x-content-type-options:
-      - nosniff
-      x-frame-options:
-      - SAMEORIGIN
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: https://slack.com/api/users.admin.invite?email=jan%40kowalski.example.org&first_name=Jan&set_active=True
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
-    headers:
-      access-control-allow-headers:
-      - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
-        x-b3-sampled, x-b3-flags
-      access-control-allow-origin:
-      - '*'
-      access-control-expose-headers:
-      - x-slack-req-id, retry-after
-      cache-control:
-      - private, no-cache, no-store, must-revalidate
-      content-encoding:
-      - gzip
-      content-length:
-      - '53'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 04 Jan 2023 17:13:47 GMT
-      expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      pragma:
-      - no-cache
-      referrer-policy:
-      - no-referrer
-      server:
-      - Apache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      vary:
-      - Accept-Encoding
-      via:
-      - envoy-www-iad-hu06, envoy-edge-gru-doe0
-      x-accepted-oauth-scopes:
-      - client
-      x-backend:
-      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
-        main_control_with_overflow main_bedrock_control_with_overflow
-      x-content-type-options:
-      - nosniff
-      x-edge-backend:
-      - envoy-www
-      x-envoy-upstream-service-time:
-      - '121'
-      x-powered-by:
-      - HHVM/4.153.1
-      x-robots-tag:
-      - noindex,nofollow
-      x-server:
-      - slack-www-hhvm-main-iad-epvp
-      x-slack-backend:
-      - r
-      x-slack-edge-shared-secret-outcome:
-      - no-match
-      x-slack-req-id:
-      - 9e159a893f45bf36772f98e8debc9a63
-      x-slack-shared-secret-outcome:
-      - no-match
-      x-slack-unique-id:
-      - Y7WzywbFyvQkUoZf38C0dAAAEB8
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.26.0
+      method: GET
+      uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
+    response:
+      body:
+        string: "[]"
+      headers:
+        Access-Control-Allow-Methods:
+          - OPTIONS,GET
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Sun, 01 Jan 2023 02:14:18 GMT
+        Keep-Alive:
+          - timeout=20
+        Server:
+          - nginx
+        Transfer-Encoding:
+          - chunked
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: first_name=Jan&set_active=1&team_id=T024ABSJLVD&email=jan%40kowalski.example.org&channel_ids=C024ABSJZGF
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "104"
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/admin.users.invite
+    response:
+      body:
+        string: '{"ok":false,"error":"not_allowed_token_type"}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:14:19 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-4n83, envoy-edge-canary-gru-enuc
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "237"
+        x-powered-by:
+          - HHVM/4.153.1
+        x-robots-tag:
+          - noindex,nofollow
+        x-server:
+          - slack-www-hhvm-main-iad-llxw
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - 217fbcde3c1d0c99aeeff6e865210bc1
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7Dse5_u_XY6H0HOvSSf0gAAAC8
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"channel": "#general", "text": ":django_pony: :zap: Woohoo! :tada: New
+        Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski!",
+        "icon_emoji": ":django_heart:", "username": "Django Girls"}'
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "212"
+        Content-Type:
+          - application/json;charset=utf-8
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/chat.postMessage
+    response:
+      body:
+        string:
+          '{"ok":true,"channel":"C024ABSJZGF","ts":"1672539260.095899","message":{"type":"message","subtype":"bot_message","text":":django_pony:
+          :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls Oz, Neverland.
+          Congrats Jan Kowalski!","ts":"1672539260.095899","username":"Django Girls","icons":{"emoji":":django_heart:"},"bot_id":"B024R555BFC","app_id":"A024ABWABGX","blocks":[{"type":"rich_text","block_id":"2o9","elements":[{"type":"rich_text_section","elements":[{"type":"emoji","name":"django_pony"},{"type":"text","text":"
+          "},{"type":"emoji","name":"zap","unicode":"26a1"},{"type":"text","text":"
+          Woohoo! "},{"type":"emoji","name":"tada","unicode":"1f389"},{"type":"text","text":"
+          New Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski!"}]}]}]}}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:14:20 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-su7x, envoy-edge-gru-jyfp
+        x-accepted-oauth-scopes:
+          - chat:write
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "287"
+        x-oauth-scopes:
+          - chat:write,chat:write.public,channels:read,bookmarks:read,chat:write.customize
+        x-powered-by:
+          - HHVM/4.153.1
+        x-server:
+          - slack-www-hhvm-main-iad-tvlu
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - b3eb9f059d0679873e71c5508809f2c8
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DsfKDaNT6uODuiqHR1dAAAEBI
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/core/vcr/new_event_with_two_organizers.yaml
+++ b/tests/core/vcr/new_event_with_two_organizers.yaml
@@ -1,204 +1,297 @@
 interactions:
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      User-Agent:
-      - python-requests/2.26.0
-    method: GET
-    uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
-  response:
-    body:
-      string: '[]'
-    headers:
-      Access-Control-Allow-Methods:
-      - OPTIONS,GET
-      Access-Control-Allow-Origin:
-      - '*'
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json; charset=UTF-8
-      Date:
-      - Wed, 04 Jan 2023 17:13:48 GMT
-      Keep-Alive:
-      - timeout=20
-      Server:
-      - nginx
-      Transfer-Encoding:
-      - chunked
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: https://slack.com/api/users.admin.invite?email=jan%40kowalski.example.org&first_name=Jan&set_active=True
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
-    headers:
-      access-control-allow-headers:
-      - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
-        x-b3-sampled, x-b3-flags
-      access-control-allow-origin:
-      - '*'
-      access-control-expose-headers:
-      - x-slack-req-id, retry-after
-      cache-control:
-      - private, no-cache, no-store, must-revalidate
-      content-encoding:
-      - gzip
-      content-length:
-      - '53'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 04 Jan 2023 17:13:48 GMT
-      expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      pragma:
-      - no-cache
-      referrer-policy:
-      - no-referrer
-      server:
-      - Apache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      vary:
-      - Accept-Encoding
-      via:
-      - envoy-www-iad-4juy, envoy-edge-gru-c8dy
-      x-accepted-oauth-scopes:
-      - client
-      x-backend:
-      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
-        main_control_with_overflow main_bedrock_control_with_overflow
-      x-content-type-options:
-      - nosniff
-      x-edge-backend:
-      - envoy-www
-      x-envoy-upstream-service-time:
-      - '123'
-      x-powered-by:
-      - HHVM/4.153.1
-      x-robots-tag:
-      - noindex,nofollow
-      x-server:
-      - slack-www-hhvm-main-iad-ohdj
-      x-slack-backend:
-      - r
-      x-slack-edge-shared-secret-outcome:
-      - no-match
-      x-slack-req-id:
-      - 5653a685d62833a00053ea47931bf6d6
-      x-slack-shared-secret-outcome:
-      - no-match
-      x-slack-unique-id:
-      - Y7WzzED7AUlb8qK_WjQLRwAAED4
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      User-Agent:
-      - python-requests/2.26.0
-    method: POST
-    uri: https://slack.com/api/users.admin.invite?email=ealenor%40organizer.example.org&first_name=Eleanor&set_active=True
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAAA6tWys9WskpLzClO1VFKLSrKL1KyUsrLL4lPLC3JSE1RqgUA9xsXwyEAAAA=
-    headers:
-      access-control-allow-headers:
-      - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
-        x-b3-sampled, x-b3-flags
-      access-control-allow-origin:
-      - '*'
-      access-control-expose-headers:
-      - x-slack-req-id, retry-after
-      cache-control:
-      - private, no-cache, no-store, must-revalidate
-      content-encoding:
-      - gzip
-      content-length:
-      - '53'
-      content-type:
-      - application/json; charset=utf-8
-      date:
-      - Wed, 04 Jan 2023 17:13:49 GMT
-      expires:
-      - Mon, 26 Jul 1997 05:00:00 GMT
-      pragma:
-      - no-cache
-      referrer-policy:
-      - no-referrer
-      server:
-      - Apache
-      strict-transport-security:
-      - max-age=31536000; includeSubDomains; preload
-      vary:
-      - Accept-Encoding
-      via:
-      - envoy-www-iad-btzo, envoy-edge-gru-olp5
-      x-accepted-oauth-scopes:
-      - client
-      x-backend:
-      - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
-        main_control_with_overflow main_bedrock_control_with_overflow
-      x-content-type-options:
-      - nosniff
-      x-edge-backend:
-      - envoy-www
-      x-envoy-upstream-service-time:
-      - '122'
-      x-powered-by:
-      - HHVM/4.153.1
-      x-robots-tag:
-      - noindex,nofollow
-      x-server:
-      - slack-www-hhvm-main-iad-djbe
-      x-slack-backend:
-      - r
-      x-slack-edge-shared-secret-outcome:
-      - no-match
-      x-slack-req-id:
-      - c25ab90a4edd24554960de3e88f0f17a
-      x-slack-shared-secret-outcome:
-      - no-match
-      x-slack-unique-id:
-      - Y7Wzze8PIqNx27g0KtOVmgAAAB4
-      x-xss-protection:
-      - '0'
-    status:
-      code: 200
-      message: OK
+  - request:
+      body: null
+      headers:
+        Accept:
+          - "*/*"
+        Accept-Encoding:
+          - gzip, deflate
+        Connection:
+          - keep-alive
+        User-Agent:
+          - python-requests/2.26.0
+      method: GET
+      uri: https://nominatim.openstreetmap.org/search?format=json&q=Oz%2C+Neverland
+    response:
+      body:
+        string: "[]"
+      headers:
+        Access-Control-Allow-Methods:
+          - OPTIONS,GET
+        Access-Control-Allow-Origin:
+          - "*"
+        Connection:
+          - keep-alive
+        Content-Type:
+          - application/json; charset=UTF-8
+        Date:
+          - Sun, 01 Jan 2023 02:18:06 GMT
+        Keep-Alive:
+          - timeout=20
+        Server:
+          - nginx
+        Transfer-Encoding:
+          - chunked
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: first_name=Jan&set_active=1&team_id=T024ABSJLVD&email=jan%40kowalski.example.org&channel_ids=C024ABSJZGF
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "104"
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/admin.users.invite
+    response:
+      body:
+        string: '{"ok":false,"error":"not_allowed_token_type"}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:18:07 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-5kmc, envoy-edge-gru-quux
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "257"
+        x-powered-by:
+          - HHVM/4.153.1
+        x-robots-tag:
+          - noindex,nofollow
+        x-server:
+          - slack-www-hhvm-main-iad-fwes
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - f72672daa073393416a96797ad3d840d
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DtX4LMY68jlYQohCD5ZwAAEB0
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body: first_name=Eleanor&set_active=1&team_id=T024ABSJLVD&email=ealenor%40organizer.example.org&channel_ids=C024ABSJZGF
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "113"
+        Content-Type:
+          - application/x-www-form-urlencoded
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/admin.users.invite
+    response:
+      body:
+        string: '{"ok":false,"error":"not_allowed_token_type"}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:18:08 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-lfpl, envoy-edge-gru-grgh
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "242"
+        x-powered-by:
+          - HHVM/4.153.1
+        x-robots-tag:
+          - noindex,nofollow
+        x-server:
+          - slack-www-hhvm-main-iad-bhtv
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - a1775611042f71fdff168c7e941ff3e7
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DtYGU4r461ag_n92xP-QAAEAw
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
+  - request:
+      body:
+        '{"channel": "#general", "text": ":django_pony: :zap: Woohoo! :tada: New
+        Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski,
+        Eleanor Organizer!", "icon_emoji": ":django_heart:", "username": "Django Girls"}'
+      headers:
+        Authorization:
+          - Bearer xoxb-2146400632999-2167340908708-XWFmLgkYBBV8kGqz72DELJIc
+        Connection:
+          - close
+        Content-Length:
+          - "231"
+        Content-Type:
+          - application/json;charset=utf-8
+        Host:
+          - www.slack.com
+        User-Agent:
+          - Python/3.10.4 slackclient/3.19.5 Darwin/22.2.0
+      method: POST
+      uri: https://www.slack.com/api/chat.postMessage
+    response:
+      body:
+        string:
+          '{"ok":true,"channel":"C024ABSJZGF","ts":"1672539488.846239","message":{"type":"message","subtype":"bot_message","text":":django_pony:
+          :zap: Woohoo! :tada: New Django Girls alert! Welcome Django Girls Oz, Neverland.
+          Congrats Jan Kowalski, Eleanor Organizer!","ts":"1672539488.846239","username":"Django
+          Girls","icons":{"emoji":":django_heart:"},"bot_id":"B024R555BFC","app_id":"A024ABWABGX","blocks":[{"type":"rich_text","block_id":"aJsQP","elements":[{"type":"rich_text_section","elements":[{"type":"emoji","name":"django_pony"},{"type":"text","text":"
+          "},{"type":"emoji","name":"zap","unicode":"26a1"},{"type":"text","text":"
+          Woohoo! "},{"type":"emoji","name":"tada","unicode":"1f389"},{"type":"text","text":"
+          New Django Girls alert! Welcome Django Girls Oz, Neverland. Congrats Jan Kowalski,
+          Eleanor Organizer!"}]}]}]}}'
+      headers:
+        access-control-allow-headers:
+          - slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid,
+            x-b3-sampled, x-b3-flags
+        access-control-allow-origin:
+          - "*"
+        access-control-expose-headers:
+          - x-slack-req-id, retry-after
+        cache-control:
+          - private, no-cache, no-store, must-revalidate
+        connection:
+          - close
+        content-type:
+          - application/json; charset=utf-8
+        date:
+          - Sun, 01 Jan 2023 02:18:08 GMT
+        expires:
+          - Mon, 26 Jul 1997 05:00:00 GMT
+        pragma:
+          - no-cache
+        referrer-policy:
+          - no-referrer
+        server:
+          - Apache
+        strict-transport-security:
+          - max-age=31536000; includeSubDomains; preload
+        transfer-encoding:
+          - chunked
+        vary:
+          - Accept-Encoding
+        via:
+          - envoy-www-iad-badn, envoy-edge-gru-nczd
+        x-accepted-oauth-scopes:
+          - chat:write
+        x-backend:
+          - main_normal main_bedrock_normal_with_overflow main_canary_with_overflow main_bedrock_canary_with_overflow
+            main_control_with_overflow main_bedrock_control_with_overflow
+        x-content-type-options:
+          - nosniff
+        x-edge-backend:
+          - envoy-www
+        x-envoy-upstream-service-time:
+          - "286"
+        x-oauth-scopes:
+          - chat:write,chat:write.public,channels:read,bookmarks:read,chat:write.customize
+        x-powered-by:
+          - HHVM/4.153.1
+        x-server:
+          - slack-www-hhvm-main-iad-gzjm
+        x-slack-backend:
+          - r
+        x-slack-edge-shared-secret-outcome:
+          - no-match
+        x-slack-req-id:
+          - d00028ab566726d2dc37a76dd1476ab8
+        x-slack-shared-secret-outcome:
+          - no-match
+        x-slack-unique-id:
+          - Y7DtYNhVtlhG81MdetrpCgAAAAM
+        x-xss-protection:
+          - "0"
+      status:
+        code: 200
+        message: OK
 version: 1

--- a/tests/mocks/__init__.py
+++ b/tests/mocks/__init__.py
@@ -1,0 +1,2 @@
+# flake8: noqa
+from .slack import *

--- a/tests/mocks/slack.py
+++ b/tests/mocks/slack.py
@@ -1,0 +1,14 @@
+import pytest
+from easydict import EasyDict
+
+from core.slack_client import slack_client
+
+
+@pytest.fixture()
+def slack_mock(mocker):
+    mocks = EasyDict()
+
+    mocks.chat_postMessage = mocker.patch.object(slack_client, 'chat_postMessage')
+    mocks.admin_users_invite = mocker.patch.object(slack_client, 'admin_users_invite')
+
+    return mocks


### PR DESCRIPTION
## Changes
* Remove deprecated lib `slacker`
* Replace calls to Slack API with their own SDK
* Pin pip-tools (it's always good to pin requirement versions to help prevent compatibility issues and unexpected behavior in production)
* Rename `SLACK_API_KEY` to `SLACK_BOT_TOKEN` for explicitness

## Notes
* To send the message with a custom username and icon_emoji, the app needs the [chat.write:customize](https://api.slack.com/scopes/chat:write.customize) scope (I think this is new, so someone might need to update the permissions on the Slack dashboard)
* It's now required to pass a team and channel IDs when inviting users to Slack (in `user_invite_to_slack`), so some environment variables were added: `SLACK_TEAM_ID`, `SLACK_INVITE_CHANNEL_IDS` (the latter is a comma-separated list with channel IDs) - [here's a guide on how to find these IDs](https://feedly.helpscoutdocs.com/article/648-how-to-find-slack-channel-id)
* I couldn't test the `user_invite_to_slack`, tried to test locally but it seems the scope required to invite users ([admin.users:write](https://api.slack.com/scopes/admin.users:write)) is limited to workspaces in Enterprise Grid
<img src="https://user-images.githubusercontent.com/23136832/210029764-4142ef08-c728-48f9-aac3-82af51db627a.png" width="500">

## Actions Required

These are the actions required from maintainers to make sure the new code works as expected.

- [ ] Set `SLACK_TEAM_ID`, `SLACK_INVITE_CHANNEL_IDS` settings on production
- [ ] Make sure the app has a chat.write:customize scope on Slack
- [ ] Rename `SLACK_API_KEY` to `SLACK_BOT_TOKEN` on production
- [ ] After PR is deployed, test `user_invite_to_slack`

This PR should fix #787 