### PR TITLE
Fix #921: Truncate latlng to 30 chars

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -15,7 +15,9 @@ def get_coordinates_for_city(city, country):
 
     try:
         data = req.json()[0]
-        return f'{data["lat"]}, {data["lon"]}'
+        formatted_lat = "{:.6f}".format(float(data["lat"]))
+        formatted_lon = "{:.6f}".format(float(data["lon"]))
+        return f'{formatted_lat}, {formatted_lon}'
     except (IndexError, KeyError):
         return None
 

--- a/core/utils.py
+++ b/core/utils.py
@@ -15,9 +15,9 @@ def get_coordinates_for_city(city, country):
 
     try:
         data = req.json()[0]
-        formatted_lat = "{:.6f}".format(float(data["lat"]))
-        formatted_lon = "{:.6f}".format(float(data["lon"]))
-        return f'{formatted_lat}, {formatted_lon}'
+        formatted_lat = "{:.7f}".format(float(data["lat"]))
+        formatted_lon = "{:.7f}".format(float(data["lon"]))
+        return f"{formatted_lat}, {formatted_lon}"
     except (IndexError, KeyError):
         return None
 

--- a/organize/models.py
+++ b/organize/models.py
@@ -129,8 +129,7 @@ class EventApplication(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.latlng:
-            latlng_coord = get_coordinates_for_city(self.city, self.get_country_display())
-            self.latlng = latlng_coord[:30]  # Truncate to 30 characters to match the database field limit
+            self.latlng = get_coordinates_for_city(self.city, self.get_country_display())
 
         super().save(*args, **kwargs)
 

--- a/organize/models.py
+++ b/organize/models.py
@@ -129,7 +129,8 @@ class EventApplication(models.Model):
 
     def save(self, *args, **kwargs):
         if not self.latlng:
-            self.latlng = get_coordinates_for_city(self.city, self.get_country_display())
+            latlng_coord = get_coordinates_for_city(self.city, self.get_country_display())
+            self.latlng = latlng_coord[:30]  # Truncate to 30 characters to match the database field limit
 
         super().save(*args, **kwargs)
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -24,7 +24,9 @@ def test_get_coordinates_for_city(mock_get):
             "q": "London, UK",
         },
     )
-    assert result == "1.23, 4.56"
+    expected_lat = "{:.7f}".format(float("1.23"))
+    expected_lon = "{:.7f}".format(float("4.56"))
+    assert result == f"{expected_lat}, {expected_lon}"
 
 
 @mock.patch("requests.get")


### PR DESCRIPTION
This pull request fixes #921  the DataError encountered when saving `latlng` values longer than 30 characters. 
It modifies the `save` method of the `EventApplication` model to truncate the `latlng` value to 30 characters, ensuring data integrity without altering the database schema.