### PR TITLE
Hardcode year in renewal subject, add line break before signature

### DIFF
--- a/globalpartners/emails.py
+++ b/globalpartners/emails.py
@@ -8,7 +8,6 @@ year = date.year
 
 
 def send_sponsor_email(contact_person, contact_email, template, subject, errors=None):
-
     content = render_to_string(template, {"contact_person": contact_person, "errors": errors})
 
     send_email(content, subject, [contact_email])
@@ -26,7 +25,7 @@ def send_renewal_email(contact_person, contact_email):
     """Sends annual sponsors email asking if they are interested in supporting
     our work in the new year.
     """
-    subject = f"Will you be supporting us again in {year}?"
+    subject = "Will you be supporting us again in 2023?"
     template = "emails/globalpartners/renewal_email.html"
     send_sponsor_email(contact_person, contact_email, template, subject)
 

--- a/templates/emails/globalpartners/promotional_material.html
+++ b/templates/emails/globalpartners/promotional_material.html
@@ -17,7 +17,7 @@
     {% endif %}
 
     <p>Once again, thank you for supporting our work.</p>
-    
+    <br>
     <p>Sparkles, cupcakes and high-fives, 🎉🎊🎉✨🍰👋</p>
 
     <p>Anna Makarudze <br>

--- a/templates/emails/globalpartners/prospective_sponsor.html
+++ b/templates/emails/globalpartners/prospective_sponsor.html
@@ -14,7 +14,7 @@
     if you would like to get on a call for more details.</p> 
 
 <p>Looking forward to hearing from you soon.</p>
-
+<br>
 <p>Sparkles, cupcakes and high-fives, 🎉🎊🎉✨🍰👋</p> 
 
 <p>

--- a/templates/emails/globalpartners/renewal_email.html
+++ b/templates/emails/globalpartners/renewal_email.html
@@ -1,8 +1,6 @@
 <html>
 <p>Hello {{ contact_person.split.0 }},</p>
 
-<p>Happy New Year!</p>
-
 <p>We would like to thank you for your past support, we are so grateful that you chose 
     to help Django Girls on our mission to inspire women to fall in love with programming.</p>
 
@@ -20,7 +18,7 @@
     by introducing a part-time paid Communications Officer role to help promote our work.</p>
 
 <p>Thank you once again for supporting our work. We look forward to working with you again in 2023.</p>
-
+<br>
 <p>Sparkles, cupcakes and high-fives, 🎉🎊🎉✨🍰👋</p>
 
 <p>Anna Makarudze <br>

--- a/templates/emails/globalpartners/thank_you.html
+++ b/templates/emails/globalpartners/thank_you.html
@@ -5,7 +5,7 @@
         in the new year. </p>
 
     <p>Happy holidays from all of us at Django Girls!</p>
-
+    <br>
     <p>Sparkles, cupcakes and high-fives, 🎉🎊🎉✨🍰👋</p>
 
     <p>Anna Makarudze <br>


### PR DESCRIPTION
- Hardcode year in renewal email subject as it's being added as a datetime object.
- Add line break before signature in email templates