### PR TITLE
Update Python version for actions to 3.10

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -6,13 +6,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       OS: ubuntu-latest
-      PYTHON: '3.9'
+      PYTHON: '3.10'
 
     strategy:
       max-parallel: 4
       matrix:
         python-version:
-        - 3.9
+        - '3.10'
 
     services:
       postgres:

--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -26,7 +26,7 @@ jobs:
       max-parallel: 4
       matrix:
         python-version:
-        - 3.9
+        - '3.10'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Changes Python version used in GitHub Actions CI from 3.9 to 3.10 to match production.

Addresses #839. 