### PR TITLE
ci: Cleanup linting & switch to ruff formatter

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+ignore-words-list = BA,FO,PTD
+skip = package-lock.json,*.js,*.js.html,*.po,./node_modules/*,./.idea/*,./.env/*,./.venv/*,templates/core/coc/fr.html

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,0 @@
-[codespell]
-ignore-words-list = BA,FO,PTD
-skip = package-lock.json,*.js,*.js.html,*.po,./node_modules/*,./.idea/*,./.env/*,./.venv/*,templates/core/coc/fr.html

--- a/.github/workflows/ruff.yml
+++ b/.github/workflows/ruff.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Ruff
 
 on:
   push:
@@ -15,16 +15,11 @@ jobs:
   ruff:
     name: ruff
     runs-on: ubuntu-latest
+
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.10"
-          cache: 'pip'
-      - run: |
-          python -m pip install --upgrade pip
-          pip install ruff
-      - name: Run Ruff
-        run: ruff .
+    - uses: actions/checkout@v4
+
+    - run: python -Im pip install --user ruff
+
+    - name: Run Ruff
+      run: ruff --output-format=github .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,6 @@ repos:
      hooks:
        -  id: pyupgrade
           args: ["--py310-plus"]
-  - repo: https://github.com/codespell-project/codespell
-    rev: v2.1.0
-    hooks:
-      - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.1.14
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,9 @@ ci:
     autoupdate_commit_msg: 'ci: pre-commit autoupdate'
     autoupdate_schedule: monthly
 
+default_language_version:
+  python: python3.10
+
 fail_fast: true
 
 repos:
@@ -20,29 +23,13 @@ repos:
      hooks:
        -  id: pyupgrade
           args: ["--py310-plus"]
-  - repo: https://github.com/PyCQA/autoflake
-    rev: v2.2.1
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.1.0
     hooks:
-      - id: autoflake
-        entry: bash -c 'autoflake "$@"; git add -u;' --
-        language: python
-        args:
-          [
-            "--in-place",
-            "--remove-all-unused-imports",
-            "--remove-unused-variables",
-            "--expand-star-imports",
-            "--ignore-init-module-imports",
-          ]
-        files: \.py$
-  - repo: https://github.com/psf/black
-    rev: 23.12.1
-    hooks:
-      - id: black
-        entry: bash -c 'black "$@"; git add -u;' --
-        language_version: python3.10
+      - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.1.9"
+    rev: v0.1.14
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
+      - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
        -  id: pyupgrade
           args: ["--py310-plus"]
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.14
+    rev: v0.1.15
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ extend-exclude = [
   ".ruff_cache",
   ".env",
   ".venv",
+  "**locale/**",
   "**migrations/**",
   "node_modules",
   "venv",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,3 @@
-[tool.black]
-line-length = 120
-target-version = ["py310"]
-
 [tool.ruff]
 # https://beta.ruff.rs/docs/configuration/
 line-length = 120
@@ -29,7 +25,7 @@ select = [
   "RUF"
 ]
 
-exclude = [
+extend-exclude = [
   ".eggs",
   ".git",
   ".mypy_cache",
@@ -41,7 +37,7 @@ exclude = [
   "venv",
 ]
 
-ignore = [
+extend-ignore = [
   "B006",  # Do not use mutable data structures for argument defaults
   "B011",  # tests use assert False
   "B019",  # Use of `functools.lru_cache` or `functools.cache` on methods can lead to memory leaks
@@ -87,3 +83,9 @@ known-first-party = [
   "story",
 ]
 extra-standard-library = ["dataclasses"]
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"
+docstring-code-format = true
+docstring-code-line-length = 80


### PR DESCRIPTION
This improves the efficiency of the current ruff github action and switches black for the ruff formatter which is effectively the same in how it formats code, but faster and with a few configuration options.

I've also removed autoflake as not to conflict with the ruff linter.