### PR TITLE
Add 12 months to the year clause

### DIFF
--- a/templates/organize/event_funding.html
+++ b/templates/organize/event_funding.html
@@ -28,7 +28,7 @@
                 <li>
                     {% blocktrans trimmed %}
                     The DSF has set aside a limited budget for Django Girls workshops sponsorship spread out through the year. 
-                    For this reason, they will only sponsorship only one event per city per year.
+                    For this reason, they will only sponsorship only one event per city per year (within 12 months).
                     {% endblocktrans %}
                 </li>
                 <li>


### PR DESCRIPTION
Clarify that the DSF funds only 1 event per city in 12 months.