### PR TITLE
Fix Event.MultipleObjectsReturned error

### DIFF
--- a/core/views.py
+++ b/core/views.py
@@ -62,7 +62,11 @@ def resources(request):
 def event(request, page_url):
     now = timezone.now()
     now_approx = ApproximateDate(year=now.year, month=now.month, day=now.day)
-    event_obj = get_object_or_404(Event, page_url=page_url.lower())
+
+    try:
+        event_obj = get_object_or_404(Event, page_url=page_url.lower())
+    except Event.MultipleObjectsReturned:
+        event_obj = Event.objects.filter(page_url=page_url.lower()).order_by("-date").first()
 
     user = request.user
     user_is_organizer = user.is_authenticated and event_obj.has_organizer(user)

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,7 +1,7 @@
 import pytest
 
 from coach.models import Coach
-from core.models import EventPageContent, EventPageMenu
+from core.models import Event, EventPageContent, EventPageMenu
 from globalpartners.models import GlobalPartner
 from sponsor.models import Sponsor
 from story.models import Story
@@ -117,3 +117,20 @@ def global_partners(db):
             ),
         ]
     )
+
+
+@pytest.fixture
+def old_event(organizer_peter):
+    event = Event.objects.create(
+        email="bonn@djangogirls.org",
+        city="Bonn",
+        name="Django Girls Bonn",
+        country="the Neverlands",
+        is_on_homepage=True,
+        main_organizer=organizer_peter,
+        date="2023-01-01",
+        page_url="bonn",
+        is_page_live=True,
+    )
+    event.team.add(organizer_peter)
+    return event

--- a/tests/core/test_views.py
+++ b/tests/core/test_views.py
@@ -168,6 +168,16 @@ def test_event_unpublished_with_auth_organizer(user, client, hidden_event):
     assert hidden_event.page_title in resp.content.decode("utf-8")
 
 
+def test_event_multiple_events_same_page_url(client, future_event, old_event):
+    # Check if event loads even if a past event has same page_url
+    url = reverse("core:event", kwargs={"page_url": future_event.page_url})
+    resp = client.get(url)
+    assert resp.status_code == 200
+
+    # Check if website is returning correct data
+    assert "event" and "menu" and "content" in resp.context
+
+
 def test_coc_legacy(client):
     AVAILABLE_LANG = {
         "en": "<h1>Code of Conduct</h1>",


### PR DESCRIPTION
Fixes #819 by using `filter` if 2 or more events are returned instead of `get` in a `try..except` block.