### PR TITLE
Allow map icons overlap

### DIFF
--- a/templates/core/map.html
+++ b/templates/core/map.html
@@ -51,7 +51,8 @@
                     'source': 'event', // reference the data source
                     'layout': {
                         'icon-image': 'pin-heart', // reference the image
-                        'icon-size': 0.40
+                        'icon-size': 0.40,
+                        'icon-allow-overlap': true
                     },
                 });
 


### PR DESCRIPTION
Newer Mapbox version requires `icon-allow-overlap` to be true for icons to overlap.