### PR TITLE
Fixes #920 and #764. Resolved MVDkeyError in Stripe token

### DIFF
--- a/donations/views.py
+++ b/donations/views.py
@@ -27,11 +27,17 @@ def charge(request):
         if form.is_valid():
             amount = int(request.POST["amount"])
             currency = request.POST["currency"]
-
+            # key = ""
             try:
                 customer = stripe.Customer.create(
-                    email=request.POST["email"], name=request.POST["name"], source=request.POST["stripeToken"]
+                    email=request.POST["email"],
+                    name=request.POST["name"],
+                    source=request.POST["stripeToken"],
+                    # idempotency_key=key,
                 )
+            except stripe.error.APIConnectionError as err:
+                request.session["stripe_message"] = err.user_message
+                return redirect(reverse("donations:error"))
             except CardError as err:
                 request.session["stripe_message"] = err.user_message
                 return redirect(reverse("donations:error"))

--- a/donations/views.py
+++ b/donations/views.py
@@ -1,3 +1,5 @@
+import uuid
+
 import stripe
 from django.conf import settings
 from django.http import HttpResponseForbidden
@@ -27,13 +29,13 @@ def charge(request):
         if form.is_valid():
             amount = int(request.POST["amount"])
             currency = request.POST["currency"]
-            # key = ""
+            key = uuid.uuid4().hex
             try:
                 customer = stripe.Customer.create(
                     email=request.POST["email"],
                     name=request.POST["name"],
-                    source=request.POST["stripeToken"],
-                    # idempotency_key=key,
+                    source=request.POST.get("stripeToken"),
+                    idempotency_key=key,
                 )
             except stripe.error.APIConnectionError as err:
                 request.session["stripe_message"] = err.user_message

--- a/donations/views.py
+++ b/donations/views.py
@@ -5,7 +5,7 @@ from django.conf import settings
 from django.http import HttpResponseForbidden
 from django.shortcuts import redirect, render
 from django.urls import reverse
-from stripe.error import CardError, StripeError
+from stripe.error import APIConnectionError, CardError, StripeError
 
 from patreonmanager.models import FundraisingStatus
 
@@ -37,7 +37,7 @@ def charge(request):
                     source=request.POST.get("stripeToken"),
                     idempotency_key=key,
                 )
-            except stripe.error.APIConnectionError as err:
+            except APIConnectionError as err:
                 request.session["stripe_message"] = err.user_message
                 return redirect(reverse("donations:error"))
             except CardError as err:


### PR DESCRIPTION
This error (issue #920 and issue #764) was raised due to a network connection problem (occurs rarely) between the stripe and the server, hence the token was not getting generated. Solutions are mentioned in [stripe's documentation](https://stripe.com/docs/error-handling?lang=python#connection-errors).
This is fixed by exception handling. Now it displays the following message instead of giving an error:
![Screenshot (56)](https://github.com/DjangoGirls/djangogirls/assets/93462818/c4cab132-e668-4538-a825-d556b815c4c3)

Idempotency keys are also added while creating a customer, to recover from connection error. UUID V4 is used to generate a string that could be used as Idempotency key, as mentioned in the documentation.