### PR TITLE
Make sure application return only one objecte

### DIFF
--- a/applications/views.py
+++ b/applications/views.py
@@ -142,7 +142,7 @@ def application_detail(request, page_url, app_number):
     """
     Display the details of a single application.
     """
-    application = get_object_or_404(Application, form__event__page_url=page_url, number=app_number)
+    application = Application.object.filter(number=app_number).order_by("-created").first()
     try:
         score = Score.objects.get(user=request.user, application=application)
     except Score.DoesNotExist:


### PR DESCRIPTION
This PR looks forward to solving #890 

To solve this issue that `Application` is returning two objects, I decided to filter them by `number` and then order them by `-created` (where - refers to the inverted list), selecting the latest application created,  following the Application Model: https://github.com/DjangoGirls/djangogirls/blob/main/applications/models.py#L116.

