### PR TITLE
Catch ValueError due to approximate date with no day

### DIFF
--- a/organize/models.py
+++ b/organize/models.py
@@ -49,17 +49,29 @@ class EventApplicationManager(models.Manager):
         )
 
         if previous_event:
-            event_date = data_dict["date"]
-            if date(event_date.year, event_date.month, event_date.day) - date(
-                previous_event.date.year, previous_event.date.month, previous_event.date.day
-            ) < timedelta(days=180):
-                raise ValidationError(
-                    {
-                        "date": _(
-                            "Your workshops should be at least 6 months apart. " "Please read our Organizer Manual."
-                        )
-                    }
-                )
+            try:
+                event_date = data_dict["date"]
+                if date(event_date.year, event_date.month, event_date.day) - date(
+                    previous_event.date.year, previous_event.date.month, previous_event.date.day
+                ) < timedelta(days=180):
+                    raise ValidationError(
+                        {
+                            "date": _(
+                                "Your workshops should be at least 6 months apart. " "Please read our Organizer Manual."
+                            )
+                        }
+                    )
+            except ValueError:
+                if date(event_date.year, event_date.month, event_date.day) - date(
+                    previous_event.date.year, previous_event.date.month, 1
+                ) < timedelta(days=180):
+                    raise ValidationError(
+                        {
+                            "date": _(
+                                "Your workshops should be at least 6 months apart. " "Please read our Organizer Manual."
+                            )
+                        }
+                    )
         return super().create(**data_dict)
 
 

--- a/organize/models.py
+++ b/organize/models.py
@@ -49,8 +49,8 @@ class EventApplicationManager(models.Manager):
         )
 
         if previous_event:
+            event_date = data_dict["date"]
             try:
-                event_date = data_dict["date"]
                 if date(event_date.year, event_date.month, event_date.day) - date(
                     previous_event.date.year, previous_event.date.month, previous_event.date.day
                 ) < timedelta(days=180):

--- a/tests/organize/conftest.py
+++ b/tests/organize/conftest.py
@@ -454,3 +454,31 @@ def workshop_form_invalid_no_link():
         "confirm_covid_19_protocols": True,
     }
     return data
+
+
+@pytest.fixture
+def previous_deployed_event():
+    return EventApplication.objects.create(
+        city="Zanzibar",
+        country="Tanzania",
+        date="2070-10-10",
+        created_at=datetime.now() - timedelta(days=181),
+        main_organizer_email="test@example.com",
+        main_organizer_first_name="Anna",
+        main_organizer_last_name="Smith",
+        status="deployed",
+    )
+
+
+@pytest.fixture
+def previous_application_approximate_date():
+    return EventApplication.objects.create(
+        city="Zanzibar",
+        country="Tanzania",
+        date="2070-10-0",
+        created_at=datetime.now() - timedelta(days=181),
+        main_organizer_email="test@example.com",
+        main_organizer_first_name="Anna",
+        main_organizer_last_name="Smith",
+        status="deployed",
+    )

--- a/tests/organize/test_models.py
+++ b/tests/organize/test_models.py
@@ -43,7 +43,6 @@ def test_deploy_event_from_previous_event(get_or_create_gmail, base_application,
 
 @mock.patch("organize.models.gmail_accounts.get_or_create_gmail")
 def test_send_deployed_email(get_or_create_gmail, base_application, mailoutbox, stock_pictures):
-
     get_or_create_gmail.return_value = (f"{base_application.city}@djangogirls.org", "asd123ASD")
 
     base_application.create_event()
@@ -108,3 +107,15 @@ def test_application_fails_if_event_dates_not_six_months_apart(data_dict, previo
 def test_event_application_manager_create_method(data_dict):
     event = EventApplication.object.create(**data_dict)
     assert event.city == "Harare"
+
+
+def test_previous_deployed_event_years_apart_is_successful(data_dict, previous_deployed_event):
+    assert EventApplication.object.count() == 1
+    EventApplication.object.create(**data_dict)
+    assert EventApplication.object.count() == 2
+
+
+def test_previous_application_with_approximate_date(data_dict, previous_application_approximate_date):
+    assert EventApplication.object.count() == 1
+    EventApplication.object.create(**data_dict)
+    assert EventApplication.object.count() == 2


### PR DESCRIPTION
If an existing organizer applies to organize an event while their old event application had an approximate date with month and year only, validation fails because the day which will be  will be out of range for that month. This PR fixes #885 

Changes in this PR
- Add `try...except` block to the event application validation and catch the `ValueError`.
- Add test for event application years apart.
- Add test for old event application with only an approximate date with `month` and `year` only.