### PR TITLE
Fix 'str' object has no attribute 'year'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,8 @@ __pycache__
 /src
 /include
 .coverage
-.venv
+.venv/
+venv/
 static/media
 .idea/*
 .vscode

--- a/core/utils.py
+++ b/core/utils.py
@@ -31,7 +31,10 @@ def get_event(page_url, is_user_authenticated, is_preview):
         event = Event.objects.filter(page_url=page_url).order_by("-date").first()
 
     if not (is_user_authenticated or is_preview) and not event.is_page_live:
-        past = event.date <= now_approx
+        try:
+            past = event.date <= now_approx
+        except AttributeError:
+            past = True
         return page_url, past
 
     return event

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -130,7 +130,7 @@ def old_event(organizer_peter):
         main_organizer=organizer_peter,
         date="2023-01-01",
         page_url="bonn",
-        is_page_live=True,
+        is_page_live=False,
     )
     event.team.add(organizer_peter)
     return event

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -134,3 +134,20 @@ def old_event(organizer_peter):
     )
     event.team.add(organizer_peter)
     return event
+
+
+@pytest.fixture
+def old_event_no_date(organizer_peter):
+    event = Event.objects.create(
+        email="bonn@djangogirls.org",
+        city="Bonn",
+        name="Django Girls Bonn",
+        country="the Neverlands",
+        is_on_homepage=True,
+        main_organizer=organizer_peter,
+        date="",
+        page_url="bonn",
+        is_page_live=False,
+    )
+    event.team.add(organizer_peter)
+    return event

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -112,3 +112,8 @@ def test_get_event_multiple_events(old_event, future_event):
 def test_get_event_none_exists():
     result = get_event("bonn", True, False)
     assert result is None
+
+
+def test_get_event_no_date(old_event_no_date):
+    result = get_event("bonn", False, False)
+    assert result == ("bonn", True)

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -102,3 +102,13 @@ def test_get_event_not_past(future_event):
 def test_get_event_not_past_user_authenticated(future_event):
     result = get_event("bonn", True, False)
     assert result == future_event
+
+
+def test_get_event_multiple_events(old_event, future_event):
+    result = get_event("bonn", True, False)
+    assert result == future_event
+
+
+def test_get_event_none_exists():
+    result = get_event("bonn", True, False)
+    assert result is None

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -3,7 +3,7 @@ from unittest import mock
 
 from freezegun import freeze_time
 
-from core.utils import NOMINATIM_URL, get_coordinates_for_city, next_deadline
+from core.utils import NOMINATIM_URL, get_coordinates_for_city, get_event, next_deadline
 
 
 @mock.patch("requests.get")
@@ -87,3 +87,18 @@ def test_day_before_deadline():  # noqa: F811
     result = next_deadline()
 
     assert result == date(2016, 10, 30)
+
+
+def test_get_event_past(old_event):
+    result = get_event("bonn", False, False)
+    assert result == ("bonn", True)
+
+
+def test_get_event_not_past(future_event):
+    result = get_event("bonn", False, False)
+    assert result == future_event
+
+
+def test_get_event_not_past_user_authenticated(future_event):
+    result = get_event("bonn", True, False)
+    assert result == future_event


### PR DESCRIPTION
Changes in this PR:
- Add a `try...except` block for the past event in `core.utils.get_event` function.
- Fixes #916 