### PR TITLE
Remove Covid-19 restrictions from in-person form

### DIFF
--- a/core/validators.py
+++ b/core/validators.py
@@ -2,7 +2,6 @@ from datetime import date, timedelta
 
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
-from urlextract import URLExtract
 
 today = date.today()
 
@@ -22,9 +21,3 @@ def validate_event_date(e_date):
 def validate_future_date(e_date):
     if date(e_date.year, e_date.month, e_date.day) - today < timedelta(days=0):
         raise ValidationError(_("Event date should be in the future"))
-
-
-def validate_local_restrictions(local_restrictions):
-    extractor = URLExtract()
-    if not extractor.has_urls(local_restrictions):
-        raise ValidationError(_("Please provide a link to your government website outlining this."))

--- a/organize/forms.py
+++ b/organize/forms.py
@@ -9,7 +9,6 @@ from core.validators import (
     validate_approximatedate,
     validate_event_date,
     validate_future_date,
-    validate_local_restrictions,
 )
 
 from .constants import INVOLVEMENT_CHOICES
@@ -97,11 +96,8 @@ class WorkshopForm(forms.Form):
     venue = forms.CharField(widget=forms.Textarea(attrs={"class": "compact-input"}))
     sponsorship = forms.CharField(widget=forms.Textarea(attrs={"class": "compact-input"}))
     coaches = forms.CharField(widget=forms.Textarea(attrs={"class": "compact-input"}))
-    local_restrictions = forms.CharField(required=True, widget=forms.Textarea(attrs={"class": "compact-input"}))
-    safety = forms.CharField(required=True, widget=forms.Textarea(attrs={"class": "compact-input"}))
     diversity = forms.CharField(widget=forms.Textarea(attrs={"class": "compact-input"}))
     additional = forms.CharField(widget=forms.Textarea(attrs={"class": "compact-input"}))
-    confirm_covid_19_protocols = forms.BooleanField()
 
     def clean_date(self):
         date = self.cleaned_data.get("date")
@@ -114,12 +110,6 @@ class WorkshopForm(forms.Form):
 
     def get_data_for_saving(self):
         return self.cleaned_data
-
-    def clean_local_restrictions(self):
-        local_restrictions = self.cleaned_data.get("local_restrictions")
-        # Check if organizer provides link to government website
-        validate_local_restrictions(local_restrictions)
-        return local_restrictions
 
 
 class RemoteWorkshopForm(forms.Form):

--- a/templates/organize/form/step5_workshop.html
+++ b/templates/organize/form/step5_workshop.html
@@ -154,43 +154,6 @@
                     </section>
 
                     <section class="form-section">
-                        <label class="form-section-heading{% if form.local_restrictions.field.required %} required{% endif %}">{% trans "What are your current local restrictions?" %}</label>
-                        <p class="form-section-subhead">{% trans "Please also provide a link to your government website outlining this." %}</p>
-
-                        <ul class="row">
-                            <li class="col-sm-12 col-md-9">
-                                {{ wizard.form.local_restrictions }}
-                                {% if wizard.form.local_restrictions.errors %}
-                                    <ul class="error-list">
-                                        {% for error in wizard.form.local_restrictions.errors %}
-                                            <li class="error">{{ error }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </li>
-                        </ul>
-                    </section>
-
-
-                    <section class="form-section">
-                        <label class="form-section-heading{% if form.safety.field.required %} required{% endif %}">{% trans "How will you host your in-person workshop during the Covid-19 pandemic?" %}</label>
-                        <p class="form-section-subhead">{% trans "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic." %}</p>
-
-                        <ul class="row">
-                            <li class="col-sm-12 col-md-9">
-                                {{ wizard.form.safety }}
-                                {% if wizard.form.safety.errors %}
-                                    <ul class="error-list">
-                                        {% for error in wizard.form.safety.errors %}
-                                            <li class="error">{{ error }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </li>
-                        </ul>
-                    </section>
-
-                    <section class="form-section">
                         <label class="form-section-heading{% if form.diversity.field.required %} required{% endif %}">{% trans "How do you intent to make your workshop inclusive and promote diversity?" %}</label>
                         <p class="form-section-subhead">{% trans "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity." %}</p>
 
@@ -218,27 +181,6 @@
                                 {% if wizard.form.additional.errors %}
                                     <ul class="error-list">
                                         {% for error in wizard.form.additional.errors %}
-                                            <li class="error">{{ error }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% endif %}
-                            </li>
-                        </ul>
-                    </section>
-
-                    <section class="form-section">
-                        <label class="form-section-heading{% if form.confirm_covid_19_protocols.field.required %} required{% endif %}">{% trans "Will you change your workshop to remote or postpone if the situation changes in your country?" %}</label>
-                        <p class="form-section-subhead">{% trans "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city." %}</p>
-
-                        <ul class="row">
-                            <li class="col-sm-12 col-md-9 checkbox-wrapper">
-                                {{ wizard.form.confirm_covid_19_protocols }} 
-                                <label>
-                                    {% trans " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead." %}
-                                </label>
-                                {% if wizard.form.confirm_covid_19_protocols.errors %}
-                                    <ul class="error-list">
-                                        {% for error in wizard.form.confirm_covid_19_protocols.errors %}
                                             <li class="error">{{ error }}</li>
                                         {% endfor %}
                                     </ul>

--- a/tests/organize/conftest.py
+++ b/tests/organize/conftest.py
@@ -158,11 +158,8 @@ def previous_organizer_in_person(past_event):
         "workshop-venue": "Beira Hall",
         "workshop-sponsorship": "My employer will sponsor the event.",
         "workshop-coaches": "My colleagues will coach at the event.",
-        "workshop-local_restrictions": "All restrictions relaxed. https://somegov.gov",
-        "workshop-safety": "Social distancing",
         "workshop-diversity": "Promote on social media and use videos",
         "workshop-additional": "None",
-        "workshop-confirm_covid_19_protocols": True,
         "organize_form_wizard-current_step": "workshop",
     }
 
@@ -209,11 +206,8 @@ def new_organizer_in_person():
         "workshop-venue": "Baixa Mall",
         "workshop-sponsorship": "We have a few local companies we can approach.",
         "workshop-coaches": "We have many Python developers here.",
-        "workshop-local_restrictions": "All restrictions relaxed. https://somegov.gov",
-        "workshop-safety": "We will practise social distancing, wear masks and sanitize hands,",
         "workshop-diversity": "Promote on social media and use videos",
         "workshop-additional": "None",
-        "workshop-confirm_covid_19_protocols": True,
         "organize_form_wizard-current_step": "workshop",
     }
 
