### PR TITLE
ci: Add pre-commit ci config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,14 @@
+ci:
+    autofix_commit_msg: |
+        ci: auto fixes from pre-commit hooks
+
+        for more information, see https://pre-commit.ci
+    autofix_prs: true
+    autoupdate_commit_msg: 'ci: pre-commit autoupdate'
+    autoupdate_schedule: monthly
+
 fail_fast: true
+
 repos:
   - repo: https://github.com/PyCQA/autoflake
     rev: v2.0.0


### PR DESCRIPTION
This adds the pre-commit CI config, because adding the pre-commit ci tool to the repo is a really good way to verify people raising PRs have actually setup pre-commit locally. It'll run through all the pre-commit hooks and pass or fail a PR based on the result.

@amakarudze you can install this CI check by going to https://pre-commit.ci and choosing "sign in with github". Then select this repo to install the service.