### PR TITLE
Fix Event.MultipleObjectsReturn on ... /apply/

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -27,6 +27,8 @@ def get_event(page_url, is_user_authenticated, is_preview):
         event = Event.objects.get(page_url=page_url)
     except Event.DoesNotExist:
         return None
+    except Event.MultipleObjectsReturned:
+        event = Event.objects.filter(page_url=page_url).first()
 
     if not (is_user_authenticated or is_preview) and not event.is_page_live:
         past = event.date <= now_approx


### PR DESCRIPTION
This fixes #818 and catches Event.MultipleObjectsReturned when visiting `page_url/apply/` URL.