@@ -237,11 +231,8 @@ def workshop_form_valid_date():
         "venue": "Baixa Mall",
         "sponsorship": "We have a few local companies we can approach.",
         "coaches": "We have many Python developers here.",
-        "local_restrictions": "Maximum number of attendees is 50. https://somegovt.com/",
-        "safety": "We will practise social distancing, wear masks and sanitize hands,",
         "diversity": "Promote on social media and use videos",
         "additional": "None",
-        "confirm_covid_19_protocols": True,
     }
     return data
 
@@ -334,7 +325,6 @@ def workshop_form_date_year_only():
         "venue": "Baixa Mall",
         "sponsorship": "We have a few local companies we can approach.",
         "coaches": "We have many Python developers here.",
-        "safety": "We will practise social distancing, wear masks and sanitize hands,",
         "diversity": "Promote on social media and use videos",
         "additional": "None",
     }
@@ -447,11 +437,8 @@ def workshop_form_invalid_no_link():
         "venue": "Baixa Mall",
         "sponsorship": "We have a few local companies we can approach.",
         "coaches": "We have many Python developers here.",
-        "local_restrictions": "Maximum number of attendees is 50 and social distancing of 1.5m apart.",
-        "safety": "We will practise social distancing, wear masks and sanitize hands,",
         "diversity": "Promote on social media and use videos",
         "additional": "None",
-        "confirm_covid_19_protocols": True,
     }
     return data
 

--- a/tests/organize/test_forms.py
+++ b/tests/organize/test_forms.py
@@ -1,5 +1,3 @@
-import re
-
 from organize.forms import RemoteWorkshopForm, WorkshopForm
 
 
@@ -53,10 +51,3 @@ def test_workshop_form_date_year_only(workshop_form_date_year_only):
     form = WorkshopForm(data=workshop_form_date_year_only)
     assert not form.is_valid()
     assert form.errors["date"] == ["Event date can't be a year only. " "Please, provide at least a month and a year."]
-
-
-def test_workshop_form_local_restrictions_no_link(workshop_form_invalid_no_link):
-    form = WorkshopForm(data=workshop_form_invalid_no_link)
-    print(re.findall(r"(https?://[^\s]+)", workshop_form_invalid_no_link["local_restrictions"]))
-    assert not form.is_valid()
-    assert form.errors["local_restrictions"] == ["Please provide a link to your government website outlining this."]


### PR DESCRIPTION
Covid-19 regulations have been relaxed globally so there is no longer need for us to enforce this when organizers apply to organize workshops. This PR addresses that by:
- Removing the fields from `WorkshopForm`.
- Removing the fields from `templates/organize/form/workshop.html`.
- Removing fields in `tests/organize.conftest.py`.
- Removing the test for checking if `local_restrictions` field has a valid link for government regulations.