### PR TITLE
Handle 404 errors in fetch_stories

### DIFF
--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -5,6 +5,7 @@ from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
 from django.core.management.base import BaseCommand
 from pyquery import PyQuery as pq  # noqa: N813
+from urllib.error import URLError, HTTPError
 
 from story.models import Story
 
@@ -44,7 +45,7 @@ class Command(BaseCommand):
                             img.write(urlopen(image_url).read())
                             img.flush()
                             story.image.save(image_url.split("/")[-1], File(img))
-                    except Exception as e:
+                    except (HTTPError, URLError, Exception) as e:
                         print(f"Failed to fetch image from {image_url}: {e}")
 
                 story.save()

--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -1,4 +1,4 @@
-from urllib.error import HTTPError, URLError
+from urllib.error import URLError, HTTPError
 from xml.etree import ElementTree
 
 import requests
@@ -45,8 +45,12 @@ class Command(BaseCommand):
                             img.write(urlopen(image_url).read())
                             img.flush()
                             story.image.save(image_url.split("/")[-1], File(img))
-                    except (HTTPError, URLError, Exception) as e:
-                        print(f"Failed to fetch image from {image_url}: {e}")
+                    except HTTPError as e:
+                        print(f"HTTP error when fetching image from {image_url}: {e.code} {e.reason}")
+                    except URLError as e:
+                        print(f"URL error when fetching image from {image_url}: {e.reason}")
+                    except Exception as e:
+                        print(f"Unexpected error when fetching image from {image_url}: {e}")
 
                 story.save()
 

--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -1,3 +1,4 @@
+from urllib.error import HTTPError, URLError
 from xml.etree import ElementTree
 
 import requests
@@ -5,7 +6,6 @@ from django.core.files import File
 from django.core.files.temp import NamedTemporaryFile
 from django.core.management.base import BaseCommand
 from pyquery import PyQuery as pq  # noqa: N813
-from urllib.error import URLError, HTTPError
 
 from story.models import Story
 

--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -39,10 +39,13 @@ class Command(BaseCommand):
                 story = Story(name=name, post_url=post_url, content=_post, is_story=is_story)
 
                 if image_url:
-                    img = NamedTemporaryFile(delete=True)
-                    img.write(urlopen(image_url).read())
-                    img.flush()
-                    story.image.save(image_url.split("/")[-1], File(img))
+                    try:
+                        with NamedTemporaryFile(delete=True) as img:
+                            img.write(urlopen(image_url).read())
+                            img.flush()
+                            story.image.save(image_url.split("/")[-1], File(img))
+                    except Exception as e:
+                        print(f"Failed to fetch image from {image_url}: {e}")
 
                 story.save()
 

--- a/story/management/commands/fetch_stories.py
+++ b/story/management/commands/fetch_stories.py
@@ -1,4 +1,4 @@
-from urllib.error import URLError, HTTPError
+from urllib.error import HTTPError, URLError
 from xml.etree import ElementTree
 
 import requests


### PR DESCRIPTION
This PR addresses the issue encountered when fetching blog posts with images that result in a 404 error. By implementing error handling for these cases, the fetch_stories command can now gracefully skip over images that are not found, ensuring that the process continues to fetch and store all available blog posts without interruption and Image (If 404).

This approach ensures that individual failures due to missing images do not halt the overall execution, improving the reliability and robustness of our blog post fetching mechanism.

<img width="918" alt="Screenshot 2024-02-18 at 3 26 52 am" src="https://github.com/DjangoGirls/djangogirls/assets/28702192/f88704f3-13e2-4600-847f-be67d030b59d">

Fixes #949 
