### PR TITLE
Catch HttpError when creating/migrating emails

### DIFF
--- a/core/gmail_accounts.py
+++ b/core/gmail_accounts.py
@@ -52,18 +52,21 @@ def create_gmail_account(event):
     if not service:
         return None, None
 
-    service.users().insert(
-        body={
-            "primaryEmail": email,
-            "name": {
-                "fullName": event.name,
-                "givenName": "Django Girls",
-                "familyName": event.city,
-            },
-            "password": password,
-            "changePasswordAtNextLogin": True,
-        }
-    ).execute()
+    try:
+        service.users().insert(
+            body={
+                "primaryEmail": email,
+                "name": {
+                    "fullName": event.name,
+                    "givenName": "Django Girls",
+                    "familyName": event.city,
+                },
+                "password": password,
+                "changePasswordAtNextLogin": True,
+            }
+        ).execute()
+    except HttpError:
+        pass
 
     return email, password
 

--- a/core/gmail_accounts.py
+++ b/core/gmail_accounts.py
@@ -66,7 +66,7 @@ def create_gmail_account(event):
             }
         ).execute()
     except HttpError:
-        pass
+        return None, None
 
     return email, password
 


### PR DESCRIPTION
When triaging event applications and creating emails for existing events, Google API often throws HttpError when the email exists and was not migrated properly. This PR catches the HttpError to prevent server errors as a result of these HttpErrors.