### PR TITLE
Escape event url in the map properties on the Django Girls events map

### DIFF
--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -14,7 +14,7 @@
                 properties: {
                     city: "{{ event.city }}",
                     date: "{{ event.date }}",
-                    url: "{% if event.is_page_live %}<a href="/{{ event.page_url }}">{% endif %}{{ event.city }}, {{ event.country }}{% if event.is_page_live %}</a>{% endif %}"
+                    url: '{% if event.is_page_live %}<a href="/{{ event.page_url }}">{% endif %}{{ event.city }}, {{ event.country }}{% if event.is_page_live %}</a>{% endif %}'
                 }
             },
         {%endif%}{%endfor%}


### PR DESCRIPTION
After changing the code for the events map it got broken because of an unescapred url string. That's fixed here.