### PR TITLE
Typo with dependency to translation files in application/decorator

### DIFF
--- a/locale/de/LC_MESSAGES/django.po
+++ b/locale/de/LC_MESSAGES/django.po
@@ -1,49 +1,85 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: de\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: de\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. Typo. "use", not "user".
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
-msgstr "Der Slug \"City\" muss vorhanden sein, um diesen Dekorator zu verwenden."
+#: applications/decorators.py:21
+#, fuzzy
+#| msgid "\"page_url\" slug must be present to user this decorator."
+msgid "\"page_url\" slug must be present to use this decorator."
+msgstr ""
+"Der Slug \"page_url\" muss vorhanden sein, um diesen Dekorator zu verwenden."
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
 msgstr "Bewerbung für diese E-Mail-Adresse existiert bereits."
+
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
+msgstr "Bestätigung Ihrer Bewerbung für %(page_title)s"
 
 #: applications/models.py:19
 msgid "Apply for a spot at Django Girls [City]!"
 msgstr "Bewerbe dich für einen Platz bei Django Girls [Stadt]!"
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
-msgstr "Juhu! Wir freuen uns sehr, dass Sie an unserem Workshop teilnehmen möchten. Bitte beachte, dass du mit dem Ausfüllen des Formulars keinen Platz für den Workshop bekommst, sondern nur die Chance, einen zu bekommen. Das Bewerbungsverfahren ist von {DATUM EINFÜGEN} bis {DATUM EINFÜGEN} geöffnet. Wenn du neugierig bist, nach welchen Kriterien wir die Bewerber auswählen, kannst du das im <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls Blog</a> nachlesen. Viel Glück!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
+msgstr ""
+"Juhu! Wir freuen uns sehr, dass Sie an unserem Workshop teilnehmen möchten. "
+"Bitte beachte, dass du mit dem Ausfüllen des Formulars keinen Platz für den "
+"Workshop bekommst, sondern nur die Chance, einen zu bekommen. Das "
+"Bewerbungsverfahren ist von {DATUM EINFÜGEN} bis {DATUM EINFÜGEN} geöffnet. "
+"Wenn du neugierig bist, nach welchen Kriterien wir die Bewerber auswählen, "
+"kannst du das im <a href='http://blog.djangogirls.org/post/91067112853/"
+"djangogirls-how-we-scored-applications'>Django Girls Blog</a> nachlesen. "
+"Viel Glück!"
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
 "Django Girls"
-msgstr "Hallo zusammen!\n"
+msgstr ""
+"Hallo zusammen!\n"
 "\n"
-"Dies ist eine Bestätigung deiner Bewerbung bei <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Juhu! Das ist schon ein großer Schritt, wir sind stolz auf dich!\n"
+"Dies ist eine Bestätigung deiner Bewerbung bei <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Juhu! Das ist schon ein großer "
+"Schritt, wir sind stolz auf dich!\n"
 "\n"
-"Beachte, dass dies keine Bestätigung für die Teilnahme an der Veranstaltung ist, sondern eine Bestätigung, dass wir deine Bewerbung erhalten haben.\n"
+"Beachte, dass dies keine Bestätigung für die Teilnahme an der Veranstaltung "
+"ist, sondern eine Bestätigung, dass wir deine Bewerbung erhalten haben.\n"
 "\n"
-"Du wirst bald eine E-Mail von dem Team erhalten, das Django Girls {CITY} organisiert. Du kannst sie jederzeit erreichen, indem du auf diese E-Mail antwortest oder an {Ihre Veranstaltungsmail} schreibst.\n"
+"Du wirst bald eine E-Mail von dem Team erhalten, das Django Girls {CITY} "
+"organisiert. Du kannst sie jederzeit erreichen, indem du auf diese E-Mail "
+"antwortest oder an {Ihre Veranstaltungsmail} schreibst.\n"
 "Zu deiner Information fügen wir deine Antworten unten an.\n"
 "\n"
 "Umarmungen, Törtchen und High-Fives!\n"
@@ -78,7 +114,9 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr "Liste alle verfügbaren Optionen getrennt durch Semikolon (;) auf"
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+#, fuzzy
+#| msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr "Wird nur beim Fragetyp \"Auswahlmöglichkeiten\" verwendet"
 
 #: applications/models.py:98
@@ -91,7 +129,9 @@ msgstr "Frageposition"
 
 #: applications/models.py:111
 msgid "You can only get choices for fields that have question_type == choices."
-msgstr "Sie können nur Auswahlmöglichkeiten für Felder erhalten, die question_type == choices haben."
+msgstr ""
+"Sie können nur Auswahlmöglichkeiten für Felder erhalten, die question_type "
+"== choices haben."
 
 #: applications/models.py:118 templates/applications/applications.html:37
 #: templates/applications/applications.html:86
@@ -138,27 +178,27 @@ msgstr "Status der Anfrage"
 msgid "RSVP status"
 msgstr "RSVP-Status"
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr "5 am positivsten, 1 am negativsten."
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr "Weitere Kommentare?"
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr "Inhalt der E-Mail"
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr "Du kannst HTML Syntax in dieser Nachricht verwenden. Vorschau rechts."
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr "Empfänger"
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr "Nur Empfänger der ausgewählten Gruppe erhalten diese E-Mail."
 
@@ -175,8 +215,12 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr "Möchtest du Nachrichten vom Django Girls Team erhalten?"
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
-msgstr "Kein Spam, versprochen! Nur hilfreiche Programmiertipps und aktuelle Nachrichten aus der Django Girls Welt. Wir senden einmal alle zwei Wochen."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
+msgstr ""
+"Kein Spam, versprochen! Nur hilfreiche Programmiertipps und aktuelle "
+"Nachrichten aus der Django Girls Welt. Wir senden einmal alle zwei Wochen."
 
 #: applications/questions.py:59
 msgid "Yes, please!"
@@ -223,12 +267,23 @@ msgid "What is your current level of experience with programming?"
 msgstr "Was ist dein aktuelles Erfahrungslevel beim Programmieren?"
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
-msgstr "Ich bin absoluter Anfänger und weiß nichts darüber; Ich habe etwas HTML und CSS ausprobiert; Ich habe etwas JavaScript ausprobiert; Ich habe etwas Python gelernt; Ich habe bereits eine Webseite gebaut; Ich arbeite als Entwickler"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
+msgstr ""
+"Ich bin absoluter Anfänger und weiß nichts darüber; Ich habe etwas HTML und "
+"CSS ausprobiert; Ich habe etwas JavaScript ausprobiert; Ich habe etwas "
+"Python gelernt; Ich habe bereits eine Webseite gebaut; Ich arbeite als "
+"Entwickler"
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
-msgstr "Falls du etwas anderes als Anfänger gewählt hast, erzähle uns bitte ein wenig über dein aktuelles Erfahrungslevel beim Programmieren."
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
+msgstr ""
+"Falls du etwas anderes als Anfänger gewählt hast, erzähle uns bitte ein "
+"wenig über dein aktuelles Erfahrungslevel beim Programmieren."
 
 #: applications/questions.py:115
 msgid "What is your current occupation?"
@@ -251,28 +306,61 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr "Wie hast du vor anderen beizubringen was du gelernt hast?"
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
-msgstr "Django Girls ist eine ehrenamtlich geführte Organisation und wir suchen Menschen, die aktiv sind und uns dabei helfen können, mehr Frauen in diesem Bereich zu erreichen. Wir möchten, dass Sie das, was Sie auf dem Workshop lernen, auf verschiedene Weise mit anderen teilen: indem Sie eine Django Girls-Veranstaltung in Ihrer Stadt organisieren, auf Ihren lokalen Treffen über Django Girls sprechen, einen Blog schreiben oder einfach Ihre Freunde unterrichten."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
+msgstr ""
+"Django Girls ist eine ehrenamtlich geführte Organisation und wir suchen "
+"Menschen, die aktiv sind und uns dabei helfen können, mehr Frauen in diesem "
+"Bereich zu erreichen. Wir möchten, dass Sie das, was Sie auf dem Workshop "
+"lernen, auf verschiedene Weise mit anderen teilen: indem Sie eine Django "
+"Girls-Veranstaltung in Ihrer Stadt organisieren, auf Ihren lokalen Treffen "
+"über Django Girls sprechen, einen Blog schreiben oder einfach Ihre Freunde "
+"unterrichten."
 
 #: applications/questions.py:138
 msgid "How did you hear about Django Girls?"
 msgstr "Woher kennst du Django Girls?"
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
-msgstr "Ich bestätige, dass meine Daten teilweise von Drittanbieter-Webseiten und -Services verwendet werden."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
+msgstr ""
+"Ich bestätige, dass meine Daten teilweise von Drittanbieter-Webseiten und -"
+"Services verwendet werden."
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
-msgstr "Die über dieses Formular gesammelten Daten werden nur zum Zweck der Django Girls-Veranstaltungen verwendet. Wir verwenden Websites und Dienste von Drittanbietern, um dies zu ermöglichen: zum Beispiel verwenden wir Mandrill, um Ihnen E-Mails zu senden. Keine Sorge: Wir geben Ihre Daten nicht an Spammer weiter und wir verkaufen sie nicht! Weitere Informationen zu unseren Datenschutzrichtlinien finden Sie <a href='/privacy-cookies/'>hier</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
+msgstr ""
+"Die über dieses Formular gesammelten Daten werden nur zum Zweck der Django "
+"Girls-Veranstaltungen verwendet. Wir verwenden Websites und Dienste von "
+"Drittanbietern, um dies zu ermöglichen: zum Beispiel verwenden wir Sendgrid, "
+"um Ihnen E-Mails zu senden. Keine Sorge: Wir geben Ihre Daten nicht an "
+"Spammer weiter und verkaufen sie auch nicht! Weitere Informationen zu "
+"unseren Datenschutzrichtlinien finden Sie <a href='/privacy-cookies/'>hier</"
+"a>."
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr "Ja"
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
-msgstr "Es ist wichtig, dass alle Teilnehmerinnen den <a href='/coc/'>Django Girls Verhaltenskodex</a> einhalten."
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
+msgstr ""
+"Es ist wichtig, dass alle Teilnehmerinnen den <a href='/coc/'>Django Girls "
+"Verhaltenskodex</a> einhalten."
 
 #: applications/questions.py:164
 msgid "I've read and understood the Django Girls Code of Conduct"
@@ -282,33 +370,71 @@ msgstr "Ich habe den Django Girls Verhaltenskodex gelesen und verstanden"
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr "Hurra! Deine Bewerbung wurde gespeichert. Wir melden uns bald!"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr "Bewerbungsnummer"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr "Bewerbungsstatus"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr "RSVP-Status"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr "Durchschnittliche Punktzahl"
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr "Fehlende Parameter"
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr "Die Anträge wurden aktualisiert"
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+"Bei Ihrem RSVP-Link ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns "
+"unter %(email)s mit Ihrem Namen."
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+"Ihre Teilnahme an dem Workshop wurde bestätigt! Wir können es kaum erwarten, "
+"Sie zu treffen. Wir werden Sie in Kürze über die Einzelheiten informieren."
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+"Ihre Antwort wurde gespeichert. Vielen Dank, dass Sie uns Bescheid gegeben "
+"haben. Ihr Platz wird einer anderen Person auf der Warteliste zugewiesen."
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr "Kein @ oder http://, nur den Nutzernamen"
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr "Für eine optimale Darstellung halten Sie es quadratisch"
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
 msgstr "Coaches"
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
+msgstr ""
 
 #: contact/forms.py:15
 msgid "Django Girls workshop in..."
@@ -340,7 +466,9 @@ msgstr "Danke für deine E-Mail. Wir melden uns bald."
 
 #: contact/views.py:19
 msgid "Ooops. We couldn't send your email :( Please try again later"
-msgstr "Uuups. Wir konnten deine E-Mail nicht versenden :( Bitte probiere es später noch einmal"
+msgstr ""
+"Uuups. Wir konnten deine E-Mail nicht versenden :( Bitte probiere es später "
+"noch einmal"
 
 #: core/admin/event.py:82
 msgid "past event?"
@@ -354,7 +482,7 @@ msgstr "hat eine Statistik?"
 msgid "page URL"
 msgstr "Seiten-URL"
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr "Veranstaltungsinformationen"
 
@@ -378,9 +506,59 @@ msgstr "Statistiken"
 msgid "You cannot remove yourself from a team."
 msgstr "Du kannst dich nicht selbst aus dem Team entfernen."
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr "Organisator %(user_name)s wurde entfernt"
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
 msgstr "Organisatoren löschen"
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+"%(user_name)s wurde zu Ihrer Veranstaltung hinzugefügt, juhu! Sie wurden "
+"auch zu Slack eingeladen und sollten in einer E-Mail die Anmeldedaten "
+"erhalten, um sich anzumelden."
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr "Organisatoren hinzufügen"
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr "Ändere dies nur, wenn du weißt, was du tust"
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr "Die Passwörter stimmen nicht überein."
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr "Passwort"
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr "Passwortbestätigung"
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr "Gib zur Verifizierung das selbe Passwort wie oben ein."
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
+msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
 msgid "Personal info"
@@ -393,10 +571,6 @@ msgstr "Berechtigungen"
 #: core/admin/user.py:19
 msgid "Important dates"
 msgstr "Wichtige Daten"
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
-msgstr "Ändere dies nur, wenn du weißt, was du tust"
 
 #: core/default_eventpage_content.py:60
 msgid "About"
@@ -434,57 +608,109 @@ msgstr "Vor- und Nachname des Organisators"
 msgid "E-mail address"
 msgstr "E-Mailadresse"
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr "Die Passwörter stimmen nicht überein."
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr "Passwort"
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr "Passwortbestätigung"
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr "Gib zur Verifizierung das selbe Passwort wie oben ein."
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr "Lass uns über das Team sprechen. Zuerst der Hauptorganisator:"
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
-msgstr "Das Veranstaltungsdatum darf nicht nur aus dem Jahr bestehen. Bitte gib zumindest Monat und Jahr an."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
+msgstr ""
+"Das Veranstaltungsdatum darf nicht nur aus dem Jahr bestehen. Bitte gib "
+"zumindest Monat und Jahr an."
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
-msgstr "Dein Veranstaltungsdatum ist zu kurzfristig. Das Datum sollte mindestens 3 Monate (90 Tage) in der Zukunft liegen."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
+msgstr ""
+"Dein Veranstaltungsdatum ist zu kurzfristig. Das Datum sollte mindestens 3 "
+"Monate (90 Tage) in der Zukunft liegen."
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr "Das Datum sollte in der Zukunft liegen"
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr "Liste von Django Girls Veranstaltungen weltweit"
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr "Keine Übersetzung für Sprache %(lang)s"
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr "Englisch"
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr "Brasilianisches Portugiesisch"
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr "Französisch"
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr "Deutsch"
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr "Koreanisch"
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr "Persisch"
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
 msgstr "Portugisisch"
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr "Russisch"
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr "Spanisch"
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+"Die Einführungs-E-Mail für %(contact_person)s, von %(company_name)s wurde "
+"gesendet."
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+"Die Verlängerungs-E-Mail für %(contact_person)s, von %(company_name)s wurde "
+"gesendet."
+
+#: globalpartners/admin.py:75
+#, fuzzy, python-format
+#| msgid ""
+#| "Request for promotional material email for %(contact_person)s, of "
+#| "%(company_name)s has been sent."
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+"Anforderung von Werbematerial per E-Mail für %(Kontaktperson)s, von "
+"%(Firmenname)s wurde gesendet."
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+"Die Dankes-E-Mail für %(contact_person)s, von %(company_name)s wurde "
+"gesendet."
 
 #: organize/admin.py:16
 msgid "Move selected application to on hold"
@@ -494,22 +720,32 @@ msgstr "Ausgewählte Anwendung in die Warteschleife verschieben"
 msgid "Move selected application to in review"
 msgstr "Ausgewählte Anwendung nach \"In Prüfung\" verschieben"
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr "Bewerbungsinformation"
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr "Bewerbung"
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr "Hauptorganisator"
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr "Die Anwendung ist bereits im Einsatz"
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
 msgstr "Ungültiger Status für Bewerbung"
+
+#: organize/admin.py:190
+#, fuzzy, python-format
+#| msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+msgstr "Der Antrag für %(Stadt)s, %(Land)s wurde nach %(Status)s verschoben"
 
 #: organize/constants.py:4
 msgid "I've never been to a Django Girls event"
@@ -555,135 +791,185 @@ msgstr "Abgelehnt"
 msgid "Deployed"
 msgstr "Eingesetzt"
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr "Ja, ich habe bereits Django Girls organisiert"
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+#, fuzzy
+#| msgid "No, it’s my first time organizing Django Girls"
+msgid "No, it's my first time organizing Django Girls"
 msgstr "Nein, ich organisiere Django Girls zum ersten Mal"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr "Fernbedienung"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr "Persönlich"
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr "Wähle eine Veranstaltung"
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr "Du musst eine Veranstaltung auswählen."
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr "Wähle ein Land"
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
-msgstr "Sie können sich nicht für die Organisation einer weiteren Veranstaltung bewerben, wenn Sie bereits eine andere offene Veranstaltungsanmeldung haben."
+#: organize/forms.py:109
+#, fuzzy
+#| msgid ""
+#| "Your event date is too close. Workshop date should be at least 3 months "
+#| "(90 days) from now."
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
+msgstr ""
+"Dein Veranstaltungsdatum ist zu kurzfristig. Das Datum sollte mindestens 3 "
+"Monate (90 Tage) in der Zukunft liegen."
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
-msgstr "Der Abstand zwischen Ihren Workshops sollte mindestens 6 Monate betragen. Bitte lesen Sie unser Handbuch für Organisatoren."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
+msgstr ""
+"Sie können sich nicht für die Organisation einer weiteren Veranstaltung "
+"bewerben, wenn Sie bereits eine andere offene Veranstaltungsanmeldung haben."
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+"Der Abstand zwischen Ihren Workshops sollte mindestens 6 Monate betragen. "
+"Bitte lesen Sie unser Handbuch für Organisatoren."
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr "Über den Veranstalter"
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr "Beweggründe für die Organisation"
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr "Mitwirkung bei Django Girls"
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr "Erfahrung mit der Organisation anderer Veranstaltungen"
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr "Informationen über Ihren potenziellen Veranstaltungsort"
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr "Informationen über potentielles Sponsoring"
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr "Informationen über potentielle Trainer"
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr "Informationen darüber, wie der Remote Workshop abgehalten werden soll"
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
-msgstr "Informationen darüber, wie die Sicherheit von Teilnehmern und Trainern während der Covid-19-Pandemie gewährleistet werden soll"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
+msgstr ""
+"Informationen über örtliche Beschränkungen für physische Einschränkungen "
+"aufgrund der Covid-19-Pandemie."
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
-msgstr "Informationen darüber, wie Inklusion und Vielfalt während dem Workshop gewährleistet werden kann"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
+msgstr ""
+"Informationen darüber, wie die Sicherheit von Teilnehmern und Trainern "
+"während der Covid-19-Pandemie gewährleistet werden soll"
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+"Informationen darüber, wie Inklusion und Vielfalt während dem Workshop "
+"gewährleistet werden kann"
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr "Weitere Informationen, um deine Bewerbung voranzubringen"
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+"Bestätigung, dass Sie die Veranstaltung verschieben oder an einem anderen "
+"Ort durchführen werden, wenn sich die gesetzlichen Bestimmungen für Covid-19 "
+"ändern."
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr "Kann Bewerbungen annehmen Organisieren"
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr "Dieses Feld ist verpflichtend."
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr "Co-Organisator"
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr "Co-Organisatoren"
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr "Twitter"
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr "Zahlungen"
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] "%d Zahlung"
 msgstr[1] "%d Zahlungen"
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr "Zahlungen"
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr "Unvollständige Zahlungen"
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr "Schirmherr"
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr "Markieren Sie ausgewählte Zahlungen als abgeschlossen"
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] "%d Zahlung als abgeschlossen markiert"
 msgstr[1] "%d Zahlungen als abgeschlossen markiert"
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr "Markieren Sie ausgewählte Zahlungen als abgeschlossen"
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -770,13 +1056,17 @@ msgid "payments"
 msgstr "Zahlungen"
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
-msgstr[0] "%(counter)s Zahlung\n"
+msgstr[0] ""
+"%(counter)s Zahlung\n"
 "            "
 msgstr[1] "%(counter)s Zahlungen"
 
@@ -789,8 +1079,12 @@ msgid "Section background"
 msgstr "Hintergrund der Sektion"
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
-msgstr "Verwende nur Bilder unter der <a href='https://creativecommons.org/licenses/'>Creative Commons Lizenz</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
+msgstr ""
+"Verwende nur Bilder unter der <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons Lizenz</a>."
 
 #: pictures/models.py:39
 msgid "photo URL"
@@ -804,11 +1098,11 @@ msgstr "Stelle sicher, dass das Logo nicht breiter ist als 200 px"
 msgid "No logo"
 msgstr "Kein Logo"
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr "Geschichte"
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr "Geschichten"
 
@@ -821,24 +1115,43 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr "Entschuldigung! Diese Seite ist nicht verfügbar."
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr "Zu allen <a href=\"%(events_url)s\">anstehenden Veranstaltungen</a>."
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
-msgstr "<a href=\"%(organise_url)s\">Finde heraus</a> wie du einen Django Girls Workshop in deiner Stadt planen kannst."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
+msgstr ""
+"<a href=\"%(organise_url)s\">Finde heraus</a> wie du einen Django Girls "
+"Workshop in deiner Stadt planen kannst."
 
 #: templates/admin/applications/form/view_submissions.html:5
 msgid "Submitted applications"
 msgstr "Eingereichte Bewerbungen"
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
-msgstr "Um eingereichte Bewerbungen zu deinem Workshop einzusehen, wähle eine Veranstaltung aus der Liste unten:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
+msgstr ""
+"Um eingereichte Bewerbungen zu deinem Workshop einzusehen, wähle eine "
+"Veranstaltung aus der Liste unten:"
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
-msgstr "Um eingereichte Bewerbungen zu sehen, musst du zuerst <a href=\"%(add_url)s\">ein Bewerbungsformular hinzufügen</a>."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+"Um eingereichte Bewerbungen zu sehen, musst du zuerst <a "
+"href=\"%(add_url)s\">ein Bewerbungsformular hinzufügen</a>."
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
+msgstr "Django Girls admin"
 
 #: templates/admin/core/event/view_add_organizers.html:6
 msgid "Add a new organizer to your event"
@@ -846,7 +1159,9 @@ msgstr "Füge einen neuen Organisator zu deiner Veranstaltung hinzu"
 
 #: templates/admin/core/event/view_add_organizers.html:7
 msgid "We will send them access instructions through automated email."
-msgstr "Wir werden ihnen per automatisierter E-Mail Anweisungen für den Zugang zukommen lassen."
+msgstr ""
+"Wir werden ihnen per automatisierter E-Mail Anweisungen für den Zugang "
+"zukommen lassen."
 
 #: templates/admin/core/event/view_add_organizers.html:33
 msgid "Add organizer"
@@ -857,7 +1172,9 @@ msgid "Remove event organizers"
 msgstr "Organisatoren löschen"
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+#, fuzzy
+#| msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr "Hier kannst du vorhandene Organisatoren löschen."
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -865,6 +1182,8 @@ msgid "To get started, choose an event:"
 msgstr "Wählen Sie zunächst ein Ereignis aus:"
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, fuzzy, python-format
+#| msgid "Organizers of %(event_name)s"
 msgid "Organizers of %(event_name)s"
 msgstr "Organisatoren von %(Ereignis_name)s"
 
@@ -881,17 +1200,49 @@ msgid "Action"
 msgstr "Aktion"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
-msgstr "Sind Sie sicher, dass Sie den Organisator %(org_email)s von der Veranstaltung %(event_name)s entfernen möchten?"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
+msgstr ""
+"Sind Sie sicher, dass Sie den Organisator %(org_email)s von der "
+"Veranstaltung %(event_name)s entfernen möchten?"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr "Entfernen"
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
 msgstr "Triagierung"
+
+#: templates/admin/core/organizerissue/change_form.html:15
+#, fuzzy
+#| msgid "Main organizer"
+msgid "Blacklist Organizer"
+msgstr "Hauptorganisator"
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr "E-Mail an potenziellen Sponsor senden"
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr "Erneuerung per E-Mail senden"
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr "Werbematerial per E-Mail versenden"
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
+msgstr "Dankes-E-Mail senden"
 
 #: templates/admin/organize/eventapplication/change_form.html:15
 msgid "Accept application"
@@ -909,24 +1260,36 @@ msgstr "Zum Halten bewegen"
 msgid "Reject application"
 msgstr "Bewerbung ablehnen"
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr "Die Anwendung wird eingesetzt."
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr "Bewerbung geschlossen."
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "                %(app_city)s, %(app_country)s Antrag genehmigen?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
-msgstr "\n"
-"                Sind Sie sicher, dass Sie die Bewerbung von %(application.city)s, %(application.country)s genehmigen wollen?\n"
+msgstr ""
+"\n"
+"                Sind Sie sicher, dass Sie die Bewerbung von "
+"%(application.city)s, %(application.country)s genehmigen wollen?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:19
@@ -935,19 +1298,29 @@ msgid "Yes, I'm sure"
 msgstr "Ja, ich bin sicher"
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
-msgstr "\n"
-"                Ablehnung der %(application.city)s, %(application.country)s Bewerbung?\n"
+msgstr ""
+"\n"
+"                Ablehnung der %(application.city)s, %(application.country)s "
+"Bewerbung?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
-msgstr "\n"
-"                Sind Sie sicher, dass Sie die Bewerbung von %(application.city)s, %(application.country)s ablehnen wollen?\n"
+msgstr ""
+"\n"
+"                Sind Sie sicher, dass Sie die Bewerbung von "
+"%(application.city)s, %(application.country)s ablehnen wollen?\n"
 "            "
 
 #: templates/applications/application_detail.html:29
@@ -955,10 +1328,12 @@ msgid "Scores"
 msgstr "Spielstände"
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr "Durchschnittliche Punktzahl: %(avg_score)s"
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr "Ihr Ergebnis: %(user_score.score)s"
 
@@ -984,6 +1359,8 @@ msgid "Save & draw next"
 msgstr "Speichern & weiterzeichnen"
 
 #: templates/applications/applications.html:20
+#, fuzzy, python-format
+#| msgid "Applications for %(title)s"
 msgid "Applications for %(title)s"
 msgstr "Anträge für %(Titel)s"
 
@@ -1064,25 +1441,45 @@ msgid "Nothing to see here..."
 msgstr "Hier gibt es nichts zu sehen..."
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
-msgstr "Achtung! Dieses Formular hat keine Frage mit dem Typ \"E-Mail\"! Es ist wichtig, dass Sie die E-Mail-Adressen der Kandidaten korrekt erfassen, sonst können Sie sie nicht über unser System anschreiben :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
+msgstr ""
+"Achtung! Dieses Formular hat keine Frage mit dem Typ \"E-Mail\"! Es ist "
+"wichtig, dass Sie die E-Mail-Adressen der Kandidaten korrekt erfassen, sonst "
+"können Sie sie nicht über unser System anschreiben :sadpanda:"
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
-msgstr "\n"
-"                Hallo zusammen! Wenn Sie diese Meldung sehen, bedeutet das, dass sich niemand für Ihre Veranstaltung anmelden kann.\n"
+msgstr ""
+"\n"
+"                Hallo zusammen! Wenn Sie diese Meldung sehen, bedeutet das, "
+"dass sich niemand für Ihre Veranstaltung anmelden kann.\n"
 "                Wenn Sie Anmeldungen öffnen möchten, gehen Sie zu\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">Ihr Formular in der Verwaltungsoberfläche</a> und\n"
-"                vergewissern Sie sich, dass die Felder \"Antragsverfahren\" korrekt konfiguriert sind. Hinweis: Wir haben eine\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">Zeitzonenproblem</a>! Um sicherzustellen, dass Ihr\n"
-"                Um sicher zu sein, dass Ihr Formular geöffnet ist, verwenden Sie die von unserem Server angegebene Zeit (verfügbar im oberen Teil Ihrer Verwaltungsoberfläche). Sorry 😓.\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">Ihr Formular in der Verwaltungsoberfläche</a> und\n"
+"                vergewissern Sie sich, dass die Felder \"Antragsverfahren\" "
+"korrekt konfiguriert sind. Hinweis: Wir haben eine\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">Zeitzonenproblem</a>! Um sicherzustellen, dass Ihr\n"
+"                Um sicher zu sein, dass Ihr Formular geöffnet ist, verwenden "
+"Sie die von unserem Server angegebene Zeit (verfügbar im oberen Teil Ihrer "
+"Verwaltungsoberfläche). Sorry 😓.\n"
 "            "
 
 #: templates/applications/apply.html:56
@@ -1090,6 +1487,8 @@ msgid "Submit your application"
 msgstr "Reiche deine Bewerbung ein"
 
 #: templates/applications/communication.html:14
+#, fuzzy, python-format
+#| msgid "Send email to applicants of %(title)s"
 msgid "Send email to applicants of %(title)s"
 msgstr "E-Mail an Bewerber von %(Titel)s senden"
 
@@ -1123,6 +1522,8 @@ msgid "Create one!"
 msgstr "Erstellen Sie eine!"
 
 #: templates/applications/compose_email.html:14
+#, fuzzy, python-format
+#| msgid "Edit email for %(title)s"
 msgid "Edit email for %(title)s"
 msgstr "E-Mail für %(Titel)s bearbeiten"
 
@@ -1151,11 +1552,16 @@ msgid "Email preview"
 msgstr "E-Mail Vorschau"
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
-msgstr "\n"
-"                      Diese E-Mail wurde am %(sent)s von %(author)s an %(num_rec)s Empfänger gesendet.\n"
+msgstr ""
+"\n"
+"                      Diese E-Mail wurde am %(sent)s von %(author)s an "
+"%(num_rec)s Empfänger gesendet.\n"
 "                  "
 
 #: templates/applications/compose_email.html:45
@@ -1167,24 +1573,52 @@ msgid "Emails that failed to sent:"
 msgstr "Fehlerhaft versendete E-Mails:"
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
-msgstr "Das Ereignis für %(Stadt|Titel)s hat bereits stattgefunden und die Webseite ist nicht mehr live."
+#, fuzzy, python-format
+#| msgid ""
+#| "The event for %(city|title)s has already happened and the webpage is no "
+#| "longer live."
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
+msgstr ""
+"Das Ereignis für %(Stadt|Titel)s hat bereits stattgefunden und die Webseite "
+"ist nicht mehr live."
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                        The event page for %(city|title)s will be coming "
+#| "soon.\n"
+#| "                    "
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
-msgstr "\n"
-"                        Die Veranstaltungsseite für %(Stadt|Titel)s wird in Kürze erscheinen.\n"
+msgstr ""
+"\n"
+"                        Die Veranstaltungsseite für %(Stadt|Titel)s wird in "
+"Kürze erscheinen.\n"
 "                    "
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
-msgstr "Wenn Sie mit den Organisatoren dieser Veranstaltung Kontakt aufnehmen möchten, können Sie eine E-Mail an <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a> schicken."
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
+msgstr ""
+"Wenn Sie mit den Organisatoren dieser Veranstaltung Kontakt aufnehmen "
+"möchten, können Sie eine E-Mail an <a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a> schicken."
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
-msgstr "Sehe dir alle weiteren <a href=\"%(events_url)s\">anstehenden Veranstaltungen</a> an."
+msgstr ""
+"Sehe dir alle weiteren <a href=\"%(events_url)s\">anstehenden "
+"Veranstaltungen</a> an."
 
 #: templates/applications/rsvp.html:9
 msgid "Your answer has been saved!"
@@ -1204,15 +1638,22 @@ msgstr "Hi! Wir würden gerne von dir hören!"
 
 #: templates/contact/contact.html:16
 msgid "To be sure your email reach the right person, check this FAQ first!"
-msgstr "Um sicherzustellen, dass deine E-Mail die richtige Person erreicht, sieh dir vorher diese FAQ an!"
+msgstr ""
+"Um sicherzustellen, dass deine E-Mail die richtige Person erreicht, sieh dir "
+"vorher diese FAQ an!"
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
-msgstr "\n"
-"            Wenn Sie nicht gefunden haben, was Sie suchen, sehen Sie bitte in unserem erweiterten <a href=\"%(faq_url)s\">FAQ-Bereich</a> nach\n"
+msgstr ""
+"\n"
+"            Wenn Sie nicht gefunden haben, was Sie suchen, sehen Sie bitte "
+"in unserem erweiterten <a href=\"%(faq_url)s\">FAQ-Bereich</a> nach\n"
 "            oder benutzen Sie das untenstehende Formular. :)\n"
 "          "
 
@@ -1225,8 +1666,14 @@ msgid "Django Girls Annual Report 2015"
 msgstr "Django Girls Jahresbericht 2015"
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
-msgstr "Dank der Organisatoren, Trainer und Freiwilligen überall auf der Welt wurde 2015 zu einem absolut unglaublichen Jahr für Django Girls. Lese hier alles über unsere Herausforderungen und Erfolge in 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
+msgstr ""
+"Dank der Organisatoren, Trainer und Freiwilligen überall auf der Welt wurde "
+"2015 zu einem absolut unglaublichen Jahr für Django Girls. Lese hier alles "
+"über unsere Herausforderungen und Erfolge in 2015."
 
 #: templates/core/2015.html:25
 msgid "Annual Report 2015"
@@ -1241,20 +1688,66 @@ msgid "Financial Transparency 💰🔍"
 msgstr "Finanzielle Transparenz 💰🔍"
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
-msgstr "Die finanzielle Förderung von Django Girls begann im Februar 2015, als wir unsere <a href=\"https://www.patreon.com/djangogirls\">Patreon-Kampagne</a> und die Budgetverfolgung starteten. Im Juni 2015 haben wir die gemeinnützige <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England gegründet. Während wir noch an der besten Art und Weise arbeiten, unsere Finanzen zu präsentieren, ist hier ein erster Schritt: aggregierte Daten über unsere Ausgaben und Einnahmen im Jahr 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
+msgstr ""
+"Die finanzielle Förderung von Django Girls begann im Februar 2015, als wir "
+"unsere <a href=\"https://www.patreon.com/djangogirls\">Patreon-Kampagne</a> "
+"und die Budgetverfolgung starteten. Im Juni 2015 haben wir die gemeinnützige "
+"<a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> "
+"in England gegründet. Während wir noch an der besten Art und Weise arbeiten, "
+"unsere Finanzen zu präsentieren, ist hier ein erster Schritt: aggregierte "
+"Daten über unsere Ausgaben und Einnahmen im Jahr 2015."
 
 #: templates/core/2015.html:58
 msgid "Expenses 💸"
 msgstr "Ausgaben 💸"
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
-msgstr "Insgesamt haben wir im Jahr 2015 <span>6.095,80 USD ausgegeben</span>. Die Stelle des <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> umfasste den Großteil (70 %) aller unserer Kosten. Der Awesomeness Ambassador ist für den täglichen Betrieb der Organisation verantwortlich: Beantwortung von Anfragen der Organisatoren, Bearbeitung unserer Post, Erledigung von Verwaltungsaufgaben, Aktualisierung des Blogs und des Newsletters sowie Pflege der Website und der Ressourcen."
+#, fuzzy, python-format
+#| msgid ""
+#| "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a "
+#| "href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness "
+#| "Ambassador</a> position encompassed the majority (70%%) of all of our "
+#| "costs. The Awesomeness Ambassador is responsible for running the daily "
+#| "operations of the organization: responding to organizer's requests, "
+#| "handling our mail, doing administrative tasks, updating the blog and "
+#| "newsletter, and maintaining the website and resources."
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
+msgstr ""
+"Insgesamt haben wir im Jahr 2015 <span>6.095,80 USD ausgegeben</span>. Die "
+"Stelle des <a href=\"https://djangogirls.org/pages/awesomness-ambassador/"
+"\">Awesomeness Ambassador</a> umfasste den Großteil (70 %) aller unserer "
+"Kosten. Der Awesomeness Ambassador ist für den täglichen Betrieb der "
+"Organisation verantwortlich: Beantwortung von Anfragen der Organisatoren, "
+"Bearbeitung unserer Post, Erledigung von Verwaltungsaufgaben, Aktualisierung "
+"des Blogs und des Newsletters sowie Pflege der Website und der Ressourcen."
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
-msgstr "Ein weiterer wichtiger Kostenpunkt war die Entsendung einiger Django Girls-Teammitglieder zur EuroPython, aber diese Kosten wurden durch einen großzügigen Zuschuss von Divio vollständig ausgeglichen. Ihr Sponsoring deckte die Kosten für die Entsendung von 3 Mitgliedern des Django-Girls-Teams zur EuroPython in Spanien vollständig ab."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
+msgstr ""
+"Ein weiterer wichtiger Kostenpunkt war die Entsendung einiger Django Girls-"
+"Teammitglieder zur EuroPython, aber diese Kosten wurden durch einen "
+"großzügigen Zuschuss von Divio vollständig ausgeglichen. Ihr Sponsoring "
+"deckte die Kosten für die Entsendung von 3 Mitgliedern des Django-Girls-"
+"Teams zur EuroPython in Spanien vollständig ab."
 
 #: templates/core/2015.html:77
 msgid "Expense"
@@ -1266,6 +1759,7 @@ msgid "Amount"
 msgstr "Anzahl"
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr "%% an Ausgaben"
 
@@ -1298,18 +1792,54 @@ msgid "Income 🌟👀"
 msgstr "Einnahmen 🌟👀"
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
-msgstr "<span>Wir haben im Jahr 2015 37.157,5 USD gesammelt</span>. Der größte Teil unseres Einkommens stammt von einem Unternehmen: <a href=\"https://www.elastic.co/\">Elastic</a>. Ihre Großzügigkeit macht 60 % unseres Gesamtbudgets für 2015 aus: Sie <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">spendeten 17.000 USD</a> aus dem Ticketverkauf für die Elastic{ON} Tour-Veranstaltungsreihe gespendet und unsere Stelle als Awesomeness Ambassador mit weiteren 5.645,19 USD gesponsert."
+#, fuzzy, python-format, python-brace-format
+#| msgid ""
+#| "<span>We raised $37,157.5 USD in 2015</span>. The most significant part "
+#| "of our incomes comes from one company: <a href=\"https://www.elastic.co/"
+#| "\">Elastic</a>. Their generosity accounts for 60%% of our overall budget "
+#| "for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/"
+#| "meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets "
+#| "sales for Elastic{ON} Tour event series, and sponsored our Awesomeness "
+#| "Ambassador position with an additional $5,645.19 USD."
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
+msgstr ""
+"<span>Wir haben im Jahr 2015 37.157,5 USD gesammelt</span>. Der größte Teil "
+"unseres Einkommens stammt von einem Unternehmen: <a href=\"https://www."
+"elastic.co/\">Elastic</a>. Ihre Großzügigkeit macht 60 % unseres "
+"Gesamtbudgets für 2015 aus: Sie <a href=\"http://blog.djangogirls.org/"
+"post/135185350903/meet-our-new-sponsor-elastic\">spendeten 17.000 USD</a> "
+"aus dem Ticketverkauf für die Elastic{ON} Tour-Veranstaltungsreihe gespendet "
+"und unsere Stelle als Awesomeness Ambassador mit weiteren 5.645,19 USD "
+"gesponsert."
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
-msgstr "Außerdem haben wir fast 19 % unserer Gesamteinnahmen durch <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> gesammelt. Wir erhalten derzeit 899 USD pro Monat von 48 Personen oder Organisationen."
+#, fuzzy, python-format
+#| msgid ""
+#| "We also raised almost 19%% of our total income through <a href=\"https://"
+#| "www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 "
+#| "USD a month from 48 people or organizations."
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
+msgstr ""
+"Außerdem haben wir fast 19 % unserer Gesamteinnahmen durch <a href=\"https://"
+"www.patreon.com/djangogirls\">Patreon</a> gesammelt. Wir erhalten derzeit "
+"899 USD pro Monat von 48 Personen oder Organisationen."
 
 #: templates/core/2015.html:122
 msgid "Income"
 msgstr "Einkommen"
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr "% % des Einkommens"
 
@@ -1322,6 +1852,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr "Elastic Sponsorship of Awesomeness Botschafterin"
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr "Elastisch{ON} Tour-Spende"
 
@@ -1346,8 +1877,16 @@ msgid "Total income"
 msgstr "Gesamteinnahmen"
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
-msgstr "<span>Unser Gesamtguthaben zum Jahresende 2015 beträgt 31.061,70 USD. </span> Wir sind all den großzügigen Menschen und Organisationen unglaublich dankbar, die in diesem Jahr gespendet und uns geholfen haben, ein Budget für noch mehr Aktivitäten im Jahr 2016 zu sichern."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
+msgstr ""
+"<span>Unser Gesamtguthaben zum Jahresende 2015 beträgt 31.061,70 USD. </"
+"span> Wir sind all den großzügigen Menschen und Organisationen unglaublich "
+"dankbar, die in diesem Jahr gespendet und uns geholfen haben, ein Budget für "
+"noch mehr Aktivitäten im Jahr 2016 zu sichern."
 
 #: templates/core/2015.html:151
 msgid "Budget for 2016 💵💡"
@@ -1358,136 +1897,505 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr "Für 2016 planen wir uns auf folgende Initiativen zu fokussieren:"
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
-msgstr "Machen Sie die Django Girls Foundation nachhaltig, indem Sie unser monatlich wiederkehrendes Einkommen erhöhen, um die laufenden Kosten zu decken. Derzeit benötigen wir mindestens 1.500 $ pro Monat, um die Kosten für die Buchhaltung, das Gehalt der Botschafterin und die Kosten für andere Dienste, die wir zur Pflege der Website nutzen, zu decken. Wir möchten diese Einnahmen erhöhen, indem wir uns stärker auf unsere <a href=\"https://www.patreon.com/djangogirls\">Patreon-Kampagne</a> konzentrieren, mehr Organisationen mit einem Fundraising-Deck erreichen und einen permanenten Online-Merchandise-Shop einrichten. (Immer nur T-Shirts! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
+msgstr ""
+"Machen Sie die Django Girls Foundation nachhaltig, indem Sie unser monatlich "
+"wiederkehrendes Einkommen erhöhen, um die laufenden Kosten zu decken. "
+"Derzeit benötigen wir mindestens 1.500 $ pro Monat, um die Kosten für die "
+"Buchhaltung, das Gehalt der Botschafterin und die Kosten für andere Dienste, "
+"die wir zur Pflege der Website nutzen, zu decken. Wir möchten diese "
+"Einnahmen erhöhen, indem wir uns stärker auf unsere <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon-Kampagne</a> konzentrieren, mehr "
+"Organisationen mit einem Fundraising-Deck erreichen und einen permanenten "
+"Online-Merchandise-Shop einrichten. (Immer nur T-Shirts! 👕)"
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
-msgstr "Wir würden gerne die Django-Girls-Box ins Leben rufen: Wir würden allen Veranstaltern erlauben, eine kostenlose Box mit Django-Girls-Aufklebern, Raumdekoration, Spickzetteln, Luftballons, Anstecknadeln und anderen kleinen Leckereien zu bestellen, die fast immer für Workshops bestellt werden 🎈🍬. Wir können die Kosten für diese Artikel für alle Workshops erheblich senken, indem wir sie im Voraus in großen Mengen kaufen."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
+msgstr ""
+"Wir würden gerne die Django-Girls-Box ins Leben rufen: Wir würden allen "
+"Veranstaltern erlauben, eine kostenlose Box mit Django-Girls-Aufklebern, "
+"Raumdekoration, Spickzetteln, Luftballons, Anstecknadeln und anderen kleinen "
+"Leckereien zu bestellen, die fast immer für Workshops bestellt werden 🎈🍬. "
+"Wir können die Kosten für diese Artikel für alle Workshops erheblich senken, "
+"indem wir sie im Voraus in großen Mengen kaufen."
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
-msgstr "Wir gehen davon aus, dass die Kosten für die Einstellung des Awesomeness Ambassador im nächsten Jahr aus verschiedenen Gründen steigen werden, also bereiten wir uns darauf vor."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
+msgstr ""
+"Wir gehen davon aus, dass die Kosten für die Einstellung des Awesomeness "
+"Ambassador im nächsten Jahr aus verschiedenen Gründen steigen werden, also "
+"bereiten wir uns darauf vor."
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
-msgstr "Wir planen, unseren ersten Django Girls Summit zu organisieren: eine zweitägige Unkonferenz, bei der sich Organisatoren treffen und ihre Erfahrungen mit Django Girls Workshops austauschen können. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
+msgstr ""
+"Wir planen, unseren ersten Django Girls Summit zu organisieren: eine "
+"zweitägige Unkonferenz, bei der sich Organisatoren treffen und ihre "
+"Erfahrungen mit Django Girls Workshops austauschen können. 👭👫"
 
 #: templates/core/2015.html:187
 msgid "Achievements & Events in 2015 🏆🏅"
 msgstr "Erfolge & Veranstaltungen in 2015 🏆🏅"
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
-msgstr "2015 war ein ziemlich aufregendes Jahr für uns. Hier ist ein Überblick über die Ereignisse, Saison für Saison."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
+msgstr ""
+"2015 war ein ziemlich aufregendes Jahr für uns. Hier ist ein Überblick über "
+"die Ereignisse, Saison für Saison."
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
-msgstr "Gleich zu Beginn des Jahres beschlossen Ola & Ola, dass sie Hilfe brauchen, um Django Girls weiter wachsen zu lassen, und luden <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste ein, ein Support Team</a> (damals noch Kernteam genannt) zu bilden. Zu diesem Zeitpunkt wurden die ersten formalen Prozesse für das Erstellen neuer Veranstaltungen, das Hinzufügen neuer Organisatoren und das Treffen von Entscheidungen festgelegt. Wir begannen, diese Prozesse in einem kleinen <a href=\"https://github.com/DjangoGirls/wiki\">Wiki</a> zu dokumentieren."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgstr ""
+"Gleich zu Beginn des Jahres beschlossen Ola & Ola, dass sie Hilfe brauchen, "
+"um Django Girls weiter wachsen zu lassen, und luden <a href=\"http://blog."
+"djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & "
+"Baptiste ein, ein Support Team</a> (damals noch Kernteam genannt) zu bilden. "
+"Zu diesem Zeitpunkt wurden die ersten formalen Prozesse für das Erstellen "
+"neuer Veranstaltungen, das Hinzufügen neuer Organisatoren und das Treffen "
+"von Entscheidungen festgelegt. Wir begannen, diese Prozesse in einem kleinen "
+"<a href=\"https://github.com/DjangoGirls/wiki\">Wiki</a> zu dokumentieren."
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
-msgstr "Im ersten Quartal waren wir mit wunderbaren Menschen beschäftigt, die an unsere Türen klopften und uns fragten, ob sie bei der Übersetzung des Tutorials helfen könnten. Wir entschieden uns für <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> als Übersetzungsplattform und begannen einen nicht enden wollenden Prozess, um herauszufinden, wie diese Übersetzungssache überhaupt funktioniert. Die polnische Übersetzung war die erste, die in diesem Jahr veröffentlicht wurde!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
+msgstr ""
+"Im ersten Quartal waren wir mit wunderbaren Menschen beschäftigt, die an "
+"unsere Türen klopften und uns fragten, ob sie bei der Übersetzung des "
+"Tutorials helfen könnten. Wir entschieden uns für <a href=\"https://crowdin."
+"com/project/django-girls-tutorial\">Crowdin</a> als Übersetzungsplattform "
+"und begannen einen nicht enden wollenden Prozess, um herauszufinden, wie "
+"diese Übersetzungssache überhaupt funktioniert. Die polnische Übersetzung "
+"war die erste, die in diesem Jahr veröffentlicht wurde!"
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
-msgstr "Das Ende des Winters wurde mit einem Django Girls-Stand auf der PyCon US eingeläutet. Wir hatten eine wunderbare Zeit, um die Fragen der Besucher zu beantworten und das Wort über Django Girls zu verbreiten. Wir haben auch die <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; T-Shirts</a> vorgestellt und 100 davon verkauft!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgstr ""
+"Das Ende des Winters wurde mit einem Django Girls-Stand auf der PyCon US "
+"eingeläutet. Wir hatten eine wunderbare Zeit, um die Fragen der Besucher zu "
+"beantworten und das Wort über Django Girls zu verbreiten. Wir haben auch die "
+"<a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-"
+"like\">&ldquo;This is what a programmer looks like&rdquo; T-Shirts</a> "
+"vorgestellt und 100 davon verkauft!"
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
-msgstr "Das ganze Jahr über haben wir auf unserem Blog <a href=\"https://djangogirls.org/story/\">53 Geschichten von tollen Frauen veröffentlicht</a> - eine für jede Woche des Jahres. Ein großes Dankeschön an Anna Ossowski, die dieses Projekt über ein Jahr lang geleitet hat, und an <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a>, die jetzt dafür verantwortlich ist."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgstr ""
+"Das ganze Jahr über haben wir auf unserem Blog <a href=\"https://djangogirls."
+"org/story/\">53 Geschichten von tollen Frauen veröffentlicht</a> - eine für "
+"jede Woche des Jahres. Ein großes Dankeschön an Anna Ossowski, die dieses "
+"Projekt über ein Jahr lang geleitet hat, und an <a href=\"http://blog."
+"djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a>, die jetzt dafür verantwortlich ist."
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
-msgstr "Wir haben uns auf die Verbesserung der Werkzeuge für Organisatoren konzentriert. Dank der harten Arbeit unserer Freiwilligen haben wir einige unglaubliche Beiträge zu unserem <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a> gesehen. Außerdem haben wir ein Bewerbungstool für Organisatoren entwickelt, das es ihnen endlich ermöglicht, Bewerbungen über die Django-Girls-Website zu empfangen und zu bewerten, anstatt über Google-Formulare und Tabellenkalkulationen. Puh!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
+msgstr ""
+"Wir haben uns auf die Verbesserung der Werkzeuge für Organisatoren "
+"konzentriert. Dank der harten Arbeit unserer Freiwilligen haben wir einige "
+"unglaubliche Beiträge zu unserem <a href=\"http://organize.djangogirls.org/"
+"\">Organizer's Manual</a> gesehen. Außerdem haben wir ein Bewerbungstool für "
+"Organisatoren entwickelt, das es ihnen endlich ermöglicht, Bewerbungen über "
+"die Django-Girls-Website zu empfangen und zu bewerten, anstatt über Google-"
+"Formulare und Tabellenkalkulationen. Puh!"
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
-msgstr "Das Support-Team wurde um weitere Mitarbeiter erweitert: Wir begrüßten <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\">Kasia und Geoffrey</a>. Dies war auch der Startschuss für einen Prozess, der unsere Bemühungen um mehr Transparenz verstärkte. Wir haben viel Zeit damit verbracht, neue Dokumentationen zu verfassen und die bestehenden internen Dokumente zu verbessern, und haben sie dann in Form des <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a> veröffentlicht. Von nun an ist alles darüber, was wir glauben und wie wir arbeiten, offen und öffentlich."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
+msgstr ""
+"Das Support-Team wurde um weitere Mitarbeiter erweitert: Wir begrüßten <a "
+"href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-"
+"geoffrey-to-django-girls-core\">Kasia und Geoffrey</a>. Dies war auch der "
+"Startschuss für einen Prozess, der unsere Bemühungen um mehr Transparenz "
+"verstärkte. Wir haben viel Zeit damit verbracht, neue Dokumentationen zu "
+"verfassen und die bestehenden internen Dokumente zu verbessern, und haben "
+"sie dann in Form des <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a> veröffentlicht. Von nun an ist alles darüber, was wir glauben "
+"und wie wir arbeiten, offen und öffentlich."
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
-msgstr "Im Mai haben wir auch das Django-Girls-Tutorial auf den neuesten Stand gebracht und <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">das Deploy-Kapitel umgeschrieben</a>, um Python Anywhere zu verwenden. Ein großes Dankeschön an Harry Percival, der dies möglich gemacht hat."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
+msgstr ""
+"Im Mai haben wir auch das Django-Girls-Tutorial auf den neuesten Stand "
+"gebracht und <a href=\"http://blog.djangogirls.org/post/118716365753/django-"
+"girls-now-deploy-to-python-anywhere\">das Deploy-Kapitel umgeschrieben</a>, "
+"um Python Anywhere zu verwenden. Ein großes Dankeschön an Harry Percival, "
+"der dies möglich gemacht hat."
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
-msgstr "Zu guter Letzt haben wir die Django Girls Foundation während der DjangoCon Europe 2015 gegründet. Wir unterzeichneten die Papiere, klebten den Emoji-Aufkleber darauf und machten es offiziell. Django Girls ist jetzt eine Wohltätigkeitsorganisation!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
+msgstr ""
+"Zu guter Letzt haben wir die Django Girls Foundation während der DjangoCon "
+"Europe 2015 gegründet. Wir unterzeichneten die Papiere, klebten den Emoji-"
+"Aufkleber darauf und machten es offiziell. Django Girls ist jetzt eine "
+"Wohltätigkeitsorganisation!"
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
-msgstr "Oh je, der Sommer war ein Höllenritt. Erstens, die Geburtstagsparty! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> fand am 22. Juli im EuroPython statt. Wir feierten mit 50 wunderbaren Freunden in einem Park, teilten Muffins, stießen mit Sangria an und spielten ein paar Spiele."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
+msgstr ""
+"Oh je, der Sommer war ein Höllenritt. Erstens, die Geburtstagsparty! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> fand am 22. Juli "
+"im EuroPython statt. Wir feierten mit 50 wunderbaren Freunden in einem Park, "
+"teilten Muffins, stießen mit Sangria an und spielten ein paar Spiele."
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
-msgstr "Der August war auch der Monat, in dem die <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a>-Seiten unserer Website geboren wurden. Dies geschah dank der großartigen Arbeit von Marysia Lowas-Rzechonek und Kasia Siedlarek, beides Django Girls-Teilnehmerinnen, die mehr über Django lernen wollten, indem sie einen Beitrag zu Open Source leisteten, sowie Becky Smith, die ihnen als Mentorin zur Seite stand, und Ania Warzecha, die sie anleitete und den letzten Pull Request zusammenführte. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
+msgstr ""
+"Der August war auch der Monat, in dem die <a href=\"http://blog.djangogirls."
+"org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a>-"
+"Seiten unserer Website geboren wurden. Dies geschah dank der großartigen "
+"Arbeit von Marysia Lowas-Rzechonek und Kasia Siedlarek, beides Django Girls-"
+"Teilnehmerinnen, die mehr über Django lernen wollten, indem sie einen "
+"Beitrag zu Open Source leisteten, sowie Becky Smith, die ihnen als Mentorin "
+"zur Seite stand, und Ania Warzecha, die sie anleitete und den letzten Pull "
+"Request zusammenführte. YAY!"
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
-msgstr "Um das Support-Team weiter zu vergrößern, haben wir <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\"> Lacey zu uns eingeladen</a>. Von Anfang an leistete sie großartige Arbeit bei der Einführung neuer Prozesse, der Verbesserung alter Prozesse und der Verbesserung unserer Transparenzbemühungen."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
+msgstr ""
+"Um das Support-Team weiter zu vergrößern, haben wir <a href=\"http://blog."
+"djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\"> Lacey zu uns eingeladen</a>. Von Anfang an leistete sie großartige "
+"Arbeit bei der Einführung neuer Prozesse, der Verbesserung alter Prozesse "
+"und der Verbesserung unserer Transparenzbemühungen."
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
-msgstr "Der Sommer hat uns auch mit der Einstellung des Awesomeness Ambassador - unseres ersten bezahlten Mitarbeiters - unglaublich beschäftigt! Wir haben buchstäblich Hunderte von Stunden damit verbracht, die beste Bewerberin zu rekrutieren: Lucie Daeye. Das hat sich wirklich gelohnt. Wenn Sie mehr über den Einstellungsprozess erfahren möchten, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">haben wir ihn ausführlich in unserem Blog beschrieben</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
+msgstr ""
+"Der Sommer hat uns auch mit der Einstellung des Awesomeness Ambassador - "
+"unseres ersten bezahlten Mitarbeiters - unglaublich beschäftigt! Wir haben "
+"buchstäblich Hunderte von Stunden damit verbracht, die beste Bewerberin zu "
+"rekrutieren: Lucie Daeye. Das hat sich wirklich gelohnt. Wenn Sie mehr über "
+"den Einstellungsprozess erfahren möchten, <a href=\"http://blog.djangogirls."
+"org/post/129169522198/django-girls-is-hiring-lessons-learned-from-"
+"our\">haben wir ihn ausführlich in unserem Blog beschrieben</a>."
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
-msgstr "Nach dem sehr arbeitsreichen Sommer war es an der Zeit, sich auszuruhen und die Batterien ein wenig aufzuladen. Wir ließen Lucie (die Awesomeness-Botschafterin) die Show für ein paar Wochen leiten, und sie machte einen tollen Job. In dieser Zeit wurde uns auch klar, dass viele von uns einem Burnout nahe waren, und die Entscheidung, unsere erste bezahlte Mitarbeiterin einzustellen, kam genau zum richtigen Zeitpunkt."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
+msgstr ""
+"Nach dem sehr arbeitsreichen Sommer war es an der Zeit, sich auszuruhen und "
+"die Batterien ein wenig aufzuladen. Wir ließen Lucie (die Awesomeness-"
+"Botschafterin) die Show für ein paar Wochen leiten, und sie machte einen "
+"tollen Job. In dieser Zeit wurde uns auch klar, dass viele von uns einem "
+"Burnout nahe waren, und die Entscheidung, unsere erste bezahlte "
+"Mitarbeiterin einzustellen, kam genau zum richtigen Zeitpunkt."
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
-msgstr "Lucie konzentrierte einige ihrer Bemühungen auf Fundraising-Aktivitäten und reiste nach München zur Elastic{ON} Tour nach München, um den Stand von Django Girls zu betreuen. Wir haben uns mit Elastic zusammengetan, und nach der Veranstaltung haben sie eine erstaunliche Spende von 17.000 Dollar gemacht! Das ist die größte Spende, die wir bisher gesehen haben, und völlig unerwartet. Nochmals vielen Dank!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
+msgstr ""
+"Lucie konzentrierte einige ihrer Bemühungen auf Fundraising-Aktivitäten und "
+"reiste nach München zur Elastic{ON} Tour nach München, um den Stand von "
+"Django Girls zu betreuen. Wir haben uns mit Elastic zusammengetan, und nach "
+"der Veranstaltung haben sie eine erstaunliche Spende von 17.000 Dollar "
+"gemacht! Das ist die größte Spende, die wir bisher gesehen haben, und völlig "
+"unerwartet. Nochmals vielen Dank!"
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
-msgstr "Im Oktober beschloss Ania Warzecha, aus dem Support-Team auszuscheiden, und schrieb einen wertvollen Beitrag über <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">Überengagement und Burnout</a>. Dadurch wurde uns noch bewusster, wie wichtig es ist, bei der ehrenamtlichen Arbeit und der Open-Source-Arbeit eine gute Selbstfürsorge zu praktizieren."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
+msgstr ""
+"Im Oktober beschloss Ania Warzecha, aus dem Support-Team auszuscheiden, und "
+"schrieb einen wertvollen Beitrag über <a href=\"http://blog.djangogirls.org/"
+"post/131283812099/overcommitment-and-burnout\">Überengagement und Burnout</"
+"a>. Dadurch wurde uns noch bewusster, wie wichtig es ist, bei der "
+"ehrenamtlichen Arbeit und der Open-Source-Arbeit eine gute Selbstfürsorge zu "
+"praktizieren."
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
-msgstr "Wir haben unsere E-Mails nicht mehr auf einem VPS gehostet, der uns großzügig von Megiteam zur Verfügung gestellt wurde, sondern auf Google Apps, das für uns kostenlos wurde, als wir uns offiziell als Wohltätigkeitsorganisation registriert haben. Das war ein ziemliches Projekt: 100+ E-Mail-Konten und Zehntausende von E-Mails umzustellen, ohne die Organisation zu unterbrechen! Ohne Adria Richards, die sich freiwillig gemeldet und uns ihr Wissen und ihre Erfahrung kostenlos zur Verfügung gestellt hat, wäre dies nicht so reibungslos verlaufen. Vielen Dank, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
+msgstr ""
+"Wir haben unsere E-Mails nicht mehr auf einem VPS gehostet, der uns "
+"großzügig von Megiteam zur Verfügung gestellt wurde, sondern auf Google "
+"Apps, das für uns kostenlos wurde, als wir uns offiziell als "
+"Wohltätigkeitsorganisation registriert haben. Das war ein ziemliches "
+"Projekt: 100+ E-Mail-Konten und Zehntausende von E-Mails umzustellen, ohne "
+"die Organisation zu unterbrechen! Ohne Adria Richards, die sich freiwillig "
+"gemeldet und uns ihr Wissen und ihre Erfahrung kostenlos zur Verfügung "
+"gestellt hat, wäre dies nicht so reibungslos verlaufen. Vielen Dank, Adria!"
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
-msgstr "Seit Lucie dem Team beigetreten ist, haben wir auch unsere Kommunikation erheblich verbessert: Der Django Girls Dispatch wird regelmäßig alle zwei Wochen an fast 1.100 Personen verschickt! <a href=\"https://djangogirls.org/newsletter/\">Hier</a> finden Sie alle bisher von uns verschickten Dispatches."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
+msgstr ""
+"Seit Lucie dem Team beigetreten ist, haben wir auch unsere Kommunikation "
+"erheblich verbessert: Der Django Girls Dispatch wird regelmäßig alle zwei "
+"Wochen an fast 1.100 Personen verschickt! <a href=\"https://djangogirls.org/"
+"newsletter/\">Hier</a> finden Sie alle bisher von uns verschickten "
+"Dispatches."
 
 #: templates/core/2015.html:351
 msgid "Success stories 💖"
 msgstr "Erfolgsgeschichten 💖"
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
-msgstr "Wir haben keine Informationen über die Anzahl der Personen, die nach Django Girls zu Entwicklern wurden, und diese Informationen sind schwer zu sammeln. Aber es ist eine wichtige Kennzahl. In diesem Abschnitt stellen wir Interviews mit einigen Django Girls-Teilnehmern vor, die seit dem Workshop zu professionellen Entwicklern geworden sind. Wir hoffen, dass diese Anekdoten Ihnen einen Eindruck davon vermitteln, wie mächtig und lebensverändernd die Teilnahme an einem Django Girls Workshop sein kann."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
+msgstr ""
+"Wir haben keine Informationen über die Anzahl der Personen, die nach Django "
+"Girls zu Entwicklern wurden, und diese Informationen sind schwer zu sammeln. "
+"Aber es ist eine wichtige Kennzahl. In diesem Abschnitt stellen wir "
+"Interviews mit einigen Django Girls-Teilnehmern vor, die seit dem Workshop "
+"zu professionellen Entwicklern geworden sind. Wir hoffen, dass diese "
+"Anekdoten Ihnen einen Eindruck davon vermitteln, wie mächtig und "
+"lebensverändernd die Teilnahme an einem Django Girls Workshop sein kann."
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
-msgstr "Agata Grdal ist 23 und lebt in Wrocław, Polen. Sie nahm an der allerersten Django Girls-Veranstaltung auf der EuroPython teil und begann kurz darauf als Python-Entwicklerin zu arbeiten. Jetzt studiert sie auch Informatik und ist Mitorganisatorin eines lokalen Treffens für Python-Entwickler in ihrer Stadt."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
+msgstr ""
+"Agata Grdal ist 23 und lebt in Wrocław, Polen. Sie nahm an der allerersten "
+"Django Girls-Veranstaltung auf der EuroPython teil und begann kurz darauf "
+"als Python-Entwicklerin zu arbeiten. Jetzt studiert sie auch Informatik und "
+"ist Mitorganisatorin eines lokalen Treffens für Python-Entwickler in ihrer "
+"Stadt."
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
-msgstr "Django Girls hat mir zu mehr Selbstvertrauen verholfen und mir einen Schub gegeben, weiter zu lernen. Ich habe meinen eigenen Blog erstellt und dann Workshops vorbereitet und anderen Frauen das Programmieren beigebracht. Mit diesem Haufen verrückter, positiver Menschen ist nichts unmöglich!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
+msgstr ""
+"Django Girls hat mir zu mehr Selbstvertrauen verholfen und mir einen Schub "
+"gegeben, weiter zu lernen. Ich habe meinen eigenen Blog erstellt und dann "
+"Workshops vorbereitet und anderen Frauen das Programmieren beigebracht. Mit "
+"diesem Haufen verrückter, positiver Menschen ist nichts unmöglich!"
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
-msgstr "Catherine ist 25 Jahre alt und lebt in Frankreich. Nach der Teilnahme an der Django-Girls-Veranstaltung in Paris beschloss sie, den Beruf zu wechseln und studiert jetzt Vollzeit Computerprogrammierung."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
+msgstr ""
+"Catherine ist 25 Jahre alt und lebt in Frankreich. Nach der Teilnahme an der "
+"Django-Girls-Veranstaltung in Paris beschloss sie, den Beruf zu wechseln und "
+"studiert jetzt Vollzeit Computerprogrammierung."
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
-msgstr "Ich war auf der Suche nach einer professionellen Umstellung, als ich auf Django Girls stieß, und es war mein erstes Eintauchen in die Welt der Programmierung. Es war wunderbar! Das Lerntempo war intensiv und aufregend, und die Gemeinschaft, die auf starken Werten aufbaut, war sehr einladend. Das hat mich ermutigt, mich weiter mit diesem Bereich zu befassen, und ich studiere ihn jetzt in Vollzeit!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
+msgstr ""
+"Ich war auf der Suche nach einer professionellen Umstellung, als ich auf "
+"Django Girls stieß, und es war mein erstes Eintauchen in die Welt der "
+"Programmierung. Es war wunderbar! Das Lerntempo war intensiv und aufregend, "
+"und die Gemeinschaft, die auf starken Werten aufbaut, war sehr einladend. "
+"Das hat mich ermutigt, mich weiter mit diesem Bereich zu befassen, und ich "
+"studiere ihn jetzt in Vollzeit!"
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
-msgstr "Maria Lowas-Rzechonek ist 32 Jahre alt und lebt in Kraków, Polen. Seit Dezember 2015 kann sie mit Stolz \"Junior Django Developer\" als ihre neue Berufsbezeichnung hinzufügen. Außerdem war sie Mitorganisatorin von Django Girls Kraków 2014 und Coach bei Django Girls Kraków 2015. Im letzten Frühjahr organisierte sie mit einer Gruppe von Leuten einen zweimonatigen wöchentlichen Workshop für Anfänger, um das Lösen einfacher Programmierprobleme in Python zu üben. In jüngster Zeit war sie auch an der Organisation der Krakauer Python User Group und der DjangoCon Europe 2016 beteiligt."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgstr ""
+"Maria Lowas-Rzechonek ist 32 Jahre alt und lebt in Kraków, Polen. Seit "
+"Dezember 2015 kann sie mit Stolz \"Junior Django Developer\" als ihre neue "
+"Berufsbezeichnung hinzufügen. Außerdem war sie Mitorganisatorin von Django "
+"Girls Kraków 2014 und Coach bei Django Girls Kraków 2015. Im letzten "
+"Frühjahr organisierte sie mit einer Gruppe von Leuten einen zweimonatigen "
+"wöchentlichen Workshop für Anfänger, um das Lösen einfacher "
+"Programmierprobleme in Python zu üben. In jüngster Zeit war sie auch an der "
+"Organisation der Krakauer Python User Group und der DjangoCon Europe 2016 "
+"beteiligt."
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
-msgstr "Ohne die Django Girls wäre ich nicht da, wo ich jetzt bin. Ich wäre nicht so motiviert gewesen, das Programmieren weiter zu lernen, wenn ich nicht an den Django Girls bei der EuroPython 2014 teilgenommen hätte. Ich hätte nicht so eine wunderbare Erfahrung mit der Django/Python-Community gemacht, und wahrscheinlich würde ich mich deshalb auch nicht an lokalen Treffen beteiligen. Ohne den Django Girls Winter of Code hätte ich nicht diese großartige Gelegenheit, zu üben und meinen Code zu veröffentlichen. Und schließlich würde ich ohne Django Girls nicht all diese wunderbaren Menschen kennenlernen, die mich mit Leuten in Kontakt bringen, die nach Nachwuchsentwicklern suchen. Programmieren zu lernen ist eine gefährliche Reise, wenn man sie allein antritt."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
+msgstr ""
+"Ohne die Django Girls wäre ich nicht da, wo ich jetzt bin. Ich wäre nicht so "
+"motiviert gewesen, das Programmieren weiter zu lernen, wenn ich nicht an den "
+"Django Girls bei der EuroPython 2014 teilgenommen hätte. Ich hätte nicht so "
+"eine wunderbare Erfahrung mit der Django/Python-Community gemacht, und "
+"wahrscheinlich würde ich mich deshalb auch nicht an lokalen Treffen "
+"beteiligen. Ohne den Django Girls Winter of Code hätte ich nicht diese "
+"großartige Gelegenheit, zu üben und meinen Code zu veröffentlichen. Und "
+"schließlich würde ich ohne Django Girls nicht all diese wunderbaren Menschen "
+"kennenlernen, die mich mit Leuten in Kontakt bringen, die nach "
+"Nachwuchsentwicklern suchen. Programmieren zu lernen ist eine gefährliche "
+"Reise, wenn man sie allein antritt."
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
-msgstr "Päivi Suomela ist 30 Jahre alt und lebt in Sheffield, UK. Nachdem sie an Django Girls London 2015 teilgenommen hat, bekam sie einen Job als Junior Full-Stack Developer und arbeitet nun täglich mit Django, Python, C# und JavaScript! Im Herbst organisierte sie die Django Girls Coventry auf der PyCon UK 2015 und ist gerade dabei, die Django Girls Sheffield zu leiten, die im Februar 2016 stattfinden werden. Sie war auch am <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> beteiligt, bei dem es darum ging, Python für BBC Micro:Bit zu schreiben, was ihr sehr viel Spaß gemacht hat."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
+msgstr ""
+"Päivi Suomela ist 30 Jahre alt und lebt in Sheffield, UK. Nachdem sie an "
+"Django Girls London 2015 teilgenommen hat, bekam sie einen Job als Junior "
+"Full-Stack Developer und arbeitet nun täglich mit Django, Python, C# und "
+"JavaScript! Im Herbst organisierte sie die Django Girls Coventry auf der "
+"PyCon UK 2015 und ist gerade dabei, die Django Girls Sheffield zu leiten, "
+"die im Februar 2016 stattfinden werden. Sie war auch am <a href=\"http://"
+"microworldtour.github.io/about.html\">microbit worldtour project</a> "
+"beteiligt, bei dem es darum ging, Python für BBC Micro:Bit zu schreiben, was "
+"ihr sehr viel Spaß gemacht hat."
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
-msgstr "Ich hörte zum ersten Mal von Django Girls, als es gerade anfing, und bewarb mich für den ersten Workshop, wurde aber damals nicht ausgewählt. Als der Workshop im März 2015 in London stattfand, bewarb ich mich erneut, und diesmal wurde ich angenommen. Ich hatte selbst programmieren gelernt, aber der Workshop gab mir den nötigen Anstoß, mich ernsthaft damit zu beschäftigen und tatsächlich zu versuchen, Arbeit als Entwicklerin zu finden. Es war toll, Geschichten von anderen Frauen zu hören, die Entwicklerinnen geworden sind, obwohl sie nicht CS an der Universität studiert und bereits in anderen Berufen gearbeitet haben. Dadurch wurde mir klar, dass ich es auch schaffen könnte! Außerdem habe ich durch Django Girls viele nette Leute kennengelernt und von verschiedenen Möglichkeiten gehört, von denen ich sonst vielleicht nicht gewusst hätte."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
+msgstr ""
+"Ich hörte zum ersten Mal von Django Girls, als es gerade anfing, und bewarb "
+"mich für den ersten Workshop, wurde aber damals nicht ausgewählt. Als der "
+"Workshop im März 2015 in London stattfand, bewarb ich mich erneut, und "
+"diesmal wurde ich angenommen. Ich hatte selbst programmieren gelernt, aber "
+"der Workshop gab mir den nötigen Anstoß, mich ernsthaft damit zu "
+"beschäftigen und tatsächlich zu versuchen, Arbeit als Entwicklerin zu "
+"finden. Es war toll, Geschichten von anderen Frauen zu hören, die "
+"Entwicklerinnen geworden sind, obwohl sie nicht CS an der Universität "
+"studiert und bereits in anderen Berufen gearbeitet haben. Dadurch wurde mir "
+"klar, dass ich es auch schaffen könnte! Außerdem habe ich durch Django Girls "
+"viele nette Leute kennengelernt und von verschiedenen Möglichkeiten gehört, "
+"von denen ich sonst vielleicht nicht gewusst hätte."
 
 #: templates/core/2015.html:461
 msgid "Summary 👍"
@@ -1498,120 +2406,315 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr "2015 war ein unglaublich arbeitsreiches Jahr für Django Girls."
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
-msgstr "Von einer winzigen und lose definierten Organisation im Jahr 2014 wuchsen wir zur Django Girls Foundation heran und stellten eine Person ein, die sich ausschließlich um Django Girls kümmert."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
+msgstr ""
+"Von einer winzigen und lose definierten Organisation im Jahr 2014 wuchsen "
+"wir zur Django Girls Foundation heran und stellten eine Person ein, die sich "
+"ausschließlich um Django Girls kümmert."
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
-msgstr "Wir sind unglaublich stolz darauf, wie viel die Django Girls-Community im vergangenen Jahr erreicht hat, und wir hoffen, dass 2016 noch besser und aufregender wird!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
+msgstr ""
+"Wir sind unglaublich stolz darauf, wie viel die Django Girls-Community im "
+"vergangenen Jahr erreicht hat, und wir hoffen, dass 2016 noch besser und "
+"aufregender wird!"
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
-msgstr "Um Django Girls nachhaltig zu machen und weiteres Wachstum zu ermöglichen, <span><b>brauchen wir Ihre Hilfe</b></span>. Eines unserer Ziele für 2016 ist es, die Position des Awesomeness Ambassador für die Zukunft zu sichern und die Einnahmen aus <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> zu erhöhen, um die damit verbundenen Kosten zu decken. Wir hoffen, dass wir in den nächsten Monaten mit Hilfe der großartigen Community rund um Django Girls weiterhin die Liebe zum Programmieren auf der ganzen Welt verbreiten können. Um uns dabei zu helfen, erwägen Sie bitte, einen monatlichen Beitrag zu <a href=\"https://www.patreon.com/djangogirls\">unserer Patreon-Kampagne</a> zu leisten, oder <a href=\"https://djangogirls.org/contact/\">schicken Sie uns eine E-Mail</a>, um ein Sponsoring zu besprechen. Wir versprechen, Sie werden es nicht bereuen!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
+msgstr ""
+"Um Django Girls nachhaltig zu machen und weiteres Wachstum zu ermöglichen, "
+"<span><b>brauchen wir Ihre Hilfe</b></span>. Eines unserer Ziele für 2016 "
+"ist es, die Position des Awesomeness Ambassador für die Zukunft zu sichern "
+"und die Einnahmen aus <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> zu erhöhen, um die damit verbundenen Kosten zu "
+"decken. Wir hoffen, dass wir in den nächsten Monaten mit Hilfe der "
+"großartigen Community rund um Django Girls weiterhin die Liebe zum "
+"Programmieren auf der ganzen Welt verbreiten können. Um uns dabei zu helfen, "
+"erwägen Sie bitte, einen monatlichen Beitrag zu <a href=\"https://www."
+"patreon.com/djangogirls\">unserer Patreon-Kampagne</a> zu leisten, oder <a "
+"href=\"https://djangogirls.org/contact/\">schicken Sie uns eine E-Mail</a>, "
+"um ein Sponsoring zu besprechen. Wir versprechen, Sie werden es nicht "
+"bereuen!"
 
 #: templates/core/2015.html:479
 msgid "Thank you for constant support and love we receive from you!"
-msgstr "Vielen Dank für die ständige Unterstützung und Liebe, die wir von Ihnen erhalten!"
+msgstr ""
+"Vielen Dank für die ständige Unterstützung und Liebe, die wir von Ihnen "
+"erhalten!"
 
 #: templates/core/2015.html:486 templates/core/2016-2017.html:422
 msgid "Sponsors 📢️"
 msgstr "Sponsoren 📢️"
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
-msgstr "Wir möchten uns nochmals bei den großartigen Sponsoren von Django Girls und den einzelnen Django Girls Workshops auf der ganzen Welt bedanken. Sie helfen uns, Django Girls nachhaltig zu gestalten und, was noch wichtiger ist, sie helfen den lokalen Organisatoren, ihre Veranstaltungen kostenlos zu halten. Wir möchten, dass Django Girls so vielen Menschen wie möglich zugänglich ist, und das wäre ohne sie nicht möglich."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
+msgstr ""
+"Wir möchten uns nochmals bei den großartigen Sponsoren von Django Girls und "
+"den einzelnen Django Girls Workshops auf der ganzen Welt bedanken. Sie "
+"helfen uns, Django Girls nachhaltig zu gestalten und, was noch wichtiger "
+"ist, sie helfen den lokalen Organisatoren, ihre Veranstaltungen kostenlos zu "
+"halten. Wir möchten, dass Django Girls so vielen Menschen wie möglich "
+"zugänglich ist, und das wäre ohne sie nicht möglich."
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
-msgstr "Elastic ist bekannt für Elasticsearch, Kibana, Beats und Logstash und entwickelt Produkte für die Suche, Analyse und Visualisierung von Daten, mit denen Sie in Echtzeit verwertbare Erkenntnisse gewinnen können. Bevor sie zu einem unserer größten Sponsoren wurden, haben sie auch mehrere lokale Veranstaltungen gesponsert. Danke <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
+msgstr ""
+"Elastic ist bekannt für Elasticsearch, Kibana, Beats und Logstash und "
+"entwickelt Produkte für die Suche, Analyse und Visualisierung von Daten, mit "
+"denen Sie in Echtzeit verwertbare Erkenntnisse gewinnen können. Bevor sie zu "
+"einem unserer größten Sponsoren wurden, haben sie auch mehrere lokale "
+"Veranstaltungen gesponsert. Danke <3"
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
-msgstr "Die Django Software Foundation (DSF) ist eine gemeinnützige Organisation, die die Entwicklung von Django fördert, unterstützt und vorantreibt. Sie hat schon vielen Django Girls Veranstaltungen geholfen, die Probleme hatten, lokale Sponsoren zu finden. Danke <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
+msgstr ""
+"Die Django Software Foundation (DSF) ist eine gemeinnützige Organisation, "
+"die die Entwicklung von Django fördert, unterstützt und vorantreibt. Sie hat "
+"schon vielen Django Girls Veranstaltungen geholfen, die Probleme hatten, "
+"lokale Sponsoren zu finden. Danke <3"
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
-msgstr "Die Python Software Foundation (PSF) ist eine gemeinnützige Organisation, die die geistigen Eigentumsrechte an der Programmiersprache Python hält. Sie ist einer der größten Sponsoren für lokale Veranstaltungen. Danke <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
+msgstr ""
+"Die Python Software Foundation (PSF) ist eine gemeinnützige Organisation, "
+"die die geistigen Eigentumsrechte an der Programmiersprache Python hält. Sie "
+"ist einer der größten Sponsoren für lokale Veranstaltungen. Danke <3"
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
-msgstr "GitHub ist ein Git-Repository-Hosting-Dienst. Sie haben viele Django Girls Veranstaltungen gesponsert und stellen nützliche Materialien für neue Lernende wie Spickzettel zur Verfügung. Danke <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
+msgstr ""
+"GitHub ist ein Git-Repository-Hosting-Dienst. Sie haben viele Django Girls "
+"Veranstaltungen gesponsert und stellen nützliche Materialien für neue "
+"Lernende wie Spickzettel zur Verfügung. Danke <3"
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
-msgstr "Divio, das Unternehmen, das Django CMS und Aldryn entwickelt hat, nutzt Python und Django, um Unterstützung bei der Installation, Wartung, Fehlerbehebung und Entwicklung von Websites zu leisten. Sie haben viele lokale Veranstaltungen gesponsert und sind im Juni 2015 als Patreon-Unterstützer beigetreten. Danke <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
+msgstr ""
+"Divio, das Unternehmen, das Django CMS und Aldryn entwickelt hat, nutzt "
+"Python und Django, um Unterstützung bei der Installation, Wartung, "
+"Fehlerbehebung und Entwicklung von Websites zu leisten. Sie haben viele "
+"lokale Veranstaltungen gesponsert und sind im Juni 2015 als Patreon-"
+"Unterstützer beigetreten. Danke <3"
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
-msgstr "Lincoln Loop ist ein Full-Service-Webstudio, das User Experience und Entwicklung auf Basis des Django Web Frameworks anbietet. Sie sind unserer Patreon-Kampagne im April 2015 beigetreten und haben zu lokalen Veranstaltungen beigetragen. Danke <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
+msgstr ""
+"Lincoln Loop ist ein Full-Service-Webstudio, das User Experience und "
+"Entwicklung auf Basis des Django Web Frameworks anbietet. Sie sind unserer "
+"Patreon-Kampagne im April 2015 beigetreten und haben zu lokalen "
+"Veranstaltungen beigetragen. Danke <3"
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
-msgstr "Seit Mai wird Django Girls auf PythonAnywhere gehostet! Sie hosten, betreiben und kodieren Python in der Cloud und haben das Leben unserer Teilnehmer viel einfacher gemacht, da sie wirklich einfach und angenehm zu bedienen sind. Danke <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
+msgstr ""
+"Seit Mai wird Django Girls auf PythonAnywhere gehostet! Sie hosten, "
+"betreiben und kodieren Python in der Cloud und haben das Leben unserer "
+"Teilnehmer viel einfacher gemacht, da sie wirklich einfach und angenehm zu "
+"bedienen sind. Danke <3"
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
-msgstr "Mandrill ist eine transaktionale E-Mail-Plattform von MailChimp. Sie unterstützen unsere E-Mails seit September 2015 und haben auch lokale Veranstaltungen gesponsert. Danke <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
+msgstr ""
+"Mandrill ist eine transaktionale E-Mail-Plattform von MailChimp. Sie "
+"unterstützen unsere E-Mails seit September 2015 und haben auch lokale "
+"Veranstaltungen gesponsert. Danke <3"
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
-msgstr "Wir möchten uns auch bei unseren regelmäßigen Spendern von <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> bedanken: Ihr Engagement, uns jeden Monat zu helfen, ist großartig. Danke <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
+msgstr ""
+"Wir möchten uns auch bei unseren regelmäßigen Spendern von <a href=\"https://"
+"www.patreon.com/djangogirls\">Patreon</a> bedanken: Ihr Engagement, uns "
+"jeden Monat zu helfen, ist großartig. Danke <3"
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
 msgid "Django Girls Impact Report 2016-2017"
 msgstr "Django Girls Wirkungsbericht 2016-2017"
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
-msgstr "Dank der Organisatoren, Trainer und Freiwilligen in Ländern auf der ganzen Welt war 2016-2017 ein absolut unglaubliches Jahr für Django Girls. Lesen Sie alles über unsere Herausforderungen und Erfolge von 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
+msgstr ""
+"Dank der Organisatoren, Trainer und Freiwilligen in Ländern auf der ganzen "
+"Welt war 2016-2017 ein absolut unglaubliches Jahr für Django Girls. Lesen "
+"Sie alles über unsere Herausforderungen und Erfolge von 2016-2017."
 
 #: templates/core/2016-2017.html:26
 msgid "Impact Report 2016-2017"
 msgstr "Wirkungsbericht 2016-2017"
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
-msgstr "Die Django Girls Foundation ist eine Initiative, die darauf abzielt, Frauen und Mädchen, die noch nie programmiert haben, in die Welt der Technologie einzuführen und die Vielfalt in der Technologiebranche zu erhöhen. Wir erreichen dies, indem wir eintägige Workshops veranstalten und Frauen einladen, zu kommen und zu lernen, wie man das Internet mit HTML, CSS, Python und Django aufbaut. Django Girls ist eine ehrenamtlich geführte Organisation mit Freiwilligen aus der ganzen Welt. Django Girls hat zwei bezahlte Teilzeitmitarbeiterinnen und ein Support-Team (sechs großartige Frauen, die ebenfalls Freiwillige sind), die alle anderen Freiwilligen unterstützen."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
+msgstr ""
+"Die Django Girls Foundation ist eine Initiative, die darauf abzielt, Frauen "
+"und Mädchen, die noch nie programmiert haben, in die Welt der Technologie "
+"einzuführen und die Vielfalt in der Technologiebranche zu erhöhen. Wir "
+"erreichen dies, indem wir eintägige Workshops veranstalten und Frauen "
+"einladen, zu kommen und zu lernen, wie man das Internet mit HTML, CSS, "
+"Python und Django aufbaut. Django Girls ist eine ehrenamtlich geführte "
+"Organisation mit Freiwilligen aus der ganzen Welt. Django Girls hat zwei "
+"bezahlte Teilzeitmitarbeiterinnen und ein Support-Team (sechs großartige "
+"Frauen, die ebenfalls Freiwillige sind), die alle anderen Freiwilligen "
+"unterstützen."
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
-msgstr "Dieser Impact Report soll die Errungenschaften der Django Girls-Community in den letzten zwei Jahren feiern und das unglaubliche Wachstum der Organisation aufzeigen. Zum ersten Mal präsentieren wir auch die Ergebnisse einer Umfrage, die wir mit fast 600 ehemaligen Django Girls-Teilnehmern durchgeführt haben, um herauszufinden, ob die Django Girls Foundation tatsächlich das Ziel unserer Mission erreicht: mehr Frauen in die Tech-Industrie zu bringen!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
+msgstr ""
+"Dieser Impact Report soll die Errungenschaften der Django Girls-Community in "
+"den letzten zwei Jahren feiern und das unglaubliche Wachstum der "
+"Organisation aufzeigen. Zum ersten Mal präsentieren wir auch die Ergebnisse "
+"einer Umfrage, die wir mit fast 600 ehemaligen Django Girls-Teilnehmern "
+"durchgeführt haben, um herauszufinden, ob die Django Girls Foundation "
+"tatsächlich das Ziel unserer Mission erreicht: mehr Frauen in die Tech-"
+"Industrie zu bringen!"
 
 #: templates/core/2016-2017.html:50
 msgid "✨ Highlights ✨"
 msgstr "✨ Highlights ✨"
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
-msgstr "Die Django-Girls-Gemeinschaft ist auf <span>1069 Freiwillige</span> angewachsen, die <span>377 kostenlose Workshops</span> organisiert haben, und <span>102 weitere</span> sind derzeit geplant. Das sind mehr als 3000 Stunden fröhliches Programmieren!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
+msgstr ""
+"Die Django-Girls-Gemeinschaft ist auf <span>1069 Freiwillige</span> "
+"angewachsen, die <span>377 kostenlose Workshops</span> organisiert haben, "
+"und <span>102 weitere</span> sind derzeit geplant. Das sind mehr als 3000 "
+"Stunden fröhliches Programmieren!"
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
-msgstr "👩‍💻 <span>21%</span> der Teilnehmerinnen an unserer Umfrage <span>begannen nach dem Besuch des Django Girls-Workshops in der Tech-Branche zu arbeiten</span>. <a href=\"#beschäftigungsstatistiken\">👉</a>"
+#, fuzzy, python-format
+#| msgid ""
+#| "👩‍💻 <span>21%%</span> of participants in our survey <span>started "
+#| "working in tech</span> after attending Django Girls workshop. <a "
+#| "href=\"#employment-stats\">👉</a>"
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
+msgstr ""
+"👩‍💻 <span>21%</span> der Teilnehmerinnen an unserer Umfrage <span>begannen "
+"nach dem Besuch des Django Girls-Workshops in der Tech-Branche zu arbeiten</"
+"span>. <a href=\"#beschäftigungsstatistiken\">👉</a>"
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
-msgstr "💯 In den letzten 2 Jahren haben wir unsere Tools verbessert, um das Wachstum der Organisation zu unterstützen, unsere kostenlosen Online-Ressourcen erweitert (unser Tutorial gibt es jetzt in <span>14 Sprachen!</span>), den Django Girls Store als Fundraising-Maßnahme gestartet, <span>146 Organizer-Kits</span> verschickt und mehr.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
+msgstr ""
+"💯 In den letzten 2 Jahren haben wir unsere Tools verbessert, um das "
+"Wachstum der Organisation zu unterstützen, unsere kostenlosen Online-"
+"Ressourcen erweitert (unser Tutorial gibt es jetzt in <span>14 Sprachen!</"
+"span>), den Django Girls Store als Fundraising-Maßnahme gestartet, <span>146 "
+"Organizer-Kits</span> verschickt und mehr.  <a href=\"#tutorial\">👉</a>"
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
-msgstr "📈🎉 Im Juli 2017, an unserem 3. Geburtstag, feierten wir auch unseren <span>10.000sten Workshop-Teilnehmer</span> <a href=\"#wachstums\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgstr ""
+"📈🎉 Im Juli 2017, an unserem 3. Geburtstag, feierten wir auch unseren "
+"<span>10.000sten Workshop-Teilnehmer</span> <a href=\"#wachstums\">👉</a>"
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
-msgstr "🎓 Wir haben erfahren, dass <span>79%</span> der Django Girls Absolventinnen nach dem Workshop <span>immer noch programmieren lernen</span>. <a href=\"#learning-stats\">👉</a>"
+#, fuzzy, python-format
+#| msgid ""
+#| "🎓 We learned that <span>79%%</span> of Django Girls alumnis are "
+#| "<span>still learning programming</span> after the workshop. <a "
+#| "href=\"#learning-stats\">👉</a>"
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
+msgstr ""
+"🎓 Wir haben erfahren, dass <span>79%</span> der Django Girls Absolventinnen "
+"nach dem Workshop <span>immer noch programmieren lernen</span>. <a "
+"href=\"#learning-stats\">👉</a>"
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
-msgstr "📚 <span>693.524 Menschen</span> haben im letzten Jahr unser kostenloses Online-<a href=\"https://tutorial.djangogirls.org\">Tutorial</a> genutzt"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgstr ""
+"📚 <span>693.524 Menschen</span> haben im letzten Jahr unser kostenloses "
+"Online-<a href=\"https://tutorial.djangogirls.org\">Tutorial</a> genutzt"
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr "Wachstum 📈"
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
-msgstr "Karte der Django Girls Veranstaltung von Juli 2014 bis Juli 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
+msgstr "Karte der Django Girls Veranstaltungen von Januar 2016 bis Juli 2017"
 
 #: templates/core/2016-2017.html:94
 msgid "2014-2015"
@@ -1655,7 +2758,9 @@ msgstr "Eindeutige Tutorial-Leser"
 
 #: templates/core/2016-2017.html:109
 msgid "* Gathering events data on number of participants is delayed."
-msgstr "* Die Erhebung von Daten über die Anzahl der Teilnehmer an Veranstaltungen verzögert sich."
+msgstr ""
+"* Die Erhebung von Daten über die Anzahl der Teilnehmer an Veranstaltungen "
+"verzögert sich."
 
 #: templates/core/2016-2017.html:116
 msgid "Foundation's Activities 👩‍💻👩‍💻👩‍💻"
@@ -1666,12 +2771,42 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr "🌎 Wartung & übersetzung unserer kostenlosen online Ressourcen"
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
-msgstr "Das von uns entwickelte Django Girls Tutorial wird in unseren Workshops verwendet, um die Teilnehmer in die Webentwicklung mit Python und Django einzuführen. Das Tutorial wurde kostenlos online veröffentlicht, damit jeder es lernen kann, ohne an einem persönlichen Workshop teilnehmen zu müssen.<br /> Wir sind stolz darauf, dass das <span>Tutorial mittlerweile in 14 Sprachen</span> übersetzt wurde und danken allen Freiwilligen, die dies möglich gemacht haben."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
+msgstr ""
+"Das von uns entwickelte Django Girls Tutorial wird in unseren Workshops "
+"verwendet, um die Teilnehmer in die Webentwicklung mit Python und Django "
+"einzuführen. Das Tutorial wurde kostenlos online veröffentlicht, damit jeder "
+"es lernen kann, ohne an einem persönlichen Workshop teilnehmen zu müssen."
+"<br /> Wir sind stolz darauf, dass das <span>Tutorial mittlerweile in 14 "
+"Sprachen</span> übersetzt wurde und danken allen Freiwilligen, die dies "
+"möglich gemacht haben."
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
-msgstr "Die Beliebtheit des Online-Tutorials wächst deutlich schneller als die unserer persönlichen Workshops. Im zweiten Jahr stieg die Zahl der Nutzer, die das Tutorial verwendet haben, um 328,95 % und im letzten Jahr um 121,53 %. Seit der Veröffentlichung des Tutorials wurde es <span>von 1.068.995 Personen gelesen!</span>"
+#, fuzzy, python-format
+#| msgid ""
+#| "The popularity of the online tutorial keeps growing significantly faster "
+#| "than our in-person workshops. In the second year it gained a 328.95%% "
+#| "increase in the number of unique users who used the tutorial, and "
+#| "121.53%% increase in the last year. Since the tutorial as been published, "
+#| "it's been <span>read by 1,068,995 of people!</span>"
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
+msgstr ""
+"Die Beliebtheit des Online-Tutorials wächst deutlich schneller als die "
+"unserer persönlichen Workshops. Im zweiten Jahr stieg die Zahl der Nutzer, "
+"die das Tutorial verwendet haben, um 328,95 % und im letzten Jahr um 121,53 "
+"%. Seit der Veröffentlichung des Tutorials wurde es <span>von 1.068.995 "
+"Personen gelesen!</span>"
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
 msgid "Your browser does not support the video tag."
@@ -1682,20 +2817,54 @@ msgid "🎁 Organiser Starter Kits"
 msgstr "🎁 Organisatoren Starter Kits"
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
-msgstr "Wir haben festgestellt, dass bestimmte Dinge wie Raumdekoration und Werbegeschenke (Aufkleber, Buttons und Tattoos) von allen Veranstaltern benötigt werden. Wir haben die Kosten für Dekoration und Swag für jede Veranstaltung gesenkt, indem wir sie in großen Mengen bei Lieferanten bestellt und im Django Girls Shop gelagert haben. Die Organisatoren bestellen dann das Organizer Starter Kit in unserem Shop gegen eine kleine Spende, und wir haben einige davon an Veranstaltungen in Entwicklungsländern gespendet. Wir freuen uns sehr, dass wir 2016 das Django Girls Starter Kit einführen konnten."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
+msgstr ""
+"Wir haben festgestellt, dass bestimmte Dinge wie Raumdekoration und "
+"Werbegeschenke (Aufkleber, Buttons und Tattoos) von allen Veranstaltern "
+"benötigt werden. Wir haben die Kosten für Dekoration und Swag für jede "
+"Veranstaltung gesenkt, indem wir sie in großen Mengen bei Lieferanten "
+"bestellt und im Django Girls Shop gelagert haben. Die Organisatoren "
+"bestellen dann das Organizer Starter Kit in unserem Shop gegen eine kleine "
+"Spende, und wir haben einige davon an Veranstaltungen in Entwicklungsländern "
+"gespendet. Wir freuen uns sehr, dass wir 2016 das Django Girls Starter Kit "
+"einführen konnten."
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
-msgstr "Seit der Einführung haben <span>146 Veranstaltungen ihre Starterkits</span> erhalten, die ihnen geholfen haben, ihre Veranstaltungen großartig zu machen! Davon wurden 28 kostenlos für Veranstaltungen in Not gespendet."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
+msgstr ""
+"Seit der Einführung haben <span>146 Veranstaltungen ihre Starterkits</span> "
+"erhalten, die ihnen geholfen haben, ihre Veranstaltungen großartig zu "
+"machen! Davon wurden 28 kostenlos für Veranstaltungen in Not gespendet."
 
 #: templates/core/2016-2017.html:169
 msgid "💰 Fundraising"
 msgstr "💰 Fundraising"
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
-msgstr "Die meisten unserer Mittel wurden durch Spenden von Unternehmen und Einzelpersonen über Patreon, ein Online-Spendenverwaltungssystem, generiert. Im Jahr 2016 haben wir außerdem den Django Girls Shop eingeführt, in dem wir T-Shirts, Socken und Tragetaschen verkaufen, um die Wohltätigkeitsorganisation nachhaltig zu machen. Einzelheiten zu den Spendeneinnahmen im Jahr 2016 sind in der folgenden Tabelle aufgeführt:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
+msgstr ""
+"Die meisten unserer Mittel wurden durch Spenden von Unternehmen und "
+"Einzelpersonen über Patreon, ein Online-Spendenverwaltungssystem, generiert. "
+"Im Jahr 2016 haben wir außerdem den Django Girls Shop eingeführt, in dem wir "
+"T-Shirts, Socken und Tragetaschen verkaufen, um die "
+"Wohltätigkeitsorganisation nachhaltig zu machen. Einzelheiten zu den "
+"Spendeneinnahmen im Jahr 2016 sind in der folgenden Tabelle aufgeführt:"
 
 #: templates/core/2016-2017.html:183
 msgid "Activity"
@@ -1726,104 +2895,525 @@ msgid "Participants Survey"
 msgstr "Teilnehmer Umfrage"
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
-msgstr "Wir haben das Erreichen unseres Meilensteins von 10.000 Workshop-Teilnehmerinnen gefeiert, indem wir eine Umfrage durchgeführt haben, um herauszufinden, wie es den ehemaligen Teilnehmerinnen von Django Girls geht, nachdem sie den Workshop in ihrer Stadt besucht haben. Wir haben uns an unsere ehemaligen Teilnehmerinnen gewandt und eine überwältigende <span>Antwort von 519 großartigen Frauen</span> erhalten, die uns von ihren Erfahrungen mit Django Girls berichteten und wie die Teilnahme am Workshop ihr Leben verändert hat."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
+msgstr ""
+"Wir haben das Erreichen unseres Meilensteins von 10.000 Workshop-"
+"Teilnehmerinnen gefeiert, indem wir eine Umfrage durchgeführt haben, um "
+"herauszufinden, wie es den ehemaligen Teilnehmerinnen von Django Girls geht, "
+"nachdem sie den Workshop in ihrer Stadt besucht haben. Wir haben uns an "
+"unsere ehemaligen Teilnehmerinnen gewandt und eine überwältigende "
+"<span>Antwort von 519 großartigen Frauen</span> erhalten, die uns von ihren "
+"Erfahrungen mit Django Girls berichteten und wie die Teilnahme am Workshop "
+"ihr Leben verändert hat."
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
-msgstr "Das Alter der <span>Antwortenden reichte von 14 bis 65 Jahren</span>, wobei 71% unter 30 Jahre alt waren. Dies zeigt, dass die Django-Girls-Workshops offen und einladend für Frauen und Mädchen sind, unabhängig von ihrem Alter, solange sie ein Interesse an Technologie und dem Erlernen von Programmierung haben"
+#, fuzzy, python-format
+#| msgid ""
+#| "The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+#| "71%% being under the age of 30. This shows that Django Girls workshops "
+#| "are open and welcoming to women and girls irrespective of their age, as "
+#| "long they have an interest in technology and learning programming"
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+"Das Alter der <span>Antwortenden reichte von 14 bis 65 Jahren</span>, wobei "
+"71% unter 30 Jahre alt waren. Dies zeigt, dass die Django-Girls-Workshops "
+"offen und einladend für Frauen und Mädchen sind, unabhängig von ihrem Alter, "
+"solange sie ein Interesse an Technologie und dem Erlernen von Programmierung "
+"haben"
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
+msgstr ""
+"Auch wenn die Gesamtzahl der eingegangenen Antworten eine repräsentative "
+"Stichprobe der Django Girls Alumni darstellt, ist es wahrscheinlich, dass "
+"die meisten Frauen, die an unserer Umfrage teilgenommen haben, auch nach der "
+"Teilnahme an unseren Workshops in der Tech-Branche aktiv geblieben sind und "
+"die Ergebnisse daher positiv verzerrt sein könnten."
 
 #: templates/core/2016-2017.html:227
 msgid "Participants’ Involvement in Tech Activities"
 msgstr "Beteiligung der Teilnehmer an technischen Aktivitäten"
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
-msgstr "Wir haben die Befragten gefragt, ob sie nach dem Workshop an technikbezogenen Aktivitäten beteiligt waren. Zu den Tech-Aktivitäten gehörten die Teilnahme an Tech-Events, die Organisation von Django Girls und ähnlichen Tech-Events, das Coaching bei Django Girls-Workshops, das Unterrichten oder Arbeiten im Tech-Bereich, die Arbeit an Coding-Projekten und die Anmeldung zu Programmierkursen."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
+msgstr ""
+"Wir haben die Befragten gefragt, ob sie nach dem Workshop an "
+"technikbezogenen Aktivitäten beteiligt waren. Zu den Tech-Aktivitäten "
+"gehörten die Teilnahme an Tech-Events, die Organisation von Django Girls und "
+"ähnlichen Tech-Events, das Coaching bei Django Girls-Workshops, das "
+"Unterrichten oder Arbeiten im Tech-Bereich, die Arbeit an Coding-Projekten "
+"und die Anmeldung zu Programmierkursen."
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
-msgstr "Wir waren erfreut zu erfahren, dass <b>73 % der Befragten auch nach der Veranstaltung noch an technikbezogenen Aktivitäten beteiligt sind</b>."
+#, fuzzy, python-format
+#| msgid ""
+#| "We were excited to learn that <b>73%% of the respondents are still "
+#| "involved tech-related activities</b> after the event."
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
+msgstr ""
+"Wir waren erfreut zu erfahren, dass <b>73 % der Befragten auch nach der "
+"Veranstaltung noch an technikbezogenen Aktivitäten beteiligt sind</b>."
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
-msgstr "Diese Statistiken zeigen, dass unsere Workshops bei den Teilnehmerinnen Interesse an Technologie und Programmierung wecken. Dieses Interesse führt dann dazu, dass sie andere Workshops und technische Veranstaltungen organisieren und einige der Frauen auch an technischen Veranstaltungen teilnehmen. Diese Ergebnisse <b>beweisen, dass die Django-Girls-Workshops eine erfolgreiche Maßnahme</b> waren, um die Zahl der Frauen zu erhöhen, die sich für Technik und Programmierung interessieren."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
+msgstr ""
+"Diese Statistiken zeigen, dass unsere Workshops bei den Teilnehmerinnen "
+"Interesse an Technologie und Programmierung wecken. Dieses Interesse führt "
+"dann dazu, dass sie andere Workshops und technische Veranstaltungen "
+"organisieren und einige der Frauen auch an technischen Veranstaltungen "
+"teilnehmen. Diese Ergebnisse <b>beweisen, dass die Django-Girls-Workshops "
+"eine erfolgreiche Maßnahme</b> waren, um die Zahl der Frauen zu erhöhen, die "
+"sich für Technik und Programmierung interessieren."
 
 #: templates/core/2016-2017.html:258
 msgid "Participants’ learning to code after the workshop"
 msgstr "Die Teilnehmer lernen nach dem Workshop zu programmieren"
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
-msgstr "Wir wollten auch herausfinden, ob unsere ehemaligen Teilnehmer nach dem Workshop weiter programmieren lernten."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
+msgstr ""
+"Wir wollten auch herausfinden, ob unsere ehemaligen Teilnehmer nach dem "
+"Workshop weiter programmieren lernten."
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
-msgstr "79% der Frauen, die am Django Girls Workshop teilgenommen haben, haben danach weiter programmiert und 7% haben vor, weiter zu lernen."
+#, fuzzy, python-format
+#| msgid ""
+#| "79%% of women attending Django Girls workshop continued learning "
+#| "programming after and 7%% were planning to continue learning"
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
+msgstr ""
+"79% der Frauen, die am Django Girls Workshop teilgenommen haben, haben "
+"danach weiter programmiert und 7% haben vor, weiter zu lernen."
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
-msgstr "1 % der Teilnehmer hatten es versucht und aufgegeben, während 13 % das Programmieren nach dem Workshop nicht weiter gelernt hatten."
+#, fuzzy, python-format
+#| msgid ""
+#| "1%% of participants had tried and given up while 13%% had not continued "
+#| "learning programming after the workshop."
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
+msgstr ""
+"1 % der Teilnehmer hatten es versucht und aufgegeben, während 13 % das "
+"Programmieren nach dem Workshop nicht weiter gelernt hatten."
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
-msgstr "Die Ergebnisse zeigen, dass die Mehrheit der Frauen, die an den Django Girls-Workshops teilgenommen haben, danach weiter programmieren lernen. Die Frauen setzten das Lernen auf unterschiedliche Weise fort: einige auf eigene Faust, indem sie sich für Online-Programmierkurse anmeldeten oder sich an Universitäten einschrieben. Diese Ergebnisse zeigen, dass Django Girls tatsächlich die Zahl der Frauen im Bereich der Programmierung erhöht, die eines Tages als Programmiererinnen arbeiten werden, nachdem sie ihre Programmierkenntnisse entwickelt haben."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
+msgstr ""
+"Die Ergebnisse zeigen, dass die Mehrheit der Frauen, die an den Django Girls-"
+"Workshops teilgenommen haben, danach weiter programmieren lernen. Die Frauen "
+"setzten das Lernen auf unterschiedliche Weise fort: einige auf eigene Faust, "
+"indem sie sich für Online-Programmierkurse anmeldeten oder sich an "
+"Universitäten einschrieben. Diese Ergebnisse zeigen, dass Django Girls "
+"tatsächlich die Zahl der Frauen im Bereich der Programmierung erhöht, die "
+"eines Tages als Programmiererinnen arbeiten werden, nachdem sie ihre "
+"Programmierkenntnisse entwickelt haben."
 
 #: templates/core/2016-2017.html:291
 msgid "Participants’ Employment in Tech after attending workshops"
-msgstr "Beschäftigung der Teilnehmer in der Technik nach dem Besuch von Workshops"
+msgstr ""
+"Beschäftigung der Teilnehmer in der Technik nach dem Besuch von Workshops"
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
-msgstr "Die wichtigste Frage, die wir beantworten wollten, war, wie viele der Frauen nach dem Workshop als Entwicklerinnen in der Technologiebranche tätig wurden."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
+msgstr ""
+"Die wichtigste Frage, die wir beantworten wollten, war, wie viele der Frauen "
+"nach dem Workshop als Entwicklerinnen in der Technologiebranche tätig wurden."
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
-msgstr "Wir waren beeindruckt, als wir erfuhren, dass <b>21% der ehemaligen Teilnehmerinnen der Django Girls nach dem Workshop als Entwicklerinnen eingestellt wurden</b>!"
+#, fuzzy, python-format
+#| msgid ""
+#| "We were impressed to learn that <b>21%% of Django Girls' former attendees "
+#| "are now hired as developers</b> after attending the workshop!"
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
+msgstr ""
+"Wir waren beeindruckt, als wir erfuhren, dass <b>21% der ehemaligen "
+"Teilnehmerinnen der Django Girls nach dem Workshop als Entwicklerinnen "
+"eingestellt wurden</b>!"
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
-msgstr "Interessant war auch, dass 15 % der Teilnehmer bereits in der Technikbranche tätig waren und ihre neu erworbenen Fähigkeiten daher ihre Arbeitsplätze verbesserten. Etwa 23 % hatten noch keine Stelle als Entwickler gefunden, waren aber dabei, ihre Fähigkeiten weiterzuentwickeln, um in Zukunft eine Stelle zu finden, während die restlichen 40 % noch keine Stelle im technischen Bereich gefunden hatten und keine Angaben zu ihren Zukunftsplänen machten."
+#, fuzzy, python-format
+#| msgid ""
+#| "It was also interesting to note that 15%% of the attendees of were "
+#| "already working in tech and hence their newly acquired skills made their "
+#| "jobs better. About 23%% had not yet got jobs as developers but were still "
+#| "developing their skills so they could get jobs in the future while the "
+#| "remaining 40%% had not got tech jobs and did not indicate their future "
+#| "plans."
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
+msgstr ""
+"Interessant war auch, dass 15 % der Teilnehmer bereits in der Technikbranche "
+"tätig waren und ihre neu erworbenen Fähigkeiten daher ihre Arbeitsplätze "
+"verbesserten. Etwa 23 % hatten noch keine Stelle als Entwickler gefunden, "
+"waren aber dabei, ihre Fähigkeiten weiterzuentwickeln, um in Zukunft eine "
+"Stelle zu finden, während die restlichen 40 % noch keine Stelle im "
+"technischen Bereich gefunden hatten und keine Angaben zu ihren "
+"Zukunftsplänen machten."
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
-msgstr "Dies bestätigt, dass sich unsere Arbeit positiv auf das Leben der Frauen auswirkt, die wir an das Programmieren herangeführt haben, sowie auf die Technologiebranche, die diese Frauen einstellt. <strong>Wir sind stolz darauf, dass mindestens <span>109 Frauen nach der Teilnahme am Workshop als Entwicklerinnen arbeiten</span>. Das ist ein großer Erfolg, über den wir uns sehr freuen!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
+msgstr ""
+"Dies bestätigt, dass sich unsere Arbeit positiv auf das Leben der Frauen "
+"auswirkt, die wir an das Programmieren herangeführt haben, sowie auf die "
+"Technologiebranche, die diese Frauen einstellt. <strong>Wir sind stolz "
+"darauf, dass mindestens <span>109 Frauen nach der Teilnahme am Workshop als "
+"Entwicklerinnen arbeiten</span>. Das ist ein großer Erfolg, über den wir uns "
+"sehr freuen!</strong>"
 
 #: templates/core/2016-2017.html:326
 msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr "Auswirkungen der Django Girls Workshops auf das Leben der Teilnehmer"
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
-msgstr "Wir waren auch daran interessiert zu erfahren, welche Auswirkungen die Teilnahme an einem Django Girls-Workshop für die Teilnehmerinnen hatte."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
+msgstr ""
+"Wir waren auch daran interessiert zu erfahren, welche Auswirkungen die "
+"Teilnahme an einem Django Girls-Workshop für die Teilnehmerinnen hatte."
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
-msgstr "Die Umfrage ergab, dass 93 % der Teilnehmer auf unterschiedliche Weise positiv beeinflusst worden waren."
+#, fuzzy, python-format
+#| msgid ""
+#| "The survey showed that 93%% of the participants had been impacted "
+#| "positively in different ways."
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
+msgstr ""
+"Die Umfrage ergab, dass 93 % der Teilnehmer auf unterschiedliche Weise "
+"positiv beeinflusst worden waren."
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
-msgstr "Die Umfrage ergab, dass etwa 43 % der Frauen durch die Begegnung mit anderen Frauen in der Tech-Branche inspiriert wurden, was dazu führte, dass sie sich stärker in der Tech-Branche engagierten, indem sie Tech-Veranstaltungen organisierten und andere Tech-Veranstaltungen besuchten. Viele dieser Frauen waren so inspiriert, dass sie erfuhren, dass die Tech-Branche und die Programmierung auch für Frauen geeignet sind."
+#, fuzzy, python-format
+#| msgid ""
+#| "The survey showed that about 43%% had been inspired by meeting other "
+#| "women in tech resulting in them becoming more involved in tech by "
+#| "organising tech events and attending other tech events. Many of these "
+#| "women were so inspired to learn that the tech industry and programming "
+#| "are for women as well."
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
+msgstr ""
+"Die Umfrage ergab, dass etwa 43 % der Frauen durch die Begegnung mit anderen "
+"Frauen in der Tech-Branche inspiriert wurden, was dazu führte, dass sie sich "
+"stärker in der Tech-Branche engagierten, indem sie Tech-Veranstaltungen "
+"organisierten und andere Tech-Veranstaltungen besuchten. Viele dieser Frauen "
+"waren so inspiriert, dass sie erfuhren, dass die Tech-Branche und die "
+"Programmierung auch für Frauen geeignet sind."
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
-msgstr "Etwa 25 % waren begeistert, dass sie neues Wissen über Technologie, Programmierung und Web-Entwicklung erlernt haben, Erfahrungen gesammelt und persönliches Wachstum erfahren haben. Etwa 14 % der Teilnehmer waren froh, dass sie neue Freunde und neue Kontakte in der Tech-Branche gefunden haben, mit denen sie seit dem Workshop in Kontakt geblieben sind. Etwa 11 % der Teilnehmer haben ihren beruflichen Werdegang geändert und sich für eine Karriere in der Technologiebranche interessiert, was sie dazu veranlasst hat, weiter zu lernen, wie man programmiert, damit sie eines Tages Entwickler werden können. Nur 7 % gaben an, dass die Teilnahme an dem Workshop keine nennenswerten Auswirkungen auf ihr Leben hatte."
+#, fuzzy, python-format
+#| msgid ""
+#| "About 25%% had been excited that learnt new knowledge about technology, "
+#| "programming and web development; gained experienced and experienced "
+#| "personal growth. About 14%% of the participants had been happy to have "
+#| "been able to meet new friends and new connections within the tech "
+#| "industry whom they have kept in touch with since the workshop. About 11%% "
+#| "of the participants had changed their career path and became interested "
+#| "in a career in the tech industry prompting them to continue learning to "
+#| "code so they could one day become developers. Only 7%% said there was no "
+#| "remarkable impact on their lives due to participation in the workshop."
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
+msgstr ""
+"Etwa 25 % waren begeistert, dass sie neues Wissen über Technologie, "
+"Programmierung und Web-Entwicklung erlernt haben, Erfahrungen gesammelt und "
+"persönliches Wachstum erfahren haben. Etwa 14 % der Teilnehmer waren froh, "
+"dass sie neue Freunde und neue Kontakte in der Tech-Branche gefunden haben, "
+"mit denen sie seit dem Workshop in Kontakt geblieben sind. Etwa 11 % der "
+"Teilnehmer haben ihren beruflichen Werdegang geändert und sich für eine "
+"Karriere in der Technologiebranche interessiert, was sie dazu veranlasst "
+"hat, weiter zu lernen, wie man programmiert, damit sie eines Tages "
+"Entwickler werden können. Nur 7 % gaben an, dass die Teilnahme an dem "
+"Workshop keine nennenswerten Auswirkungen auf ihr Leben hatte."
 
 #: templates/core/2016-2017.html:362
 msgid "Summary"
 msgstr "Zusammenfassung"
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
-msgstr "<b>Die Ergebnisse zeigen, dass Django Girls erfolgreich dazu beigetragen hat, Frauen für das Programmieren zu begeistern, da die Teilnehmerinnen mit Frauen in Kontakt kommen, die in ihrer eigenen Gemeinschaft programmieren.</b> Das freundliche Umfeld, das die Django Girls-Workshops bieten, ermöglicht es Frauen, die noch nie programmiert haben, das Programmieren zu erlernen und dadurch das Interesse an der Technik zu wecken und <b>viele dieser Frauen dazu zu bewegen, auf einen Karrierewechsel hinzuarbeiten und eine Anstellung in der Technologiebranche anzustreben</b>. Das freundliche Umfeld schafft auch eine Atmosphäre, in der man neue Freundschaften schließen und neue Netzwerkverbindungen knüpfen kann, was die Schönheit der Django-Gemeinschaft fördert, die sich bemüht, einladend und vielfältig zu sein."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
+msgstr ""
+"<b>Die Ergebnisse zeigen, dass Django Girls erfolgreich dazu beigetragen "
+"hat, Frauen für das Programmieren zu begeistern, da die Teilnehmerinnen mit "
+"Frauen in Kontakt kommen, die in ihrer eigenen Gemeinschaft programmieren.</"
+"b> Das freundliche Umfeld, das die Django Girls-Workshops bieten, ermöglicht "
+"es Frauen, die noch nie programmiert haben, das Programmieren zu erlernen "
+"und dadurch das Interesse an der Technik zu wecken und <b>viele dieser "
+"Frauen dazu zu bewegen, auf einen Karrierewechsel hinzuarbeiten und eine "
+"Anstellung in der Technologiebranche anzustreben</b>. Das freundliche Umfeld "
+"schafft auch eine Atmosphäre, in der man neue Freundschaften schließen und "
+"neue Netzwerkverbindungen knüpfen kann, was die Schönheit der Django-"
+"Gemeinschaft fördert, die sich bemüht, einladend und vielfältig zu sein."
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
-msgstr "Anlässlich unseres dritten Geburtstags haben wir unsere Twitter-Community gebeten, uns zu erzählen, wie Django Girls ihr Leben beeinflusst hat. Die Resonanz war überwältigend positiv:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
+msgstr ""
+"Anlässlich unseres dritten Geburtstags haben wir unsere Twitter-Community "
+"gebeten, uns zu erzählen, wie Django Girls ihr Leben beeinflusst hat. Die "
+"Resonanz war überwältigend positiv:"
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
 msgstr "Mehr Erfolgsgeschichten"
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr "Django Girls Verhaltenskodex"
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr "Verhaltenskodex"
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr "Dieses Dokument ist auch verfügbar in:"
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+"Django Girls soll eine einladende Veranstaltung sein, bei der sich Menschen "
+"in einer freundlichen Umgebung treffen. Dementsprechend erwarten wir, dass "
+"sich alle Teilnehmerinnen während des gesamten Workshops respektvoll und "
+"höflich gegenüber anderen Teilnehmerinnen verhalten."
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+"Um klarzustellen, was erwartet wird, sind alle Delegierten/Teilnehmer, "
+"Redner, Aussteller, Organisatoren und Freiwilligen bei allen Django Girls-"
+"Veranstaltungen verpflichtet, den folgenden Verhaltenskodex einzuhalten. Die "
+"Organisatoren werden diesen Kodex vor und während der Veranstaltung "
+"durchsetzen."
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr "Kurz gesagt"
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+"Django Girls hat es sich zur Aufgabe gemacht, eine belästigungsfreie "
+"Workshop-Erfahrung für alle zu bieten, unabhängig von Geschlecht, sexueller "
+"Orientierung, Behinderung, körperlichem Aussehen, Körpergröße, Rasse oder "
+"Religion."
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+"Wir dulden keine Belästigung von Workshop-Teilnehmern in irgendeiner Form."
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+"Sexuelle Sprache und Bilder sind in keinem Workshop, auch nicht bei "
+"Vorträgen, angebracht."
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+"Seien Sie freundlich zu anderen. Beleidigen oder erniedrigen Sie andere "
+"Teilnehmer nicht. Verhalten Sie sich professionell. Veröffentlichen Sie "
+"keine Fotos von Personen ohne deren Zustimmung. Denken Sie daran, dass "
+"Belästigungen und sexistische, rassistische oder ausgrenzende Witze bei "
+"Django Girls nicht angebracht sind."
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+"Konferenzteilnehmer, die gegen diese Regeln verstoßen, können nach Ermessen "
+"der Workshop-Organisatoren mit Sanktionen belegt oder ohne Rückerstattung "
+"vom Workshop ausgeschlossen werden."
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr "Längere Version"
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+"Zu den Belästigungen gehören beleidigende verbale Äußerungen in Bezug auf "
+"Geschlecht, sexuelle Orientierung, Behinderung, körperliches Aussehen, "
+"Körpergröße, Rasse, Religion, sexuelle Bilder im öffentlichen Raum, "
+"absichtliche Einschüchterung, Stalking, Verfolgung, belästigendes "
+"Fotografieren oder Aufnehmen, anhaltende Störung von Gesprächen oder anderen "
+"Veranstaltungen, unangemessener Körperkontakt und unerwünschte sexuelle "
+"Aufmerksamkeit."
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+"Von Teilnehmern, die aufgefordert werden, belästigendes Verhalten zu "
+"unterlassen, wird erwartet, dass sie dem sofort nachkommen."
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+"Seien Sie vorsichtig bei der Wahl der Worte, die Sie verwenden. Denken Sie "
+"daran, dass sexistische, rassistische und andere ausgrenzende Witze für Ihre "
+"Mitmenschen beleidigend sein können. Übermäßiges Fluchen und beleidigende "
+"Witze sind bei Django Girls nicht angebracht."
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+"Bei belästigendem Verhalten eines Teilnehmers können die Organisatoren des "
+"Workshops alle Maßnahmen ergreifen, die sie für angemessen halten, "
+"einschließlich einer Verwarnung des Täters oder des Ausschlusses vom "
+"Workshop ohne Rückerstattung."
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+"Wir erwarten von den Teilnehmern, dass sie diese Regeln an allen "
+"Veranstaltungsorten und bei allen gesellschaftlichen Veranstaltungen im "
+"Zusammenhang mit dem Workshop einhalten."
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr "Meldung von Belästigungen"
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+"Wenn Sie belästigt werden, feststellen, dass eine andere Person belästigt "
+"wird, oder andere Bedenken haben, wenden Sie sich bitte sofort an Ihren "
+"Trainer oder einen der Organisatoren. Wenn Ihr Anliegen das "
+"Organisationsteam betrifft, senden Sie bitte eine E-Mail mit Einzelheiten an "
+"coc@djangogirls.org."
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
+msgstr ""
+"Die Mitarbeiter sind gut darüber informiert, wie mit dem Vorfall umzugehen "
+"ist und wie mit der Situation weiter verfahren werden kann. Die "
+"Konferenzmitarbeiter helfen den Teilnehmern gerne dabei, sich mit dem "
+"Sicherheitsdienst des Hotels/der Veranstaltungsstätte oder den örtlichen "
+"Strafverfolgungsbehörden in Verbindung zu setzen, stellen Begleitpersonen "
+"zur Verfügung oder helfen auf andere Weise denjenigen, die belästigt werden, "
+"sich für die Dauer der Konferenz sicher zu fühlen. Wir schätzen Ihre "
+"Teilnahme an der Konferenz."
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
 #: templates/global/menu.html:26
@@ -1831,48 +3421,112 @@ msgid "Contribute"
 msgstr "Beitragen"
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
-msgstr "Es gibt viele Möglichkeiten, zu Django Girls beizutragen: Du kannst eine Veranstaltung organisieren, coachen, am Tutorial arbeiten und auf Gitter helfen. Wenn Sie uns lieber finanziell helfen möchten, können Sie uns jederzeit auf <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> oder <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a> unterstützen."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgstr ""
+"Es gibt viele Möglichkeiten, zu Django Girls beizutragen: Du kannst eine "
+"Veranstaltung organisieren, coachen, am Tutorial arbeiten und auf Gitter "
+"helfen. Wenn Sie uns lieber finanziell helfen möchten, können Sie uns "
+"jederzeit auf <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> "
+"oder <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?"
+"charityId=129929&s=3\">PayPal Giving Funds</a> unterstützen."
 
 #: templates/core/contribute.html:22
 msgid "Support us!"
 msgstr "Unterstütze uns!"
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
-msgstr "Django Girls ist eine <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Eingetragene Wohltätigkeitsorganisation</a> und wird von Freiwilligen geleitet. Wenn Sie uns als Einzelperson oder Unternehmen unterstützen möchten, können Sie eine <a href=\"https://www.patreon.com/djangogirls\">monatliche Spende</a> leisten. Sie können einmalige Spenden an unser <a href=\"%(donation_url)s\">PayPal-Konto</a> senden oder <a href=\"%(donation_url)s\">mit Kreditkarte spenden</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
+msgstr ""
+"Django Girls ist eine <a href=\"http://apps.charitycommission.gov.uk/"
+"Showcharity/RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Eingetragene "
+"Wohltätigkeitsorganisation</a> und wird von Freiwilligen geleitet. Wenn Sie "
+"uns als Einzelperson oder Unternehmen unterstützen möchten, können Sie eine "
+"<a href=\"https://www.patreon.com/djangogirls\">monatliche Spende</a> "
+"leisten. Sie können einmalige Spenden an unser <a "
+"href=\"%(donation_url)s\">PayPal-Konto</a> senden oder <a "
+"href=\"%(donation_url)s\">mit Kreditkarte spenden</a>."
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
-msgstr "Wenn Sie eine bestimmte <a href=\"http://djangogirls.org/events\">Veranstaltung</a> unterstützen möchten, können Sie sich an das örtliche Organisationsteam wenden, um sie zu sponsern."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
+msgstr ""
+"Wenn Sie eine bestimmte <a href=\"http://djangogirls.org/"
+"events\">Veranstaltung</a> unterstützen möchten, können Sie sich an das "
+"örtliche Organisationsteam wenden, um sie zu sponsern."
 
 #: templates/core/contribute.html:46
 msgid "Organize!"
 msgstr "Organisiere!"
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
-msgstr "Jede Django Girls-Veranstaltung ist ein kostenloser, eintägiger Workshop für 30-60 Personen zu HTML, CSS, Python und Django. Ein typischer Workshop dauert 8 Stunden und die Teilnehmer arbeiten in kleinen 3-Personen-Gruppen mit einem Coach, der sich um jede Gruppe kümmert."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
+msgstr ""
+"Jede Django Girls-Veranstaltung ist ein kostenloser, eintägiger Workshop für "
+"30-60 Personen zu HTML, CSS, Python und Django. Ein typischer Workshop "
+"dauert 8 Stunden und die Teilnehmer arbeiten in kleinen 3-Personen-Gruppen "
+"mit einem Coach, der sich um jede Gruppe kümmert."
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
-msgstr "Möchten Sie anfangen? Lesen Sie unser <a href=\"https://organize.djangogirls.org/\">Organisationshandbuch</a> und <a href=\"https://djangogirls.org/organize/\">bringen Sie Django Girls in Ihre Stadt!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
+msgstr ""
+"Möchten Sie anfangen? Lesen Sie unser <a href=\"https://organize.djangogirls."
+"org/\">Organisationshandbuch</a> und <a href=\"https://djangogirls.org/"
+"organize/\">bringen Sie Django Girls in Ihre Stadt!</a>"
 
 #: templates/core/contribute.html:72
 msgid "Coach!"
 msgstr "Trainiere!"
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
-msgstr "Haben Sie von einer Veranstaltung in Ihrer Stadt gehört und möchten Sie helfen? Wenden Sie sich an das örtliche <a href=\"http://djangogirls.org/events\">Organisationsteam</a> und fragen Sie, ob sie weitere Trainer brauchen!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
+msgstr ""
+"Haben Sie von einer Veranstaltung in Ihrer Stadt gehört und möchten Sie "
+"helfen? Wenden Sie sich an das örtliche <a href=\"http://djangogirls.org/"
+"events\">Organisationsteam</a> und fragen Sie, ob sie weitere Trainer "
+"brauchen!"
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
-msgstr "Sie helfen einer Gruppe von 3 Personen bei der Installation dessen, was sie für die Veranstaltung benötigen, und führen sie durch unser <a href=\"https://tutorial.djangogirls.org/\">Tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
+msgstr ""
+"Sie helfen einer Gruppe von 3 Personen bei der Installation dessen, was sie "
+"für die Veranstaltung benötigen, und führen sie durch unser <a "
+"href=\"https://tutorial.djangogirls.org/\">Tutorial</a>."
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
-msgstr "Vergessen Sie nicht, sich unser <a href=\"https://coach.djangogirls.org/\">Coaching-Handbuch</a> anzusehen!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
+msgstr ""
+"Vergessen Sie nicht, sich unser <a href=\"https://coach.djangogirls.org/"
+"\">Coaching-Handbuch</a> anzusehen!"
 
 #: templates/core/contribute.html:99
 msgid "Work on the website!"
@@ -1883,12 +3537,21 @@ msgid "Computer screen with a console and a webpage."
 msgstr "Computerbildschirm mit einer Konsole und einer Webpage."
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
-msgstr "Es gibt immer etwas zu tun, um unsere Website besser zu machen. Sie können Fehler und Tippfehler melden (oder beheben!) oder an neuen Funktionen arbeiten."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
+msgstr ""
+"Es gibt immer etwas zu tun, um unsere Website besser zu machen. Sie können "
+"Fehler und Tippfehler melden (oder beheben!) oder an neuen Funktionen "
+"arbeiten."
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
-msgstr "Wir warten auf Ihre <a href=\"https://github.com/DjangoGirls/djangogirls\">Abrufanfragen!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
+msgstr ""
+"Wir warten auf Ihre <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">Abrufanfragen!</a>"
 
 #: templates/core/contribute.html:123
 msgid "Fix the tutorial!"
@@ -1899,12 +3562,24 @@ msgid "A note book and a pen."
 msgstr "Ein Notizbuch und einen Stift."
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
-msgstr "Ist etwas in der Anleitung nicht klar, oder gibt es einen Tippfehler? Sie können das Tutorial verbessern, indem Sie einen Pull-Request an unser <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub Repository</a> senden."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
+msgstr ""
+"Ist etwas in der Anleitung nicht klar, oder gibt es einen Tippfehler? Sie "
+"können das Tutorial verbessern, indem Sie einen Pull-Request an unser <a "
+"href=\"https://github.com/DjangoGirls/tutorial\">GitHub Repository</a> "
+"senden."
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
-msgstr "Sie haben gerade unser Tutorial beendet und möchten helfen? Pull-Requests zu erstellen, um Tippfehler zu beheben, ist eine großartige Möglichkeit, Ihre neuen Git-Kenntnisse anzuwenden!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
+msgstr ""
+"Sie haben gerade unser Tutorial beendet und möchten helfen? Pull-Requests zu "
+"erstellen, um Tippfehler zu beheben, ist eine großartige Möglichkeit, Ihre "
+"neuen Git-Kenntnisse anzuwenden!"
 
 #: templates/core/contribute.html:140
 msgid "Translate the tutorial!"
@@ -1912,15 +3587,32 @@ msgstr "Übersetzen Sie die Anleitung!"
 
 #: templates/core/contribute.html:143
 msgid "A computer screen saying hello and golden balloons saying yay!."
-msgstr "Ein Computerbildschirm, der \"Hallo\" sagt, und goldene Luftballons, die \"Ja\" sagen."
+msgstr ""
+"Ein Computerbildschirm, der \"Hallo\" sagt, und goldene Luftballons, die "
+"\"Ja\" sagen."
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
-msgstr "Unser Tutorial wurde bereits in <a href=\"https://tutorial.djangogirls.org/\">19 Sprachen</a> übersetzt, aber wir brauchen immer Hilfe bei der Pflege dieser Übersetzungen. Oder Sie können uns helfen, das Tutorial in eine neue Sprache zu übersetzen!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
+msgstr ""
+"Unser Tutorial wurde bereits in <a href=\"https://tutorial.djangogirls.org/"
+"\">19 Sprachen</a> übersetzt, aber wir brauchen immer Hilfe bei der Pflege "
+"dieser Übersetzungen. Oder Sie können uns helfen, das Tutorial in eine neue "
+"Sprache zu übersetzen!"
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
-msgstr "Wenn Sie sich einem bestehenden <a href=\"https://crowdin.com/project/django-girls-tutorial\">Übersetzungsteam</a> anschließen oder eine neue Übersetzung in Auftrag geben möchten, <a href=\"mailto:translations@djangogirls.org\">kontaktieren Sie uns</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgstr ""
+"Wenn Sie sich einem bestehenden <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">Übersetzungsteam</a> anschließen oder eine neue Übersetzung "
+"in Auftrag geben möchten, <a href=\"mailto:translations@djangogirls."
+"org\">kontaktieren Sie uns</a>."
 
 #: templates/core/contribute.html:166
 msgid "Help on Gitter!"
@@ -1931,12 +3623,25 @@ msgid "A web page opened on a computer."
 msgstr "Eine auf einem Computer geöffnete Webseite."
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
-msgstr "Viele Leute machen unser Lernprogramm außerhalb eines Workshops. Manchmal kommen sie nicht weiter und brauchen Hilfe. Wie wäre es, wenn Sie ihnen ein paar Stunden pro Woche helfen würden?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
+msgstr ""
+"Viele Leute machen unser Lernprogramm außerhalb eines Workshops. Manchmal "
+"kommen sie nicht weiter und brauchen Hilfe. Wie wäre es, wenn Sie ihnen ein "
+"paar Stunden pro Woche helfen würden?"
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
-msgstr "Dieser <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitterraum</a> soll ein freundlicher Raum sein, besonders für Anfänger. Denken Sie daran, dass unser <a href=\"https://djangogirls.org/pages/coc/\">Verhaltenskodex</a> auch dort gilt."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
+msgstr ""
+"Dieser <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitterraum</a> "
+"soll ein freundlicher Raum sein, besonders für Anfänger. Denken Sie daran, "
+"dass unser <a href=\"https://djangogirls.org/pages/coc/\">Verhaltenskodex</"
+"a> auch dort gilt."
 
 #: templates/core/contribute.html:188
 msgid "Want to do more?"
@@ -1947,36 +3652,80 @@ msgid "A pile a tattoo."
 msgstr "Ein Haufen ein Tattoo."
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
-msgstr "Möchten Sie auf eine Weise helfen, die hier nicht aufgeführt ist? Sie können sich unser <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello-Board</a> ansehen und neue Projekte vorschlagen, an denen Sie mitarbeiten möchten."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
+msgstr ""
+"Möchten Sie auf eine Weise helfen, die hier nicht aufgeführt ist? Sie können "
+"sich unser <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello-"
+"Board</a> ansehen und neue Projekte vorschlagen, an denen Sie mitarbeiten "
+"möchten."
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
-msgstr "Vergessen Sie nicht, die in der ersten Spalte beschriebenen Regeln zu lesen, bevor Sie eine neue Karte hinzufügen! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
+msgstr ""
+"Vergessen Sie nicht, die in der ersten Spalte beschriebenen Regeln zu lesen, "
+"bevor Sie eine neue Karte hinzufügen! ❤"
 
 #: templates/core/crowdfunding_donors.html:11
 msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr "💖 Besonderen Dank an alle unsere tollen Unterstützer! 💖"
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
-msgstr "Dieses Jahr (2018) haben wir vom 29. Januar bis zum 29. März eine Crowdfunding-Kampagne auf der großzügigen Website von Indiegogo durchgeführt, um 10.000 US-Dollar zu sammeln. Wir sind all unseren großartigen Unterstützern, die uns geholfen haben, unser Ziel zu erreichen, sehr dankbar. Wir haben es geschafft, insgesamt 13.314 $ zu sammeln - 133% unseres Ziels!"
+#, fuzzy, python-format
+#| msgid ""
+#| "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+#| "website from the 29th January to the 29th of March with the aim of "
+#| "raising US $10,000. We are truly grateful to all our awesome supporters "
+#| "who helped reach our target goal. We managed to raise a total of $13,314 "
+#| "- 133%% of our goal!"
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
+msgstr ""
+"Dieses Jahr (2018) haben wir vom 29. Januar bis zum 29. März eine "
+"Crowdfunding-Kampagne auf der großzügigen Website von Indiegogo "
+"durchgeführt, um 10.000 US-Dollar zu sammeln. Wir sind all unseren "
+"großartigen Unterstützern, die uns geholfen haben, unser Ziel zu erreichen, "
+"sehr dankbar. Wir haben es geschafft, insgesamt 13.314 $ zu sammeln - "
+"133% unseres Ziels!"
 
 #: templates/core/crowdfunding_donors.html:31
 msgid "Our awesome supporters ✨"
 msgstr "Unsere großartigen Unterstützer ✨"
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
-msgstr "Hallo zusammen! Du kannst diese Seite sehen, weil du als Administrator eingeloggt bist. Wenn Sie sie veröffentlichen möchten, gehen Sie zu <a href=\"%(event_url)s\">Ihrem Website-Bereich in der Verwaltung</a> und klicken Sie auf \"Website ist bereit\"."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
+msgstr ""
+"Hallo zusammen! Du kannst diese Seite sehen, weil du als Administrator "
+"eingeloggt bist. Wenn Sie sie veröffentlichen möchten, gehen Sie zu <a "
+"href=\"%(event_url)s\">Ihrem Website-Bereich in der Verwaltung</a> und "
+"klicken Sie auf \"Website ist bereit\"."
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
-msgstr "Die Teilnehmer müssen den <a href=\"%(coc_url)s\">Django Girls Verhaltenskodex</a> befolgen."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
+msgstr ""
+"Die Teilnehmer müssen den <a href=\"%(coc_url)s\">Django Girls "
+"Verhaltenskodex</a> befolgen."
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
-msgstr "Kontakt zu den Veranstaltern: <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgstr ""
+"Kontakt zu den Veranstaltern: <a href=\"mailto:%(email)s\">%(email)s</a>"
 
 #: templates/core/events.html:10 templates/core/index.html:91
 msgid "Upcoming events"
@@ -2003,8 +3752,15 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr "FAQ: Häufig gestellte Fragen"
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
-msgstr "Seit einiger Zeit finden überall auf der Welt Django-Girls-Veranstaltungen statt, und wir erhalten immer wieder Anfragen. Wenn du mehr Hilfe brauchst: <a href=\"%(contact_url)s\">Kontaktiere uns</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
+msgstr ""
+"Seit einiger Zeit finden überall auf der Welt Django-Girls-Veranstaltungen "
+"statt, und wir erhalten immer wieder Anfragen. Wenn du mehr Hilfe brauchst: "
+"<a href=\"%(contact_url)s\">Kontaktiere uns</a>!"
 
 #: templates/core/faq.html:20
 msgid "Django Girls workshops"
@@ -2019,48 +3775,176 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr "F: Ist Django Girls nicht sexistisch?"
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
-msgstr "A: Das ist es nicht, aber wir können verstehen, warum die Leute das so empfinden. Wir haben festgestellt, dass sich Frauen wohler fühlen, wenn sie einen Raum zum Erlernen von Python und Django haben, der nur Frauen vorbehalten ist. Siehe <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">diesen Aufsatz</a> über \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">umgekehrten Sexismus</a>\" und Rails Girls, um zu sehen, was wir meinen. Wenn Sie denken, dass es Männern schadet, wenn Sie sich speziell an Frauen wenden, oder dass es den Bemühungen um Vielfalt in anderen Bereichen schadet, empfehlen wir Ihnen, <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> von Hynek Schlawack zu lesen. Ein besonders wichtiges Zitat ist dieses:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
+msgstr ""
+"A: Das ist es nicht, aber wir können verstehen, warum die Leute das so "
+"empfinden. Wir haben festgestellt, dass sich Frauen wohler fühlen, wenn sie "
+"einen Raum zum Erlernen von Python und Django haben, der nur Frauen "
+"vorbehalten ist. Siehe <a href=\"http://jennifermann.ghost.io/minority-"
+"groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">diesen "
+"Aufsatz</a> über \"<a href=\"http://geekfeminism.wikia.com/wiki/"
+"Reverse_sexism\" target=\"_blank\">umgekehrten Sexismus</a>\" und Rails "
+"Girls, um zu sehen, was wir meinen. Wenn Sie denken, dass es Männern "
+"schadet, wenn Sie sich speziell an Frauen wenden, oder dass es den "
+"Bemühungen um Vielfalt in anderen Bereichen schadet, empfehlen wir Ihnen, <a "
+"href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-"
+"pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving "
+"Pyladies</a> von Hynek Schlawack zu lesen. Ein besonders wichtiges Zitat ist "
+"dieses:"
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
-msgstr "Aufsuchende Programme spalten unsere Gemeinschaft nicht. Sie beherbergen Menschen, die sich bei uns nicht wohlfühlen, von Anfang an und lassen unsere Gemeinschaft langfristig wachsen."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
+msgstr ""
+"Aufsuchende Programme spalten unsere Gemeinschaft nicht. Sie beherbergen "
+"Menschen, die sich bei uns nicht wohlfühlen, von Anfang an und lassen unsere "
+"Gemeinschaft langfristig wachsen."
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
-msgstr "Es spielt keine Rolle, wer die Schuld für das anfängliche Unbehagen trägt. Ob sie überempfindlich sind (Hinweis: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">sind sie nicht</a>) oder ob wir ein Haufen von Arschlöchern sind (ich weiß, dass ihr das nicht seid). Tatsache ist: Wenn wir wollen, dass unterrepräsentierte Menschen unsere Gemeinschaft bereichern, müssen wir nach pragmatischen Wegen suchen, um sie einzubeziehen. Auch wenn uns die Methoden auf den ersten Blick nicht gut erscheinen."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
+msgstr ""
+"Es spielt keine Rolle, wer die Schuld für das anfängliche Unbehagen trägt. "
+"Ob sie überempfindlich sind (Hinweis: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">sind sie nicht</a>) oder ob "
+"wir ein Haufen von Arschlöchern sind (ich weiß, dass ihr das nicht seid). "
+"Tatsache ist: Wenn wir wollen, dass unterrepräsentierte Menschen unsere "
+"Gemeinschaft bereichern, müssen wir nach pragmatischen Wegen suchen, um sie "
+"einzubeziehen. Auch wenn uns die Methoden auf den ersten Blick nicht gut "
+"erscheinen."
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
-msgstr "\"Ja, aber...\"-Diskussionen sind nicht hilfreich. PyLadies - und ähnliche Outreach-Gruppen - haben einen Weg gefunden, der funktioniert. Seien Sie also den Organisatoren dankbar, dass sie das getan haben! Und noch einmal: Wenn Sie einen besseren Weg kennen, hören Sie auf, ihren Ansatz zu kritisieren und setzen Sie ihn um! Die Welt ist nicht binär; je mehr Ansätze, je mehr Vielfalt, desto besser."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
+msgstr ""
+"\"Ja, aber...\"-Diskussionen sind nicht hilfreich. PyLadies - und ähnliche "
+"Outreach-Gruppen - haben einen Weg gefunden, der funktioniert. Seien Sie "
+"also den Organisatoren dankbar, dass sie das getan haben! Und noch einmal: "
+"Wenn Sie einen besseren Weg kennen, hören Sie auf, ihren Ansatz zu "
+"kritisieren und setzen Sie ihn um! Die Welt ist nicht binär; je mehr "
+"Ansätze, je mehr Vielfalt, desto besser."
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
-msgstr "Außerdem sind nicht alle Django-Girls-Veranstaltungen ausschließlich für Frauen gedacht. Unser Organisationshandbuch ermutigt Organisatoren, unsere Materialien zu verwenden, um Workshops für Frauen <em>und</em> für gemischtgeschlechtliche Gruppen zu veranstalten. Wenn Ihnen also unser Tutorial gefällt, Sie aber keine Django-Girls-Veranstaltung damit veranstalten wollen, können Sie es gerne weiterverwenden, uns für den Inhalt danken und es in etwas umbenennen, das für Ihre Ziele geeignet ist."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
+msgstr ""
+"Außerdem sind nicht alle Django-Girls-Veranstaltungen ausschließlich für "
+"Frauen gedacht. Unser Organisationshandbuch ermutigt Organisatoren, unsere "
+"Materialien zu verwenden, um Workshops für Frauen <em>und</em> für "
+"gemischtgeschlechtliche Gruppen zu veranstalten. Wenn Ihnen also unser "
+"Tutorial gefällt, Sie aber keine Django-Girls-Veranstaltung damit "
+"veranstalten wollen, können Sie es gerne weiterverwenden, uns für den Inhalt "
+"danken und es in etwas umbenennen, das für Ihre Ziele geeignet ist."
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
-msgstr "Wir wollen Männer nicht <em>aus</em> dem Programmieren herausholen; wir wollen nur mehr Frauen <em>hin</em> bringen. Es gibt bereits eine Menge anderer Bootcamps, Workshops, Meetups und Gruppen, die \"gemischtgeschlechtlich\" sind, aber in Wirklichkeit überwiegend aus Männern bestehen. Wir haben festgestellt, dass es für Frauen angenehmer ist, sich anzumelden, Fragen zu stellen, sich zu engagieren und später sogar dabei zu bleiben, wenn wir unseren Workshop auf die Mehrheit der Teilnehmerinnen beschränken. Und das ist eine gute Sache!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
+msgstr ""
+"Wir wollen Männer nicht <em>aus</em> dem Programmieren herausholen; wir "
+"wollen nur mehr Frauen <em>hin</em> bringen. Es gibt bereits eine Menge "
+"anderer Bootcamps, Workshops, Meetups und Gruppen, die "
+"\"gemischtgeschlechtlich\" sind, aber in Wirklichkeit überwiegend aus "
+"Männern bestehen. Wir haben festgestellt, dass es für Frauen angenehmer ist, "
+"sich anzumelden, Fragen zu stellen, sich zu engagieren und später sogar "
+"dabei zu bleiben, wenn wir unseren Workshop auf die Mehrheit der "
+"Teilnehmerinnen beschränken. Und das ist eine gute Sache!"
 
 #: templates/core/faq.html:109
 msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr "F: Sind Django-Girls-Veranstaltungen trans-inklusiv?"
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
-msgstr "A: Ja! Wir empfehlen Ihnen, dies auf Ihrer Website ausdrücklich zu erwähnen. Einige Veranstaltungen haben diese Formulierung verwendet:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
+msgstr ""
+"A: Ja! Wir empfehlen Ihnen, dies auf Ihrer Website ausdrücklich zu erwähnen. "
+"Einige Veranstaltungen haben diese Formulierung verwendet:"
 
 #: templates/core/faq.html:117
 msgid "We are trans-inclusive and welcome applications from all women."
 msgstr "Wir sind trans-inklusiv und begrüßen Bewerbungen von allen Frauen."
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
-msgstr "Sie können dies in Ihre FAQ oder in Ihre Veranstaltungsbeschreibung auf Ihrer Veranstaltungswebsite aufnehmen. Wenn Sie mehr über transsexuelle Menschen erfahren möchten, sollten Sie einen Blick auf <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">diesen Bildband über Gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">diesen Comic</a> oder eine der vielen anderen Einführungen in transsexuelle Themen im Internet werfen. Vielen Dank an die <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> für den Hinweis auf diese hervorragenden Ressourcen."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
+msgstr ""
+"Sie können dies in Ihre FAQ oder in Ihre Veranstaltungsbeschreibung auf "
+"Ihrer Veranstaltungswebsite aufnehmen. Wenn Sie mehr über transsexuelle "
+"Menschen erfahren möchten, sollten Sie einen Blick auf <a href=\"http://www."
+"thegenderbook.com/\" target=\"_blank\">diesen Bildband über Gender</a>, <a "
+"href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">diesen Comic</a> oder eine der vielen anderen Einführungen "
+"in transsexuelle Themen im Internet werfen. Vielen Dank an die <a "
+"href=\"http://kit.pyladies.com/en/latest/faqs.html\" "
+"target=\"_blank\">PyLadies FAQ</a> für den Hinweis auf diese hervorragenden "
+"Ressourcen."
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
-msgstr "A: Im Moment scheint es keinen Bedarf für Django Boys zu geben. Aber alle unsere Inhalte, einschließlich unseres Tutorials und dieses Handbuchs, sind Open Source. Wenn Sie also einen Workshop für ein anderes Publikum starten möchten, ermutigen wir Sie, dies zu tun! Wir unterstützen Sie dabei, eine Organisation zu gründen, die ein Publikum erreicht, das Ihnen am Herzen liegt. Alle von uns erstellten Ressourcen, einschließlich des Tutorials und dieses Handbuchs, sind Open Source unter Creative Commons Attribution 4.0 International (CC BY 4). Das bedeutet, dass Sie sie verändern, verbreiten und kommerziell nutzen können, aber Sie dürfen keine Unterlizenzen vergeben und müssen uns die Urheberrechte nennen."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
+msgstr ""
+"A: Im Moment scheint es keinen Bedarf für Django Boys zu geben. Aber alle "
+"unsere Inhalte, einschließlich unseres Tutorials und dieses Handbuchs, sind "
+"Open Source. Wenn Sie also einen Workshop für ein anderes Publikum starten "
+"möchten, ermutigen wir Sie, dies zu tun! Wir unterstützen Sie dabei, eine "
+"Organisation zu gründen, die ein Publikum erreicht, das Ihnen am Herzen "
+"liegt. Alle von uns erstellten Ressourcen, einschließlich des Tutorials und "
+"dieses Handbuchs, sind Open Source unter Creative Commons Attribution 4.0 "
+"International (CC BY 4). Das bedeutet, dass Sie sie verändern, verbreiten "
+"und kommerziell nutzen können, aber Sie dürfen keine Unterlizenzen vergeben "
+"und müssen uns die Urheberrechte nennen."
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
 msgid "Django Girls Foundation"
@@ -2076,32 +3960,77 @@ msgid "We inspire women to fall in love with programming."
 msgstr "Wir inspirieren Frauen dazu, sich in Programmierung zu verlieben."
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
-msgstr "Django Girls organisiert kostenlose Python- und Django-Workshops, erstellt open-source online-Tutorials und bietet fantastische erste Schritte in die Technik."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
+msgstr ""
+"Django Girls organisiert kostenlose Python- und Django-Workshops, erstellt "
+"open-source online-Tutorials und bietet fantastische erste Schritte in die "
+"Technik."
 
 #: templates/core/index.html:29
 msgid "What is Django Girls?"
 msgstr "Was ist Django Girls?"
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
-msgstr "Django Girls ist eine <a href=\"%(foundation_url)s\">Non-Profit-Organisation</a> und eine Gemeinschaft, die Frauen befähigt und ihnen hilft, kostenlose, eintägige Programmier-Workshops zu organisieren, indem sie Werkzeuge, Ressourcen und Unterstützung bereitstellt. Wir sind eine von Freiwilligen geführte Organisation mit Hunderten von Menschen, die dazu beitragen, dass mehr tolle Frauen in die Welt der Technik einsteigen. Wir machen Technologie zugänglicher, indem wir Ressourcen schaffen, die mit Einfühlungsvermögen entwickelt wurden."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
+msgstr ""
+"Django Girls ist eine <a href=\"%(foundation_url)s\">Non-Profit-"
+"Organisation</a> und eine Gemeinschaft, die Frauen befähigt und ihnen hilft, "
+"kostenlose, eintägige Programmier-Workshops zu organisieren, indem sie "
+"Werkzeuge, Ressourcen und Unterstützung bereitstellt. Wir sind eine von "
+"Freiwilligen geführte Organisation mit Hunderten von Menschen, die dazu "
+"beitragen, dass mehr tolle Frauen in die Welt der Technik einsteigen. Wir "
+"machen Technologie zugänglicher, indem wir Ressourcen schaffen, die mit "
+"Einfühlungsvermögen entwickelt wurden."
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
-msgstr "Bei jeder unserer Veranstaltungen erstellen 30-60 Frauen ihre erste Webanwendung mit HTML, CSS, Python und Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
+msgstr ""
+"Bei jeder unserer Veranstaltungen erstellen 30-60 Frauen ihre erste "
+"Webanwendung mit HTML, CSS, Python und Django."
 
 #: templates/core/index.html:53
 msgid "Django Girls impact"
 msgstr "Django Girls Auswirkungen"
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
-msgstr "Seit 2014 organisiert eine Armee von <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s Freiwilligen</span> in der Django Girls Community <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s Events.</span> Wir waren in <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">siehe sie alle auf einer Karte</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
+msgstr ""
+"Seit 2014 organisiert eine Armee von <span class=\"highlighted-"
+"number\">%(organizers_count)s Freiwilligen</span> in der Django Girls "
+"Community <span class=\"highlighted-number\">%(all_events_count)s Events.</"
+"span> Wir waren in <span class=\"highlighted-number\">%(cities_count)s "
+"cities</span> in <span class=\"highlighted-number\">%(country_count)s "
+"countries</span> (<a href=\"%(event_map_url)s\">siehe sie alle auf einer "
+"Karte</a>)."
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
-msgstr "Insgesamt haben <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s unglaubliche Frauen an den von Mitgliedern unserer Gemeinschaft organisierten Veranstaltungen teilgenommen</span>."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
+msgstr ""
+"Insgesamt besuchten <span class=\"highlighted-number\">%(attendees_sum)s "
+"unglaubliche Frauen</span> Veranstaltungen, die von Mitgliedern unserer "
+"Gemeinschaft organisiert wurden."
 
 #: templates/core/index.html:69
 msgid "Read our Annual Report to learn about the impact we make"
@@ -2112,18 +4041,33 @@ msgid "Bring Django Girls to your city!"
 msgstr "Bring Django Girls in deine Stadt!"
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
-msgstr "Gibt es in Ihrer Stadt keine Django Girls Veranstaltung? Du kannst helfen, es zu ermöglichen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
+msgstr ""
+"Gibt es in Ihrer Stadt keine Django Girls Veranstaltung? Du kannst helfen, "
+"es zu ermöglichen!"
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
-msgstr "Wir haben das <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> veröffentlicht, das alle Informationen enthält, die für die Organisation von Django Girls Workshops erforderlich sind. Indem du dich als Organisatorin meldest, trittst du einer lebendigen und unterstützenden Gemeinschaft von %(organizers_count|default_if_none:'0')s Organisatorinnen auf der ganzen Welt bei!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
+msgstr ""
+"Wir haben das <a href=\"http://organize.djangogirls.org/\">Organizer Manual</"
+"a> veröffentlicht, das alle Informationen enthält, die für die Organisation "
+"eines Django Girls Workshops erforderlich sind. Indem Sie sich als "
+"Organisatorin melden, werden Sie Teil einer lebendigen und unterstützenden "
+"Gemeinschaft von %(organizers_count)s Organisatoren auf der ganzen Welt!"
 
 #: templates/core/index.html:82 templates/organize/index.html:89
 msgid "Apply to organize a workshop"
 msgstr "Anmeldung zur Organisation eines Workshops"
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr "Alle %(future_events_count)s anstehenden Ereignisse anzeigen"
 
@@ -2132,8 +4076,12 @@ msgid "Badass Django Ladies"
 msgstr "Knallharte Django-Damen"
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
-msgstr "Jede Woche versuchen wir, eine Frau vorzustellen, die Python oder Django benutzt und ihre Arbeit hervorzuheben:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
+msgstr ""
+"Jede Woche versuchen wir, eine Frau vorzustellen, die Python oder Django "
+"benutzt und ihre Arbeit hervorzuheben:"
 
 #: templates/core/index.html:125
 msgid "Read all Django Stories"
@@ -2152,24 +4100,51 @@ msgid "Support our work"
 msgstr "Unterstützen Sie unsere Arbeit"
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
-msgstr "Django Girls ist eine ehrenamtlich geführte Organisation, und wir sind auf Ihre Unterstützung angewiesen, um das Projekt durchzuführen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+"Django Girls ist eine ehrenamtlich geführte Organisation, und wir sind auf "
+"Ihre Unterstützung angewiesen, um das Projekt durchzuführen."
+
+#: templates/core/index.html:143
+#, fuzzy
+#| msgid ""
+#| "<span class=\"highlighted-number\">$1,661</span> of <span "
+#| "class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+msgstr ""
+"<span class=\"highlighted-number\">$1.661</span> des <span "
+"class=\"highlighted-number\">$2.500</span> Monatsziels zugesagt"
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
 msgid "Make a recurring donation on Patreon"
 msgstr "Wiederkehrende Spenden auf Patreon tätigen"
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
-msgstr "Sie können uns auch eine einmalige <a href=\"%(donations_url)s\">Spende</a> zukommen lassen. Wenn Sie über eine größere Partnerschaft sprechen möchten, <a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
+msgstr ""
+"Sie können uns auch eine einmalige <a href=\"%(donations_url)s\">Spende</a> "
+"zukommen lassen. Wenn Sie über eine größere Partnerschaft sprechen möchten, "
+"<a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf</a>."
 
 #: templates/core/index.html:162
 msgid "Stay up to date!"
 msgstr "Bleiben Sie auf dem Laufenden!"
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
-msgstr "Abonnieren Sie den Django Girls Dispatch, um alle zwei Wochen das Neueste und Beste aus unserer Community direkt in Ihren Posteingang zu bekommen!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
+msgstr ""
+"Abonnieren Sie den Django Girls Dispatch, um alle zwei Wochen das Neueste "
+"und Beste aus unserer Community direkt in Ihren Posteingang zu bekommen!"
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
 msgid "email address"
@@ -2184,13 +4159,75 @@ msgstr "Abonnieren"
 msgid "See the Django Girls Dispatch archives"
 msgstr "Siehe das Archiv von Django Girls Dispatch"
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr "Hören Sie sich unseren Podcast an!"
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+"Wir haben einen neuen <a href=\"https://anchor.fm/djangogirls\">Podcast</a>, "
+"der von den Treuhändern <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\">Aisha</a> und <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> moderiert wird und in dem sie mit vielen "
+"großartigen Menschen aus unserer Gemeinschaft sprechen. Schauen Sie sich den "
+"<a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> für den <a "
+"href=\"https://anchor.fm/djangogirls\">Podcast</a> an, der auf verschiedenen "
+"Plattformen wie <a href=\"https://podcasts.apple.com/us/podcast/django-girls-"
+"podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/"
+"feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google "
+"Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a> und <a href=\"https://"
+"open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> verfügbar ist."
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr "Sie sponsern uns bereits! 💕"
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+"Diese unglaublichen Unternehmen haben sich zur Vielfalt verpflichtet und "
+"helfen uns aktiv dabei, das Verhältnis in der Tech-Branche zu ändern. <br /> "
+"Wenn Sie sich ihnen anschließen möchten, unterstützen Sie uns auf <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> oder <a "
+"href=\"%(contact_url)s\">drop us a line</a>."
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr "Sie unterstützen uns bereits! 💕"
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
-msgstr "Diese unglaublichen Unternehmen haben sich zur Vielfalt verpflichtet und helfen uns aktiv dabei, das Verhältnis in der Tech-Branche zu ändern. <br /> Wenn Sie sich ihnen anschließen möchten, unterstützen Sie uns auf <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> oder <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+"Diese unglaublichen Unternehmen helfen uns aktiv dabei, das Verhältnis in "
+"der Technologiebranche zu ändern, indem sie uns auf andere Weise "
+"unterstützen. <br /> Wenn Sie sich ihnen anschließen möchten, <a "
+"href=\"%(contact_url)s\">drop us a line</a>."
 
 #: templates/core/newsletter.html:4
 msgid "Django Girls Dispatch - Newsletter"
@@ -2201,12 +4238,22 @@ msgid "Django Girls Dispatch"
 msgstr "Django Girls Versand"
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
-msgstr "Wir versenden alle zwei Wochen einen Newsletter an Freunde und Fremde, die uns unterstützen und neugierig sind, wie es uns geht."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
+msgstr ""
+"Wir versenden alle zwei Wochen einen Newsletter an Freunde und Fremde, die "
+"uns unterstützen und neugierig sind, wie es uns geht."
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
-msgstr "Wir versenden keine Werbung oder Spam, und wir geben Ihre E-Mail an niemanden weiter. <br /> Wir verschicken nur zweiwöchentlich eine Nachricht und tolle Ankündigungen über Dinge, auf die wir stolz sind."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
+msgstr ""
+"Wir versenden keine Werbung oder Spam, und wir geben Ihre E-Mail an "
+"niemanden weiter. <br /> Wir verschicken nur zweiwöchentlich eine Nachricht "
+"und tolle Ankündigungen über Dinge, auf die wir stolz sind."
 
 #: templates/core/newsletter.html:49
 msgid "Past editions"
@@ -2217,12 +4264,21 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr "Cookie- und Datenschutzrichtlinien der Django Girls Website"
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
-msgstr "Diese Richtlinie gilt für die Verwendung aller Daten, die wir im Zusammenhang mit Ihrer Nutzung der Website erfassen."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
+msgstr ""
+"Diese Richtlinie gilt für die Verwendung aller Daten, die wir im "
+"Zusammenhang mit Ihrer Nutzung der Website erfassen."
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
-msgstr "<b>Wir, wir, unser</b> Django Girls Foundation, eingetragene Wohltätigkeitsorganisation mit der Nummer 1163260 und der Anschrift United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
+msgstr ""
+"<b>Wir, wir, unser</b> Django Girls Foundation, eingetragene "
+"Wohltätigkeitsorganisation mit der Nummer 1163260 und der Anschrift United "
+"House, North Road, London N7 9DP"
 
 #: templates/core/privacy_cookies.html:20
 msgid "<b>You, Your</b> Are a visitor to the Site"
@@ -2241,20 +4297,45 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr "In dieser Police haben die folgenden Begriffe die folgende Bedeutung:"
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
-msgstr "<b>Daten</b> bedeutet alle Informationen, die Sie uns über die Website übermitteln. Diese Definition umfasst, soweit zutreffend, die Definitionen des Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
+msgstr ""
+"<b>Daten</b> bedeutet alle Informationen, die Sie uns über die Website "
+"übermitteln. Diese Definition umfasst, soweit zutreffend, die Definitionen "
+"des Data Protection Act 1998."
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
-msgstr "<b>Cookie</b> bezeichnet eine kleine Textdatei, die von dieser Website auf Ihrem Computer gespeichert wird, wenn Sie bestimmte Teile der Website besuchen und/oder wenn Sie bestimmte Funktionen der Website nutzen."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
+msgstr ""
+"<b>Cookie</b> bezeichnet eine kleine Textdatei, die von dieser Website auf "
+"Ihrem Computer gespeichert wird, wenn Sie bestimmte Teile der Website "
+"besuchen und/oder wenn Sie bestimmte Funktionen der Website nutzen."
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
-msgstr "<b>Britisches und EU-Cookie-Recht</b> bezeichnet die Privacy and Electronic Communications (EC Directive) Regulations 2003, geändert durch die Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
+msgstr ""
+"<b>Britisches und EU-Cookie-Recht</b> bezeichnet die Privacy and Electronic "
+"Communications (EC Directive) Regulations 2003, geändert durch die Privacy "
+"and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
-msgstr "<b>EU GDPR, GDPR</b> bezeichnet die Allgemeine Datenschutzverordnung 2016/679, eine Verordnung im EU-Recht über den Datenschutz und den Schutz der Privatsphäre für alle Personen innerhalb der Europäischen Union und des Europäischen Wirtschaftsraums."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
+msgstr ""
+"<b>EU GDPR, GDPR</b> bezeichnet die Allgemeine Datenschutzverordnung "
+"2016/679, eine Verordnung im EU-Recht über den Datenschutz und den Schutz "
+"der Privatsphäre für alle Personen innerhalb der Europäischen Union und des "
+"Europäischen Wirtschaftsraums."
 
 #: templates/core/privacy_cookies.html:53
 msgid "<b>User</b> means you or anyone who uses the Site."
@@ -2265,24 +4346,50 @@ msgid "Scope of this Policy"
 msgstr "Anwendungsbereich dieser Politik"
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
-msgstr "Diese Richtlinie gilt nur für die Handlungen von Ihnen und uns bei der Nutzung der Website. Sie erstreckt sich nicht auf:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
+msgstr ""
+"Diese Richtlinie gilt nur für die Handlungen von Ihnen und uns bei der "
+"Nutzung der Website. Sie erstreckt sich nicht auf:"
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
-msgstr "jede Veranstaltung, an der Sie teilnehmen, da die Organisatoren dieser Veranstaltungen für die Einhaltung der in ihrem Zuständigkeitsbereich geltenden Datenschutzgesetze verantwortlich sind. Trotzdem sind die Organisatoren aller Veranstaltungen verpflichtet, die unten aufgeführten Richtlinien als Teil ihrer Vereinbarung mit uns zu befolgen, und wir gewähren Ihnen hiermit das Recht, sie wegen eines Verstoßes gegen diese Richtlinien zu belangen; oder"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
+msgstr ""
+"jede Veranstaltung, an der Sie teilnehmen, da die Organisatoren dieser "
+"Veranstaltungen für die Einhaltung der in ihrem Zuständigkeitsbereich "
+"geltenden Datenschutzgesetze verantwortlich sind. Trotzdem sind die "
+"Organisatoren aller Veranstaltungen verpflichtet, die unten aufgeführten "
+"Richtlinien als Teil ihrer Vereinbarung mit uns zu befolgen, und wir "
+"gewähren Ihnen hiermit das Recht, sie wegen eines Verstoßes gegen diese "
+"Richtlinien zu belangen; oder"
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
-msgstr "alle Websites, auf die von dieser Website aus zugegriffen werden kann, einschließlich, aber nicht beschränkt auf alle Links, die wir möglicherweise anbieten."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
+msgstr ""
+"alle Websites, auf die von dieser Website aus zugegriffen werden kann, "
+"einschließlich, aber nicht beschränkt auf alle Links, die wir möglicherweise "
+"anbieten."
 
 #: templates/core/privacy_cookies.html:74
 msgid "Data Collected"
 msgstr "Erfasste Daten"
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
-msgstr "Ohne Einschränkung können alle oder einige der folgenden Daten von der Website von Zeit zu Zeit gesammelt werden:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
+msgstr ""
+"Ohne Einschränkung können alle oder einige der folgenden Daten von der "
+"Website von Zeit zu Zeit gesammelt werden:"
 
 #: templates/core/privacy_cookies.html:79
 msgid "name;"
@@ -2302,7 +4409,8 @@ msgstr "Kontaktinformationen wie E-Mail-Adressen und Telefonnummern;"
 
 #: templates/core/privacy_cookies.html:83
 msgid "demographic information such as post code, preferences and interests;"
-msgstr "demografische Informationen wie Postleitzahl, Vorlieben und Interessen;"
+msgstr ""
+"demografische Informationen wie Postleitzahl, Vorlieben und Interessen;"
 
 #: templates/core/privacy_cookies.html:84
 msgid "IP address (automatically collected);"
@@ -2317,8 +4425,13 @@ msgid "operating system (automatically collected); and"
 msgstr "Betriebssystem (automatisch erhoben); und"
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
-msgstr "eine Liste von URLs, die mit einer verweisenden Website beginnen, Ihre Aktivitäten auf der Website und die Website, die Sie verlassen (automatisch erfasst)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
+msgstr ""
+"eine Liste von URLs, die mit einer verweisenden Website beginnen, Ihre "
+"Aktivitäten auf der Website und die Website, die Sie verlassen (automatisch "
+"erfasst)."
 
 #: templates/core/privacy_cookies.html:90
 msgid "Our Use of Data"
@@ -2326,23 +4439,42 @@ msgstr "Unsere Verwendung von Daten"
 
 #: templates/core/privacy_cookies.html:92
 msgid "We will keep any personal Data you submit for 60 months."
-msgstr "Wir werden die von Ihnen übermittelten personenbezogenen Daten 60 Monate lang aufbewahren."
+msgstr ""
+"Wir werden die von Ihnen übermittelten personenbezogenen Daten 60 Monate "
+"lang aufbewahren."
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
-msgstr "Sofern wir nicht gesetzlich dazu verpflichtet oder dazu berechtigt sind, und vorbehaltlich der unten aufgeführten \"Websites und Dienste Dritter\", werden wir Ihre Daten nicht an Dritte weitergeben.  Dies gilt nicht für die Unternehmen, die Teil unserer Gruppe sind."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
+msgstr ""
+"Sofern wir nicht gesetzlich dazu verpflichtet oder dazu berechtigt sind, und "
+"vorbehaltlich der unten aufgeführten \"Websites und Dienste Dritter\", "
+"werden wir Ihre Daten nicht an Dritte weitergeben.  Dies gilt nicht für die "
+"Unternehmen, die Teil unserer Gruppe sind."
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
-msgstr "Alle personenbezogenen Daten werden sicher und in Übereinstimmung mit den Grundsätzen des Data Protection Act 1998 und der EU GDPR gespeichert."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
+msgstr ""
+"Alle personenbezogenen Daten werden sicher und in Übereinstimmung mit den "
+"Grundsätzen des Data Protection Act 1998 und der EU GDPR gespeichert."
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
-msgstr "Wir verwenden Ihre Daten, um Ihnen den bestmöglichen Service und die bestmögliche Erfahrung bei der Nutzung der Website zu bieten."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
+msgstr ""
+"Wir verwenden Ihre Daten, um Ihnen den bestmöglichen Service und die "
+"bestmögliche Erfahrung bei der Nutzung der Website zu bieten."
 
 #: templates/core/privacy_cookies.html:108
 msgid "Specifically, Data may be used by us for the following reasons:"
-msgstr "Die Daten können von uns insbesondere aus den folgenden Gründen verwendet werden:"
+msgstr ""
+"Die Daten können von uns insbesondere aus den folgenden Gründen verwendet "
+"werden:"
 
 #: templates/core/privacy_cookies.html:110
 msgid "internal record keeping;"
@@ -2353,16 +4485,28 @@ msgid "improvement of our products / services;"
 msgstr "Verbesserung unserer Produkte/Dienstleistungen;"
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
-msgstr "Übermittlung von Werbematerial, das für Sie von Interesse sein könnte, per E-Mail;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
+msgstr ""
+"Übermittlung von Werbematerial, das für Sie von Interesse sein könnte, per E-"
+"Mail;"
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
-msgstr "Kontaktaufnahme zu Marktforschungszwecken, die per E-Mail, Telefon, Fax oder Post erfolgen kann;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
+msgstr ""
+"Kontaktaufnahme zu Marktforschungszwecken, die per E-Mail, Telefon, Fax oder "
+"Post erfolgen kann;"
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
-msgstr "die Organisation einer Veranstaltung, für die Sie sich beworben oder für die Sie Ihr Interesse bekundet haben; oder"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
+msgstr ""
+"die Organisation einer Veranstaltung, für die Sie sich beworben oder für die "
+"Sie Ihr Interesse bekundet haben; oder"
 
 #: templates/core/privacy_cookies.html:115
 msgid "to customise or update the Site."
@@ -2373,44 +4517,93 @@ msgid "Third Party Sites and Services"
 msgstr "Websites und Dienste von Drittanbietern"
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
-msgstr "Wir können von Zeit zu Zeit andere Parteien mit der Abwicklung von Angelegenheiten beauftragen, die unter anderem die Zahlungsabwicklung, die Lieferung von gekauften Artikeln, Suchmaschineneinrichtungen, Werbung und Marketing umfassen. Die Anbieter solcher Dienste haben Zugang zu einigen Ihrer Daten."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
+msgstr ""
+"Wir können von Zeit zu Zeit andere Parteien mit der Abwicklung von "
+"Angelegenheiten beauftragen, die unter anderem die Zahlungsabwicklung, die "
+"Lieferung von gekauften Artikeln, Suchmaschineneinrichtungen, Werbung und "
+"Marketing umfassen. Die Anbieter solcher Dienste haben Zugang zu einigen "
+"Ihrer Daten."
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
-msgstr "Alle Daten, die von diesen Parteien verwendet werden, werden nur in dem Umfang verwendet, den sie benötigen, um die von uns angeforderten Dienstleistungen zu erbringen. Jede Verwendung für andere Zwecke ist strengstens untersagt."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
+msgstr ""
+"Alle Daten, die von diesen Parteien verwendet werden, werden nur in dem "
+"Umfang verwendet, den sie benötigen, um die von uns angeforderten "
+"Dienstleistungen zu erbringen. Jede Verwendung für andere Zwecke ist "
+"strengstens untersagt."
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
-msgstr "Jegliche Daten, die von Dritten verarbeitet werden, werden gemäß den Bedingungen dieser Richtlinie und in Übereinstimmung mit dem Data Protection Act 1998 und der EU GDPR verarbeitet."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
+msgstr ""
+"Jegliche Daten, die von Dritten verarbeitet werden, werden gemäß den "
+"Bedingungen dieser Richtlinie und in Übereinstimmung mit dem Data Protection "
+"Act 1998 und der EU GDPR verarbeitet."
 
 #: templates/core/privacy_cookies.html:142
 msgid "Links to Other Websites"
 msgstr "Links zu anderen Websites"
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
-msgstr "Wir können von Zeit zu Zeit Links zu anderen Websites anbieten. Wir haben keine Kontrolle über solche Websites und können nicht für deren Inhalt verantwortlich sein. Diese Richtlinie erstreckt sich nicht auf diese Websites und wir empfehlen Ihnen, die Datenschutzrichtlinien oder -erklärungen auf diesen Websites zu lesen, bevor Sie sie nutzen."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
+msgstr ""
+"Wir können von Zeit zu Zeit Links zu anderen Websites anbieten. Wir haben "
+"keine Kontrolle über solche Websites und können nicht für deren Inhalt "
+"verantwortlich sein. Diese Richtlinie erstreckt sich nicht auf diese "
+"Websites und wir empfehlen Ihnen, die Datenschutzrichtlinien oder -"
+"erklärungen auf diesen Websites zu lesen, bevor Sie sie nutzen."
 
 #: templates/core/privacy_cookies.html:151
 msgid "Changes of Business Ownership and Control"
-msgstr "Änderungen in den Eigentumsverhältnissen und der Kontrolle des Unternehmens"
+msgstr ""
+"Änderungen in den Eigentumsverhältnissen und der Kontrolle des Unternehmens"
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
-msgstr "Wir können von Zeit zu Zeit unser Geschäft erweitern oder verkleinern, und das kann bedeuten, dass die Personen, die unser Geschäft kontrollieren, wechseln. In diesem Fall werden Ihre Daten gegebenenfalls an die Personen weitergegeben, die dann das Unternehmen kontrollieren. Diese haben dann dieselben Rechte und Pflichten wie wir gemäß den Bedingungen dieser Richtlinie."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
+msgstr ""
+"Wir können von Zeit zu Zeit unser Geschäft erweitern oder verkleinern, und "
+"das kann bedeuten, dass die Personen, die unser Geschäft kontrollieren, "
+"wechseln. In diesem Fall werden Ihre Daten gegebenenfalls an die Personen "
+"weitergegeben, die dann das Unternehmen kontrollieren. Diese haben dann "
+"dieselben Rechte und Pflichten wie wir gemäß den Bedingungen dieser "
+"Richtlinie."
 
 #: templates/core/privacy_cookies.html:161
 msgid "If we do transfer Data for this reason we will not tell you in advance."
-msgstr "Wenn wir Daten aus diesem Grund übermitteln, werden wir Sie nicht im Voraus darüber informieren."
+msgstr ""
+"Wenn wir Daten aus diesem Grund übermitteln, werden wir Sie nicht im Voraus "
+"darüber informieren."
 
 #: templates/core/privacy_cookies.html:163
 msgid "Controlling Use of Your Data"
 msgstr "Kontrolle der Verwendung Ihrer Daten"
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
-msgstr "Wenn wir Sie um Daten bitten, haben Sie die Möglichkeit, unsere Verwendung dieser Daten einzuschränken.  Dies kann Folgendes beinhalten:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
+msgstr ""
+"Wenn wir Sie um Daten bitten, haben Sie die Möglichkeit, unsere Verwendung "
+"dieser Daten einzuschränken.  Dies kann Folgendes beinhalten:"
 
 #: templates/core/privacy_cookies.html:167
 msgid "use of Data for direct marketing purposes; and"
@@ -2429,84 +4622,191 @@ msgid "Your Right to Withhold Information"
 msgstr "Ihr Recht auf Zurückhaltung von Informationen"
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
-msgstr "Sie können auf bestimmte Bereiche der Website zugreifen, ohne irgendwelche Daten anzugeben, aber um alle auf der Website verfügbaren Merkmale und Funktionen nutzen zu können, müssen Sie möglicherweise bestimmte Daten angeben."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
+msgstr ""
+"Sie können auf bestimmte Bereiche der Website zugreifen, ohne irgendwelche "
+"Daten anzugeben, aber um alle auf der Website verfügbaren Merkmale und "
+"Funktionen nutzen zu können, müssen Sie möglicherweise bestimmte Daten "
+"angeben."
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
-msgstr "Sie können die Verwendung von Cookies durch Ihren Internet-Browser einschränken - wir empfehlen Ihnen, die Einstellung \"Extras\" Ihres Internet-Browsers zu überprüfen.  Weitere Informationen finden Sie weiter unten unter \"Cookies\"."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
+msgstr ""
+"Sie können die Verwendung von Cookies durch Ihren Internet-Browser "
+"einschränken - wir empfehlen Ihnen, die Einstellung \"Extras\" Ihres "
+"Internet-Browsers zu überprüfen.  Weitere Informationen finden Sie weiter "
+"unten unter \"Cookies\"."
 
 #: templates/core/privacy_cookies.html:178
 msgid "Accessing Your Own Data"
 msgstr "Zugriff auf Ihre eigenen Daten"
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
-msgstr "Sie haben das Recht, gegen Zahlung einer geringen Gebühr von maximal 10 £ eine Kopie der von uns gespeicherten personenbezogenen Daten anzufordern."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
+msgstr ""
+"Sie haben das Recht, gegen Zahlung einer geringen Gebühr von maximal 10 £ "
+"eine Kopie der von uns gespeicherten personenbezogenen Daten anzufordern."
 
 #: templates/core/privacy_cookies.html:182
 msgid "Security"
 msgstr "Sicherheit"
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
-msgstr "Um Ihre Daten zu schützen, haben wir verschiedene physische, elektronische und verwaltungstechnische Verfahren eingeführt, um die über die Website erfassten Daten zu schützen und zu sichern."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
+msgstr ""
+"Um Ihre Daten zu schützen, haben wir verschiedene physische, elektronische "
+"und verwaltungstechnische Verfahren eingeführt, um die über die Website "
+"erfassten Daten zu schützen und zu sichern."
 
 #: templates/core/privacy_cookies.html:186
 msgid "Cookies"
 msgstr "Cookies"
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
-msgstr "Die Website kann bestimmte Cookies auf Ihrem Computer platzieren und darauf zugreifen.  Dabei handelt es sich um Cookies von Erstanbietern, die wir über die Website platzieren und die nur von uns verwendet werden.  Wir verwenden Cookies, um Ihre Erfahrung bei der Nutzung der Website zu verbessern und um unser Angebot an Produkten und/oder Dienstleistungen zu verbessern.  Wir wählen die von uns verwendeten Cookies sorgfältig aus und haben Maßnahmen ergriffen, um sicherzustellen, dass Ihre Privatsphäre stets geschützt und respektiert wird."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
+msgstr ""
+"Die Website kann bestimmte Cookies auf Ihrem Computer platzieren und darauf "
+"zugreifen.  Dabei handelt es sich um Cookies von Erstanbietern, die wir über "
+"die Website platzieren und die nur von uns verwendet werden.  Wir verwenden "
+"Cookies, um Ihre Erfahrung bei der Nutzung der Website zu verbessern und um "
+"unser Angebot an Produkten und/oder Dienstleistungen zu verbessern.  Wir "
+"wählen die von uns verwendeten Cookies sorgfältig aus und haben Maßnahmen "
+"ergriffen, um sicherzustellen, dass Ihre Privatsphäre stets geschützt und "
+"respektiert wird."
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
-msgstr "Alle von der Website verwendeten Cookies werden in Übereinstimmung mit dem geltenden britischen und EU-Cookie-Gesetz verwendet."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
+msgstr ""
+"Alle von der Website verwendeten Cookies werden in Übereinstimmung mit dem "
+"geltenden britischen und EU-Cookie-Gesetz verwendet."
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
-msgstr "Bestimmte Funktionen der Website benötigen Cookies, damit diese Funktionen funktionieren.  Das britische und das EU-Cookie-Gesetz halten diese Cookies für \"unbedingt erforderlich\".  In diesen Fällen bitten wir Sie nicht um Ihr Einverständnis, sie zu platzieren, aber Sie können diese Cookies trotzdem blockieren, indem Sie die Einstellungen Ihres Internetbrowsers wie unten beschrieben ändern."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
+msgstr ""
+"Bestimmte Funktionen der Website benötigen Cookies, damit diese Funktionen "
+"funktionieren.  Das britische und das EU-Cookie-Gesetz halten diese Cookies "
+"für \"unbedingt erforderlich\".  In diesen Fällen bitten wir Sie nicht um "
+"Ihr Einverständnis, sie zu platzieren, aber Sie können diese Cookies "
+"trotzdem blockieren, indem Sie die Einstellungen Ihres Internetbrowsers wie "
+"unten beschrieben ändern."
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
-msgstr "Die Website nutzt Analysedienste, die von Google und anderen bereitgestellt werden.  \"Analytics\" ist eine Reihe von Tools, die zur Erfassung und Analyse der Nutzung der Website verwendet werden und uns helfen, die Bedürfnisse unserer Nutzer zu verstehen.  Dies wiederum bedeutet, dass wir die Website und die über sie angebotenen Produkte und/oder Dienstleistungen verbessern können."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
+msgstr ""
+"Die Website nutzt Analysedienste, die von Google und anderen bereitgestellt "
+"werden.  \"Analytics\" ist eine Reihe von Tools, die zur Erfassung und "
+"Analyse der Nutzung der Website verwendet werden und uns helfen, die "
+"Bedürfnisse unserer Nutzer zu verstehen.  Dies wiederum bedeutet, dass wir "
+"die Website und die über sie angebotenen Produkte und/oder Dienstleistungen "
+"verbessern können."
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
-msgstr "Sie müssen uns die Verwendung dieser analytischen Cookies nicht gestatten, aber wenn wir sie verwenden, sind Ihre Privatsphäre und die sichere Nutzung der Website nicht gefährdet."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
+msgstr ""
+"Sie müssen uns die Verwendung dieser analytischen Cookies nicht gestatten, "
+"aber wenn wir sie verwenden, sind Ihre Privatsphäre und die sichere Nutzung "
+"der Website nicht gefährdet."
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
-msgstr "Der Analysedienst kann Cookies auf Ihrem Gerät ablegen, sobald Sie die Website besuchen, und es ist möglicherweise nicht möglich, vorher Ihre Zustimmung einzuholen.  Sie können diese Cookies entfernen und ihre künftige Verwendung verhindern, indem Sie die unten aufgeführten Schritte ausführen:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
+msgstr ""
+"Der Analysedienst kann Cookies auf Ihrem Gerät ablegen, sobald Sie die "
+"Website besuchen, und es ist möglicherweise nicht möglich, vorher Ihre "
+"Zustimmung einzuholen.  Sie können diese Cookies entfernen und ihre künftige "
+"Verwendung verhindern, indem Sie die unten aufgeführten Schritte ausführen:"
 
 #: templates/core/privacy_cookies.html:201
 msgid "You can choose to enable or disable Cookies in your internet browser."
-msgstr "Sie können Cookies in Ihrem Internet-Browser aktivieren oder deaktivieren."
+msgstr ""
+"Sie können Cookies in Ihrem Internet-Browser aktivieren oder deaktivieren."
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
-msgstr "Bei den meisten Internet-Browsern können Sie wählen, ob Sie alle Cookies oder nur die Cookies von Dritten deaktivieren möchten."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
+msgstr ""
+"Bei den meisten Internet-Browsern können Sie wählen, ob Sie alle Cookies "
+"oder nur die Cookies von Dritten deaktivieren möchten."
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
-msgstr "Standardmäßig akzeptieren die meisten Internetbrowser Cookies, aber das kann geändert werden. Weitere Einzelheiten entnehmen Sie bitte dem Hilfemenü Ihres Internetbrowsers."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
+msgstr ""
+"Standardmäßig akzeptieren die meisten Internetbrowser Cookies, aber das kann "
+"geändert werden. Weitere Einzelheiten entnehmen Sie bitte dem Hilfemenü "
+"Ihres Internetbrowsers."
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
-msgstr "Sie können Cookies jederzeit löschen, aber wenn Sie dies tun, können Sie alle Informationen verlieren, die es Ihnen ermöglichen, schnell und effizient auf die Website zuzugreifen, und Sie können Ihre persönlichen Einstellungen verlieren."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
+msgstr ""
+"Sie können Cookies jederzeit löschen, aber wenn Sie dies tun, können Sie "
+"alle Informationen verlieren, die es Ihnen ermöglichen, schnell und "
+"effizient auf die Website zuzugreifen, und Sie können Ihre persönlichen "
+"Einstellungen verlieren."
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
-msgstr "Wir empfehlen Ihnen, sich zu vergewissern, dass Ihr Internet-Browser auf dem neuesten Stand ist, und im Zweifelsfall die von Ihrem Internet-Browser bereitgestellte Hilfe und Anleitung zu konsultieren."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
+msgstr ""
+"Wir empfehlen Ihnen, sich zu vergewissern, dass Ihr Internet-Browser auf dem "
+"neuesten Stand ist, und im Zweifelsfall die von Ihrem Internet-Browser "
+"bereitgestellte Hilfe und Anleitung zu konsultieren."
 
 #: templates/core/privacy_cookies.html:214
 msgid "Changes to this Policy"
 msgstr "Änderungen an dieser Politik"
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
-msgstr "Wir haben das Recht, diese Richtlinie von Zeit zu Zeit zu ändern, wenn wir dies beschließen oder wenn dies gesetzlich vorgeschrieben ist. Alle Änderungen werden sofort auf der Website veröffentlicht und es wird davon ausgegangen, dass Sie die Bedingungen dieser Richtlinie bei Ihrer ersten Nutzung der Website nach diesen Änderungen akzeptieren."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
+msgstr ""
+"Wir haben das Recht, diese Richtlinie von Zeit zu Zeit zu ändern, wenn wir "
+"dies beschließen oder wenn dies gesetzlich vorgeschrieben ist. Alle "
+"Änderungen werden sofort auf der Website veröffentlicht und es wird davon "
+"ausgegangen, dass Sie die Bedingungen dieser Richtlinie bei Ihrer ersten "
+"Nutzung der Website nach diesen Änderungen akzeptieren."
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
 #: templates/global/menu.html:21
@@ -2514,8 +4814,16 @@ msgid "Resources"
 msgstr "Ressourcen"
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
-msgstr "Alle von uns erstellten Ressourcen stehen unter der Creative Commons Attribution 4.0 International (CC BY 4) zur Verfügung. Das bedeutet, dass Sie sie verändern, verbreiten und kommerziell nutzen können, aber Sie dürfen keine Unterlizenzen vergeben und müssen uns die Urheberrechte nennen."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
+msgstr ""
+"Alle von uns erstellten Ressourcen stehen unter der Creative Commons "
+"Attribution 4.0 International (CC BY 4) zur Verfügung. Das bedeutet, dass "
+"Sie sie verändern, verbreiten und kommerziell nutzen können, aber Sie dürfen "
+"keine Unterlizenzen vergeben und müssen uns die Urheberrechte nennen."
 
 #: templates/core/resources.html:22
 msgid "Django Tutorial"
@@ -2526,8 +4834,14 @@ msgid "Tutorial Django Girls"
 msgstr "Tutorial Django Girls"
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
-msgstr "Das Tutorial, das wir für alle unsere Workshops verwenden. Es ist ein sehr einsteigerfreundliches Tutorial mit Einführungen in die Kommandozeile, Python, Django, HTML und CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
+msgstr ""
+"Das Tutorial, das wir für alle unsere Workshops verwenden. Es ist ein sehr "
+"einsteigerfreundliches Tutorial mit Einführungen in die Kommandozeile, "
+"Python, Django, HTML und CSS."
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
 #: templates/core/resources.html:77 templates/core/resources.html:97
@@ -2543,16 +4857,29 @@ msgid "Organize Django Girls"
 msgstr "Django Girls organisieren"
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
-msgstr "Wir haben alles aufgeschrieben, was wir über die Organisation von Workshops wie Django Girls wissen. Es ist ein Handbuch für Organisatoren von lokalen Veranstaltungen, kann aber für jede Art von Workshop verwendet werden."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
+msgstr ""
+"Wir haben alles aufgeschrieben, was wir über die Organisation von Workshops "
+"wie Django Girls wissen. Es ist ein Handbuch für Organisatoren von lokalen "
+"Veranstaltungen, kann aber für jede Art von Workshop verwendet werden."
 
 #: templates/core/resources.html:67
 msgid "Coaching Guide Django Girls"
 msgstr "Coaching Leitfaden Django Girls"
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
-msgstr "Ein guter Coaching-Ansatz ist der wichtigste Teil der Django Girls-Veranstaltungen. Lernen Sie, wie man ein guter Coach ist, was die Regeln sind und woran wir glauben. Dies kann für das Coaching jeder Veranstaltung verwendet werden - nicht nur für Django Girls Workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
+msgstr ""
+"Ein guter Coaching-Ansatz ist der wichtigste Teil der Django Girls-"
+"Veranstaltungen. Lernen Sie, wie man ein guter Coach ist, was die Regeln "
+"sind und woran wir glauben. Dies kann für das Coaching jeder Veranstaltung "
+"verwendet werden - nicht nur für Django Girls Workshops."
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
 msgid "Tutorial Extensions"
@@ -2563,22 +4890,43 @@ msgid "Tutorial Extensions Django Girls"
 msgstr "Tutorial Erweiterungen Django Mädchen"
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
-msgstr "Dieses Buch enthält zusätzliche Aufgaben und Tutorials, die nach Abschluss unseres Haupttutorials durchgeführt werden können. Unser Haupttutorial passt in einen Tag Arbeit und wir wollen, dass das auch so bleibt."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
+msgstr ""
+"Dieses Buch enthält zusätzliche Aufgaben und Tutorials, die nach Abschluss "
+"unseres Haupttutorials durchgeführt werden können. Unser Haupttutorial passt "
+"in einen Tag Arbeit und wir wollen, dass das auch so bleibt."
 
 #: templates/core/terms_conditions.html:4
 #: templates/core/terms_conditions.html:11
 msgid "Terms and Conditions of use of Django Girls Website"
-msgstr "Allgemeine Geschäftsbedingungen für die Nutzung der Django Girls Website"
+msgstr ""
+"Allgemeine Geschäftsbedingungen für die Nutzung der Django Girls Website"
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
-msgstr "Willkommen auf unserer Seite mit den Allgemeinen Geschäftsbedingungen. Wir haben versucht, sie leicht verständlich zu machen, damit Sie genau wissen, woran Sie sind, wenn Sie bei uns bestellen. Bitte lesen Sie sie durch, und wenn Sie etwas nicht verstehen, setzen Sie sich mit uns in Verbindung, und wir werden unser Bestes tun, um es zu erklären."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
+msgstr ""
+"Willkommen auf unserer Seite mit den Allgemeinen Geschäftsbedingungen. Wir "
+"haben versucht, sie leicht verständlich zu machen, damit Sie genau wissen, "
+"woran Sie sind, wenn Sie bei uns bestellen. Bitte lesen Sie sie durch, und "
+"wenn Sie etwas nicht verstehen, setzen Sie sich mit uns in Verbindung, und "
+"wir werden unser Bestes tun, um es zu erklären."
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
-msgstr "<b>Wir</b> sind die Django Girls Foundation, eingetragene Wohltätigkeitsorganisation mit der Nummer 1163260 und der Adresse United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
+msgstr ""
+"<b>Wir</b> sind die Django Girls Foundation, eingetragene "
+"Wohltätigkeitsorganisation mit der Nummer 1163260 und der Adresse United "
+"House, North Road, London N7 9DP"
 
 #: templates/core/terms_conditions.html:18
 msgid "<b>Site</b> is djangogirls.org"
@@ -2593,16 +4941,28 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr "Mit dem Betreten unserer Website akzeptieren Sie diese T&Cs"
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
-msgstr "Eine weitere Sache, die wir erwähnen müssen, ist, dass wir diese AGB von Zeit zu Zeit ändern und Sie daher immer diese Seite besuchen müssen, um zu sehen, welche Änderungen wir vorgenommen haben - wir gehen davon aus, dass Sie das jedes Mal getan haben, wenn Sie uns kontaktieren."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
+msgstr ""
+"Eine weitere Sache, die wir erwähnen müssen, ist, dass wir diese AGB von "
+"Zeit zu Zeit ändern und Sie daher immer diese Seite besuchen müssen, um zu "
+"sehen, welche Änderungen wir vorgenommen haben - wir gehen davon aus, dass "
+"Sie das jedes Mal getan haben, wenn Sie uns kontaktieren."
 
 #: templates/core/terms_conditions.html:39
 msgid "Agreement"
 msgstr "Vereinbarung"
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
-msgstr "Diese Seite soll die Grundlage für die Beziehung zwischen uns und Ihnen bilden, und wir erklären uns damit einverstanden, dass wir uns an den Inhalt dieser Seite halten."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
+msgstr ""
+"Diese Seite soll die Grundlage für die Beziehung zwischen uns und Ihnen "
+"bilden, und wir erklären uns damit einverstanden, dass wir uns an den Inhalt "
+"dieser Seite halten."
 
 #: templates/core/terms_conditions.html:44
 msgid "Definition"
@@ -2617,128 +4977,276 @@ msgid "You promise us:"
 msgstr "Sie versprechen es uns:"
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
-msgstr "Dass Sie das Recht haben, diese AGB mit uns zu vereinbaren und dass Sie über 18 Jahre alt sind."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
+msgstr ""
+"Dass Sie das Recht haben, diese AGB mit uns zu vereinbaren und dass Sie über "
+"18 Jahre alt sind."
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
-msgstr "Wenn Sie einem unserer Links auf der Website folgen, lesen Sie bitte die Geschäftsbedingungen der Websites, zu denen wir Sie verlinken."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
+msgstr ""
+"Wenn Sie einem unserer Links auf der Website folgen, lesen Sie bitte die "
+"Geschäftsbedingungen der Websites, zu denen wir Sie verlinken."
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
-msgstr "dass Sie keine Robots, Spiders, Scrapers oder Ähnliches auf der Website verwenden werden."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgstr ""
+"dass Sie keine Robots, Spiders, Scrapers oder Ähnliches auf der Website "
+"verwenden werden."
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
-msgstr "dass Sie nicht versuchen werden, die Maßnahmen zu umgehen, die wir auf der Website getroffen haben, um den Zugang zu Teilen der Website zu verhindern oder einzuschränken."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
+msgstr ""
+"dass Sie nicht versuchen werden, die Maßnahmen zu umgehen, die wir auf der "
+"Website getroffen haben, um den Zugang zu Teilen der Website zu verhindern "
+"oder einzuschränken."
 
 #: templates/core/terms_conditions.html:53
 msgid "That you won’t do anything that might cause our systems to crash."
-msgstr "Dass Sie nichts tun werden, was unsere Systeme zum Absturz bringen könnte."
+msgstr ""
+"Dass Sie nichts tun werden, was unsere Systeme zum Absturz bringen könnte."
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
-msgstr "dass Sie die Website oder Teile davon nicht stehlen, ausleihen, kopieren oder anderweitig erhalten, um sie auf einer anderen Website oder in einer Anwendung zu verwenden, die im Widerspruch zu den Zielen und Idealen steht, die wir von Zeit zu Zeit auf der Website veröffentlichen."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
+msgstr ""
+"dass Sie die Website oder Teile davon nicht stehlen, ausleihen, kopieren "
+"oder anderweitig erhalten, um sie auf einer anderen Website oder in einer "
+"Anwendung zu verwenden, die im Widerspruch zu den Zielen und Idealen steht, "
+"die wir von Zeit zu Zeit auf der Website veröffentlichen."
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
-msgstr "dass Sie nicht versuchen werden, Programme, die wir in Verbindung mit der Website oder den von ihr angebotenen Diensten verwenden, zu verändern, zu übersetzen, anzupassen, zu bearbeiten, zu dekompilieren, zu disassemblieren oder zurückzuentwickeln, und zwar zu keinem Zweck, der im Widerspruch zu den Zielen und Idealen steht, die wir von Zeit zu Zeit auf der Website veröffentlichen."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
+msgstr ""
+"dass Sie nicht versuchen werden, Programme, die wir in Verbindung mit der "
+"Website oder den von ihr angebotenen Diensten verwenden, zu verändern, zu "
+"übersetzen, anzupassen, zu bearbeiten, zu dekompilieren, zu disassemblieren "
+"oder zurückzuentwickeln, und zwar zu keinem Zweck, der im Widerspruch zu den "
+"Zielen und Idealen steht, die wir von Zeit zu Zeit auf der Website "
+"veröffentlichen."
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
-msgstr "dass Sie die Marken und/oder Designs und/oder das Layout oder alles andere, was normalerweise geistiges Eigentum darstellt und uns gehört, nicht kopieren, nachahmen oder verwenden werden."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
+msgstr ""
+"dass Sie die Marken und/oder Designs und/oder das Layout oder alles andere, "
+"was normalerweise geistiges Eigentum darstellt und uns gehört, nicht "
+"kopieren, nachahmen oder verwenden werden."
 
 #: templates/core/terms_conditions.html:59
 msgid "Intellectual property"
 msgstr "Geistiges Eigentum"
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
-msgstr "Alle Informationen und das geistige Eigentum auf der Website gehören entweder uns oder Dritten."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
+msgstr ""
+"Alle Informationen und das geistige Eigentum auf der Website gehören "
+"entweder uns oder Dritten."
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
-msgstr "Wir freuen uns, wenn Sie Informationen oder geistiges Eigentum, das uns gehört, auf der Website verwenden, sofern Sie uns vorher (schriftlich) um Erlaubnis bitten.  Wir können Ihnen Bedingungen für die Nutzung dieser Informationen oder des geistigen Eigentums auferlegen. Wenn Sie als Veranstalter Informationen oder geistiges Eigentum von uns nutzen wollen, müssen Sie unsere Nutzungsbedingungen für Veranstalter einhalten, die Sie <a href=\"http://organize.djangogirls.org/\">hier</a> einsehen können."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
+msgstr ""
+"Wir freuen uns, wenn Sie Informationen oder geistiges Eigentum, das uns "
+"gehört, auf der Website verwenden, sofern Sie uns vorher (schriftlich) um "
+"Erlaubnis bitten.  Wir können Ihnen Bedingungen für die Nutzung dieser "
+"Informationen oder des geistigen Eigentums auferlegen. Wenn Sie als "
+"Veranstalter Informationen oder geistiges Eigentum von uns nutzen wollen, "
+"müssen Sie unsere Nutzungsbedingungen für Veranstalter einhalten, die Sie <a "
+"href=\"http://organize.djangogirls.org/\">hier</a> einsehen können."
 
 #: templates/core/terms_conditions.html:71
 msgid "Price and payment"
 msgstr "Preis und Bezahlung"
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
-msgstr "Wir erheben keine Gebühren für die Dienste, die wir Privatpersonen über die Website anbieten, und die meisten anderen von uns angebotenen Dienste sind kostenlos."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
+msgstr ""
+"Wir erheben keine Gebühren für die Dienste, die wir Privatpersonen über die "
+"Website anbieten, und die meisten anderen von uns angebotenen Dienste sind "
+"kostenlos."
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
-msgstr "Wenn Sie für die Nutzung einer unserer Dienstleistungen spenden möchten, besuchen Sie unsere <a href=\"https://www.patreon.com/djangogirls\">Patreon-Seite</a> oder <a href=\"%(donations_url)s\">unsere Spendenseite</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
+msgstr ""
+"Wenn Sie für die Nutzung einer unserer Dienstleistungen spenden möchten, "
+"besuchen Sie unsere <a href=\"https://www.patreon.com/djangogirls\">Patreon-"
+"Seite</a> oder <a href=\"%(donations_url)s\">unsere Spendenseite</a>."
 
 #: templates/core/terms_conditions.html:86
 msgid "Use of communications facilities"
 msgstr "Nutzung von Kommunikationseinrichtungen"
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
-msgstr "Wenn Sie uns Inhalte zur Veröffentlichung auf der Website übermitteln oder Foren oder Chatrooms auf der Website und/oder andere ähnliche Systeme auf der Website nutzen und wenn Sie Facebook, Wordpress oder ein anderes externes Kommunikationssystem nutzen, um mit uns in Kontakt zu treten, müssen Sie dies in Übereinstimmung mit den folgenden Regeln tun:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
+msgstr ""
+"Wenn Sie uns Inhalte zur Veröffentlichung auf der Website übermitteln oder "
+"Foren oder Chatrooms auf der Website und/oder andere ähnliche Systeme auf "
+"der Website nutzen und wenn Sie Facebook, Wordpress oder ein anderes "
+"externes Kommunikationssystem nutzen, um mit uns in Kontakt zu treten, "
+"müssen Sie dies in Übereinstimmung mit den folgenden Regeln tun:"
 
 #: templates/core/terms_conditions.html:90
 msgid "you must not use language that may be offensive to other Users;"
-msgstr "Sie dürfen keine Sprache verwenden, die für andere Nutzer beleidigend sein könnte;"
+msgstr ""
+"Sie dürfen keine Sprache verwenden, die für andere Nutzer beleidigend sein "
+"könnte;"
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
-msgstr "Sie dürfen keine Inhalte übermitteln, die rechtswidrig oder anderweitig anstößig sind.  Dazu gehören unter anderem Inhalte, die beleidigend, bedrohend, belästigend, verleumderisch, altersdiskriminierend, sexistisch oder rassistisch sind;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
+msgstr ""
+"Sie dürfen keine Inhalte übermitteln, die rechtswidrig oder anderweitig "
+"anstößig sind.  Dazu gehören unter anderem Inhalte, die beleidigend, "
+"bedrohend, belästigend, verleumderisch, altersdiskriminierend, sexistisch "
+"oder rassistisch sind;"
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
-msgstr "Sie dürfen keine Inhalte übermitteln, die Gewalt fördern oder dazu auffordern;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
+msgstr ""
+"Sie dürfen keine Inhalte übermitteln, die Gewalt fördern oder dazu "
+"auffordern;"
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
-msgstr "Die Inhalte müssen in englischer Sprache veröffentlicht werden, und die Kommunikation mit uns muss in englischer Sprache erfolgen;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
+msgstr ""
+"Die Inhalte müssen in englischer Sprache veröffentlicht werden, und die "
+"Kommunikation mit uns muss in englischer Sprache erfolgen;"
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
-msgstr "Sie dürfen keine Links zu anderen Websites veröffentlichen, die eine der oben genannten Arten von Inhalten enthalten;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
+msgstr ""
+"Sie dürfen keine Links zu anderen Websites veröffentlichen, die eine der "
+"oben genannten Arten von Inhalten enthalten;"
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
-msgstr "die Mittel, mit denen Sie sich identifizieren, dürfen nicht gegen diese AGB oder geltende Gesetze verstoßen;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
+msgstr ""
+"die Mittel, mit denen Sie sich identifizieren, dürfen nicht gegen diese AGB "
+"oder geltende Gesetze verstoßen;"
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
-msgstr "Sie dürfen keine Form der kommerziellen Werbung betreiben. Dies verbietet nicht die Erwähnung von Unternehmen zu nicht-werblichen Zwecken, auch nicht die Erwähnung von Unternehmen, bei denen die Werbung eine Nebenrolle spielt;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
+msgstr ""
+"Sie dürfen keine Form der kommerziellen Werbung betreiben. Dies verbietet "
+"nicht die Erwähnung von Unternehmen zu nicht-werblichen Zwecken, auch nicht "
+"die Erwähnung von Unternehmen, bei denen die Werbung eine Nebenrolle spielt;"
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
-msgstr "Sie geben uns das Recht, das von Ihnen eingereichte Material überall und aus jedem beliebigen Grund zu veröffentlichen, ohne dass wir Ihnen eine Gebühr zahlen oder Sie als Autor anerkennen müssen;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
+msgstr ""
+"Sie geben uns das Recht, das von Ihnen eingereichte Material überall und aus "
+"jedem beliebigen Grund zu veröffentlichen, ohne dass wir Ihnen eine Gebühr "
+"zahlen oder Sie als Autor anerkennen müssen;"
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
-msgstr "Sie dürfen sich nicht als andere Personen ausgeben, insbesondere nicht als unsere Mitarbeiter und Vertreter oder als die unserer verbundenen Unternehmen; und"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
+msgstr ""
+"Sie dürfen sich nicht als andere Personen ausgeben, insbesondere nicht als "
+"unsere Mitarbeiter und Vertreter oder als die unserer verbundenen "
+"Unternehmen; und"
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
-msgstr "Sie dürfen unser System nicht für unerlaubte Massenkommunikation wie \"Spam\" oder \"Junk-Mail\" verwenden."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
+msgstr ""
+"Sie dürfen unser System nicht für unerlaubte Massenkommunikation wie "
+"\"Spam\" oder \"Junk-Mail\" verwenden."
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
-msgstr "Sie erkennen an, dass wir das Recht haben, jegliche Kommunikation, die an uns oder über unser System erfolgt, zu überwachen."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
+msgstr ""
+"Sie erkennen an, dass wir das Recht haben, jegliche Kommunikation, die an "
+"uns oder über unser System erfolgt, zu überwachen."
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
-msgstr "Sie erkennen an, dass wir Kopien aller an uns gerichteten oder über unser System erfolgten Mitteilungen aufbewahren können."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
+msgstr ""
+"Sie erkennen an, dass wir Kopien aller an uns gerichteten oder über unser "
+"System erfolgten Mitteilungen aufbewahren können."
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
-msgstr "Sie erklären sich damit einverstanden, dass wir alle Informationen, die Sie uns übermitteln, in beliebiger Weise ändern können, und Sie erklären sich damit einverstanden, dass Sie kein moralisches Recht haben, als Urheber dieser Informationen identifiziert zu werden. Sofern wir dies nicht im Voraus mit Ihnen vereinbart haben, müssen wir uns nicht an die von Ihnen auferlegten Beschränkungen für die Nutzung dieser Informationen halten."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
+msgstr ""
+"Sie erklären sich damit einverstanden, dass wir alle Informationen, die Sie "
+"uns übermitteln, in beliebiger Weise ändern können, und Sie erklären sich "
+"damit einverstanden, dass Sie kein moralisches Recht haben, als Urheber "
+"dieser Informationen identifiziert zu werden. Sofern wir dies nicht im "
+"Voraus mit Ihnen vereinbart haben, müssen wir uns nicht an die von Ihnen "
+"auferlegten Beschränkungen für die Nutzung dieser Informationen halten."
 
 #: templates/core/terms_conditions.html:114
 msgid "Privacy and cookies"
 msgstr "Datenschutz und Cookies"
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
-msgstr "Wir und Sie sind damit einverstanden, dass <a href=\"%(cookies_url)s\">unsere Datenschutz- und Cookie-Richtlinie</a> Teil dieser AGB ist."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
+msgstr ""
+"Wir und Sie sind damit einverstanden, dass <a "
+"href=\"%(cookies_url)s\">unsere Datenschutz- und Cookie-Richtlinie</a> Teil "
+"dieser AGB ist."
 
 #: templates/core/terms_conditions.html:123
 msgid "Disclaimers"
@@ -2753,8 +5261,12 @@ msgid "that the Site will meet your needs;"
 msgstr "dass die Website Ihren Bedürfnissen entspricht;"
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
-msgstr "dass alle Informationen, die wir veröffentlichen, korrekt, aktuell und nicht irreführend sind;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
+msgstr ""
+"dass alle Informationen, die wir veröffentlichen, korrekt, aktuell und nicht "
+"irreführend sind;"
 
 #: templates/core/terms_conditions.html:130
 msgid "that the Site always works properly;"
@@ -2777,100 +5289,219 @@ msgid "that the Site is secure,"
 msgstr "dass die Website sicher ist,"
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
-msgstr "aber wir können diese Dinge nicht garantieren, und mit Ihrer Zustimmung zu diesen AGBs bestätigen Sie, dass Sie diese Situation akzeptieren."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
+msgstr ""
+"aber wir können diese Dinge nicht garantieren, und mit Ihrer Zustimmung zu "
+"diesen AGBs bestätigen Sie, dass Sie diese Situation akzeptieren."
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
-msgstr "Wir unternehmen alle angemessenen Anstrengungen, um das Material zu testen, bevor wir es auf die Website stellen. In dem sehr unwahrscheinlichen Fall eines Verlustes, einer Unterbrechung oder eines Schadens, der durch das Material auf der Website verursacht wird, können wir nicht für einen Verlust, eine Unterbrechung oder einen Schaden an Ihren Daten oder Ihrem Computersystem verantwortlich gemacht werden."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
+msgstr ""
+"Wir unternehmen alle angemessenen Anstrengungen, um das Material zu testen, "
+"bevor wir es auf die Website stellen. In dem sehr unwahrscheinlichen Fall "
+"eines Verlustes, einer Unterbrechung oder eines Schadens, der durch das "
+"Material auf der Website verursacht wird, können wir nicht für einen "
+"Verlust, eine Unterbrechung oder einen Schaden an Ihren Daten oder Ihrem "
+"Computersystem verantwortlich gemacht werden."
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
-msgstr "Die einzigen Rechte, die Sie im Rahmen dieser AGB haben, sind die, die in diesen AGB erwähnt werden. Wenn ein Recht nicht erwähnt wird (es sei denn, es handelt sich um ein Recht, das Ihnen nach den Gesetzen von England und Wales zusteht), dann existiert es nicht."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
+msgstr ""
+"Die einzigen Rechte, die Sie im Rahmen dieser AGB haben, sind die, die in "
+"diesen AGB erwähnt werden. Wenn ein Recht nicht erwähnt wird (es sei denn, "
+"es handelt sich um ein Recht, das Ihnen nach den Gesetzen von England und "
+"Wales zusteht), dann existiert es nicht."
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
-msgstr "Wenn Sie einen Fehler, ein Problem oder einen Bug bei der Nutzung einer der von uns auf der Website angebotenen Dienstleistungen oder Einrichtungen feststellen, erklären Sie sich damit einverstanden, uns entweder zu benachrichtigen, indem Sie einen Pull-Request an die folgende <a href=\"https://github.com/DjangoGirls/djangogirls/\">Adresse</a> senden, oder uns über die Einrichtungen der Website eine Frage zu stellen. Obwohl wir uns stets bemühen werden, die in diesem Absatz genannten Probleme zu lösen, übernehmen wir keine Garantie dafür, dass wir in der Lage sein werden, ein bestimmtes Ergebnis zu erzielen."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
+msgstr ""
+"Wenn Sie einen Fehler, ein Problem oder einen Bug bei der Nutzung einer der "
+"von uns auf der Website angebotenen Dienstleistungen oder Einrichtungen "
+"feststellen, erklären Sie sich damit einverstanden, uns entweder zu "
+"benachrichtigen, indem Sie einen Pull-Request an die folgende <a "
+"href=\"https://github.com/DjangoGirls/djangogirls/\">Adresse</a> senden, "
+"oder uns über die Einrichtungen der Website eine Frage zu stellen. Obwohl "
+"wir uns stets bemühen werden, die in diesem Absatz genannten Probleme zu "
+"lösen, übernehmen wir keine Garantie dafür, dass wir in der Lage sein "
+"werden, ein bestimmtes Ergebnis zu erzielen."
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
 msgid "Events"
 msgstr "Veranstaltungen"
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
-msgstr "Die über die Website organisierten Veranstaltungen werden in der Regel von Dritten und nicht von uns organisiert. Obwohl wir Richtlinien für alle Organisatoren aufstellen, haben wir keine Kontrolle darüber, ob diese Richtlinien befolgt werden oder nicht. Aus diesem Grund und im größtmöglichen gesetzlich zulässigen Umfang übernehmen wir keine Haftung für direkte oder indirekte Verluste oder Schäden, vorhersehbar oder anderweitig, einschließlich indirekter Schäden, Folgeschäden, spezieller oder exemplarischer Schäden, die sich aus Ihrer Buchung oder Teilnahme an einer Veranstaltung oder aus irgendetwas, das sich daraus ergibt, ergeben."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
+msgstr ""
+"Die über die Website organisierten Veranstaltungen werden in der Regel von "
+"Dritten und nicht von uns organisiert. Obwohl wir Richtlinien für alle "
+"Organisatoren aufstellen, haben wir keine Kontrolle darüber, ob diese "
+"Richtlinien befolgt werden oder nicht. Aus diesem Grund und im "
+"größtmöglichen gesetzlich zulässigen Umfang übernehmen wir keine Haftung für "
+"direkte oder indirekte Verluste oder Schäden, vorhersehbar oder anderweitig, "
+"einschließlich indirekter Schäden, Folgeschäden, spezieller oder "
+"exemplarischer Schäden, die sich aus Ihrer Buchung oder Teilnahme an einer "
+"Veranstaltung oder aus irgendetwas, das sich daraus ergibt, ergeben."
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
-msgstr "Sie akzeptieren, dass alle Fragen, die sich im Zusammenhang mit einer Veranstaltung ergeben, an den Veranstalter gerichtet werden müssen."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
+msgstr ""
+"Sie akzeptieren, dass alle Fragen, die sich im Zusammenhang mit einer "
+"Veranstaltung ergeben, an den Veranstalter gerichtet werden müssen."
 
 #: templates/core/terms_conditions.html:164
 msgid "Problems"
 msgstr "Probleme"
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
-msgstr "Wir tun unser Bestes, um sicherzustellen, dass Sie keine Probleme bei der Nutzung der Website haben, aber wenn Sie welche haben, müssen Sie uns das sofort mitteilen."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
+msgstr ""
+"Wir tun unser Bestes, um sicherzustellen, dass Sie keine Probleme bei der "
+"Nutzung der Website haben, aber wenn Sie welche haben, müssen Sie uns das "
+"sofort mitteilen."
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
-msgstr "Wir werden alles in unserer Macht Stehende tun, um das Problem so schnell wie möglich und für Sie kostenlos zu lösen, wenn wir der Meinung sind, dass Sie ein Problem haben."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
+msgstr ""
+"Wir werden alles in unserer Macht Stehende tun, um das Problem so schnell "
+"wie möglich und für Sie kostenlos zu lösen, wenn wir der Meinung sind, dass "
+"Sie ein Problem haben."
 
 #: templates/core/terms_conditions.html:170
 msgid "Availability of the site"
 msgstr "Verfügbarkeit des Standorts"
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
-msgstr "Wir können nicht garantieren, dass die Website ständig verfügbar ist, und wenn sie aus irgendeinem Grund nicht verfügbar ist, können wir nicht für den Verlust verantwortlich gemacht werden, den Sie dadurch erleiden."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
+msgstr ""
+"Wir können nicht garantieren, dass die Website ständig verfügbar ist, und "
+"wenn sie aus irgendeinem Grund nicht verfügbar ist, können wir nicht für den "
+"Verlust verantwortlich gemacht werden, den Sie dadurch erleiden."
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
-msgstr "Wir haben das Recht, die Website und die von ihr angebotenen Dienste jederzeit zu ändern, auszusetzen oder einzustellen."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
+msgstr ""
+"Wir haben das Recht, die Website und die von ihr angebotenen Dienste "
+"jederzeit zu ändern, auszusetzen oder einzustellen."
 
 #: templates/core/terms_conditions.html:176
 msgid "Limitation of liability"
 msgstr "Begrenzung der Haftung"
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
-msgstr "Soweit gesetzlich zulässig, übernehmen wir keine Haftung für direkte oder indirekte Verluste oder Schäden, ob vorhersehbar oder nicht, einschließlich indirekter Schäden, Folgeschäden, besonderer oder exemplarischer Schäden, die sich aus Ihrer Nutzung der Website oder der darin enthaltenen Informationen ergeben."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
+msgstr ""
+"Soweit gesetzlich zulässig, übernehmen wir keine Haftung für direkte oder "
+"indirekte Verluste oder Schäden, ob vorhersehbar oder nicht, einschließlich "
+"indirekter Schäden, Folgeschäden, besonderer oder exemplarischer Schäden, "
+"die sich aus Ihrer Nutzung der Website oder der darin enthaltenen "
+"Informationen ergeben."
 
 #: templates/core/terms_conditions.html:180
 msgid "You use the Site and its Content at your own risk."
 msgstr "Die Nutzung der Website und ihres Inhalts erfolgt auf eigene Gefahr."
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
-msgstr "Nichts in diesen AGBs schließt unsere Haftung für Tod oder Körperverletzung aus oder schränkt sie ein, die auf Fahrlässigkeit oder Betrug unsererseits zurückzuführen ist."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
+msgstr ""
+"Nichts in diesen AGBs schließt unsere Haftung für Tod oder Körperverletzung "
+"aus oder schränkt sie ein, die auf Fahrlässigkeit oder Betrug unsererseits "
+"zurückzuführen ist."
 
 #: templates/core/terms_conditions.html:184
 msgid "Linking"
 msgstr "Verlinkung"
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
-msgstr "Wir haben keine Kontrolle über die Websites, auf die wir verlinken, und können daher nicht für den Inhalt dieser Websites verantwortlich gemacht werden, und wir lehnen jede Haftung für Verluste ab, die sich aus der Nutzung dieser Websites ergeben."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
+msgstr ""
+"Wir haben keine Kontrolle über die Websites, auf die wir verlinken, und "
+"können daher nicht für den Inhalt dieser Websites verantwortlich gemacht "
+"werden, und wir lehnen jede Haftung für Verluste ab, die sich aus der "
+"Nutzung dieser Websites ergeben."
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
-msgstr "Nur weil wir auf eine Seite verlinken, heißt das nicht, dass wir diese Seite befürworten oder empfehlen."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
+msgstr ""
+"Nur weil wir auf eine Seite verlinken, heißt das nicht, dass wir diese Seite "
+"befürworten oder empfehlen."
 
 #: templates/core/terms_conditions.html:190
 msgid "We can never guarantee that a link will work."
 msgstr "Wir können nie garantieren, dass ein Link funktioniert."
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
-msgstr "Wenn Sie einen von uns angebotenen Link als anstößig empfinden, teilen Sie uns dies bitte mit, damit wir ihn entfernen können."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
+msgstr ""
+"Wenn Sie einen von uns angebotenen Link als anstößig empfinden, teilen Sie "
+"uns dies bitte mit, damit wir ihn entfernen können."
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
-msgstr "Wenn Sie über die Website einen Link zu einer anderen Website herstellen, sind Sie sich darüber im Klaren, dass für diese Websites gesonderte Bedingungen gelten und dass wir keinen Einfluss auf diese Bedingungen haben - Sie erklären sich also damit einverstanden, diese Bedingungen zu lesen und zu verstehen, bevor Sie diese Websites nutzen."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
+msgstr ""
+"Wenn Sie über die Website einen Link zu einer anderen Website herstellen, "
+"sind Sie sich darüber im Klaren, dass für diese Websites gesonderte "
+"Bedingungen gelten und dass wir keinen Einfluss auf diese Bedingungen haben "
+"- Sie erklären sich also damit einverstanden, diese Bedingungen zu lesen und "
+"zu verstehen, bevor Sie diese Websites nutzen."
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
-msgstr "Wenn Sie einen Link zu unserer Website herstellen möchten, können Sie unter den folgenden Bedingungen einen Link zu unserer Homepage herstellen:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
+msgstr ""
+"Wenn Sie einen Link zu unserer Website herstellen möchten, können Sie unter "
+"den folgenden Bedingungen einen Link zu unserer Homepage herstellen:"
 
 #: templates/core/terms_conditions.html:199
 msgid "the link mustn’t damage our reputation;"
@@ -2885,68 +5516,151 @@ msgid "you can only link from a site that you own;"
 msgstr "Sie können nur von einer Website verlinken, die Ihnen gehört;"
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
-msgstr "Sie dürfen nicht den Eindruck erwecken, dass wir mit Ihnen in Verbindung stehen, Sie unterstützen und Sie in irgendeiner Weise gutheißen; und"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
+msgstr ""
+"Sie dürfen nicht den Eindruck erwecken, dass wir mit Ihnen in Verbindung "
+"stehen, Sie unterstützen und Sie in irgendeiner Weise gutheißen; und"
 
 #: templates/core/terms_conditions.html:203
 msgid "you mustn’t frame our Site on any other site."
 msgstr "Sie dürfen unsere Website nicht auf einer anderen Website einrahmen."
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
-msgstr "Wir haben immer das Recht, eine von Ihnen hergestellte Verbindung zu lösen, auch wenn wir keine Gründe für unsere Entscheidung angeben können."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
+msgstr ""
+"Wir haben immer das Recht, eine von Ihnen hergestellte Verbindung zu lösen, "
+"auch wenn wir keine Gründe für unsere Entscheidung angeben können."
 
 #: templates/core/terms_conditions.html:208
 msgid "Modifications to these T&Cs & the site"
 msgstr "Änderungen dieser AGBs und der Website"
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
-msgstr "Wir haben dies bereits gesagt, aber wir müssen klarstellen, dass sich diese AGB von Zeit zu Zeit ändern werden und wir nicht über die Ressourcen verfügen, um alle unsere Besucher über die Änderungen zu informieren. Daher MÜSSEN Sie auf diese Seite zurückkommen, um sich zu vergewissern, dass wir diese AGB nicht geändert haben, und jedes Mal, wenn Sie auf die Website zugreifen, bestätigen Sie uns, dass Sie über alle Änderungen informiert sind."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
+msgstr ""
+"Wir haben dies bereits gesagt, aber wir müssen klarstellen, dass sich diese "
+"AGB von Zeit zu Zeit ändern werden und wir nicht über die Ressourcen "
+"verfügen, um alle unsere Besucher über die Änderungen zu informieren. Daher "
+"MÜSSEN Sie auf diese Seite zurückkommen, um sich zu vergewissern, dass wir "
+"diese AGB nicht geändert haben, und jedes Mal, wenn Sie auf die Website "
+"zugreifen, bestätigen Sie uns, dass Sie über alle Änderungen informiert sind."
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
-msgstr "Wir haben auch das Recht, die Website nach Belieben zu ändern, aber diese AGBs gelten auch für alle Änderungen, die wir vornehmen."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
+msgstr ""
+"Wir haben auch das Recht, die Website nach Belieben zu ändern, aber diese "
+"AGBs gelten auch für alle Änderungen, die wir vornehmen."
 
 #: templates/core/terms_conditions.html:221
 msgid "General stuff"
 msgstr "Allgemeines"
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
-msgstr "<i>Gültiges Recht</i> - diese AGB unterliegen den Gesetzen von England und Wales und dies ist die einzige Gerichtsbarkeit, die sie regeln kann."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
+msgstr ""
+"<i>Gültiges Recht</i> - diese AGB unterliegen den Gesetzen von England und "
+"Wales und dies ist die einzige Gerichtsbarkeit, die sie regeln kann."
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
-msgstr "<i>Partnerschaft/Joint Ventures</i> - wir und Sie vereinbaren, dass die Vereinbarung zwischen uns nicht die Grundlage für eine Partnerschaft oder ein Co-Venture bildet."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
+msgstr ""
+"<i>Partnerschaft/Joint Ventures</i> - wir und Sie vereinbaren, dass die "
+"Vereinbarung zwischen uns nicht die Grundlage für eine Partnerschaft oder "
+"ein Co-Venture bildet."
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
-msgstr "<i>Wirkung der Vereinbarung</i> - die aktuelle Vereinbarung zwischen uns und Ihnen ersetzt alle früheren Vereinbarungen in Bezug auf die behandelten Angelegenheiten und stellt die gesamte Vereinbarung zwischen uns und Ihnen dar."
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
+msgstr ""
+"<i>Wirkung der Vereinbarung</i> - die aktuelle Vereinbarung zwischen uns und "
+"Ihnen ersetzt alle früheren Vereinbarungen in Bezug auf die behandelten "
+"Angelegenheiten und stellt die gesamte Vereinbarung zwischen uns und Ihnen "
+"dar."
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
-msgstr "<i>Zeit ist das Wesentliche</i> - Zeit ist in keinem Teil der Vereinbarung zwischen uns und Ihnen von wesentlicher Bedeutung."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
+msgstr ""
+"<i>Zeit ist das Wesentliche</i> - Zeit ist in keinem Teil der Vereinbarung "
+"zwischen uns und Ihnen von wesentlicher Bedeutung."
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
-msgstr "<i>Gewährleistungen</i> - alle Parteien erkennen an und stimmen zu, dass sie die Vereinbarung zwischen uns und Ihnen nicht im Vertrauen auf etwas, das von der anderen Seite gesagt oder versprochen wurde und nicht in diesen AGBs enthalten ist, eingegangen sind."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
+msgstr ""
+"<i>Gewährleistungen</i> - alle Parteien erkennen an und stimmen zu, dass sie "
+"die Vereinbarung zwischen uns und Ihnen nicht im Vertrauen auf etwas, das "
+"von der anderen Seite gesagt oder versprochen wurde und nicht in diesen AGBs "
+"enthalten ist, eingegangen sind."
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
-msgstr "<i>Höhere Gewalt</i> - wenn etwas außerhalb unserer Kontrolle geschieht und uns daran hindert, unsere Dienstleistungen zu erbringen, dann akzeptieren Sie, dass wir nicht für die Folgen dieses Versagens haften (dies schließt Dinge wie Streiks, Unruhen, Brände, Explosionen, Krieg, Überschwemmungen usw. ein). Sollte ein solches Ereignis eintreten, werden wir Sie so schnell wie möglich darüber informieren und den Dienst so schnell wie möglich wieder aufnehmen. Wenn wir den Dienst nicht innerhalb eines angemessenen Zeitraums erbringen können, können wir ihn stornieren, und in diesem Fall erstatten wir Ihnen einen angemessenen Teil der von Ihnen geleisteten Zahlungen."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
+msgstr ""
+"<i>Höhere Gewalt</i> - wenn etwas außerhalb unserer Kontrolle geschieht und "
+"uns daran hindert, unsere Dienstleistungen zu erbringen, dann akzeptieren "
+"Sie, dass wir nicht für die Folgen dieses Versagens haften (dies schließt "
+"Dinge wie Streiks, Unruhen, Brände, Explosionen, Krieg, Überschwemmungen "
+"usw. ein). Sollte ein solches Ereignis eintreten, werden wir Sie so schnell "
+"wie möglich darüber informieren und den Dienst so schnell wie möglich wieder "
+"aufnehmen. Wenn wir den Dienst nicht innerhalb eines angemessenen Zeitraums "
+"erbringen können, können wir ihn stornieren, und in diesem Fall erstatten "
+"wir Ihnen einen angemessenen Teil der von Ihnen geleisteten Zahlungen."
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
-msgstr "<i>Unvollstreckbarkeit</i> - Sollte ein Gericht oder eine andere Instanz entscheiden, dass ein Teil dieser AGB nicht durchsetzbar ist, bleiben die restlichen AGB gültig."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
+msgstr ""
+"<i>Unvollstreckbarkeit</i> - Sollte ein Gericht oder eine andere Instanz "
+"entscheiden, dass ein Teil dieser AGB nicht durchsetzbar ist, bleiben die "
+"restlichen AGB gültig."
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
-msgstr "<i>Benachrichtigungen</i> - wenn entweder Sie oder wir eine förmliche Benachrichtigung an die jeweils andere Partei zu übermitteln haben, muss dies per E-Mail an die Adresse erfolgen, die jeder von uns dem anderen von Zeit zu Zeit mitteilt."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
+msgstr ""
+"<i>Benachrichtigungen</i> - wenn entweder Sie oder wir eine förmliche "
+"Benachrichtigung an die jeweils andere Partei zu übermitteln haben, muss "
+"dies per E-Mail an die Adresse erfolgen, die jeder von uns dem anderen von "
+"Zeit zu Zeit mitteilt."
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
-msgstr "<i>Allgemeine Vereinbarung</i> - diese AGBs enthalten die gesamte Vereinbarung zwischen uns."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
+msgstr ""
+"<i>Allgemeine Vereinbarung</i> - diese AGBs enthalten die gesamte "
+"Vereinbarung zwischen uns."
 
 #: templates/core/terms_conditions.html:235
 msgid "The Schedule"
@@ -2957,52 +5671,102 @@ msgid "Definitions"
 msgstr "Definitionen"
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
-msgstr "<b>Verbraucherrecht</b> bedeutet die Verordnung über Verbraucherverträge (Information, Stornierung und zusätzliche Gebühren) 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
+msgstr ""
+"<b>Verbraucherrecht</b> bedeutet die Verordnung über Verbraucherverträge "
+"(Information, Stornierung und zusätzliche Gebühren) 2013."
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
-msgstr "<b>Inhalt</b> bezeichnet alle Texte, Grafiken, Bilder, Audio- und Videodateien, Software, Datensammlungen und jede andere Form von Informationen, die in einem Computer gespeichert werden können und auf der Website erscheinen oder Teil davon sind."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
+msgstr ""
+"<b>Inhalt</b> bezeichnet alle Texte, Grafiken, Bilder, Audio- und "
+"Videodateien, Software, Datensammlungen und jede andere Form von "
+"Informationen, die in einem Computer gespeichert werden können und auf der "
+"Website erscheinen oder Teil davon sind."
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
-msgstr "<b>Veranstaltung</b> bezeichnet jede Veranstaltung, die von einem Veranstalter unter Verwendung des von uns auf der Website angebotenen Materials organisiert wird."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
+msgstr ""
+"<b>Veranstaltung</b> bezeichnet jede Veranstaltung, die von einem "
+"Veranstalter unter Verwendung des von uns auf der Website angebotenen "
+"Materials organisiert wird."
 
 #: templates/core/terms_conditions.html:244
 msgid "<b>Organiser</b> means the organiser or promoter of an Event."
-msgstr "<b>Organisator</b> bezeichnet den Organisator oder Veranstalter einer Veranstaltung."
+msgstr ""
+"<b>Organisator</b> bezeichnet den Organisator oder Veranstalter einer "
+"Veranstaltung."
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
-msgstr "<b>System</b> bezeichnet das Kommunikations- und andere System oder Systeme, die wir in Verbindung mit der Website verwenden. bezeichnet das Kommunikations- und andere System oder Systeme, die wir in Verbindung mit der Website verwenden."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
+msgstr ""
+"<b>System</b> bezeichnet das Kommunikations- und andere System oder Systeme, "
+"die wir in Verbindung mit der Website verwenden. bezeichnet das "
+"Kommunikations- und andere System oder Systeme, die wir in Verbindung mit "
+"der Website verwenden."
 
 #: templates/core/terms_conditions.html:253
 msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr "<b>T&Cs</b> bedeutet diese Bedingungen."
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
-msgstr "<b>Nutzer</b> bezeichnet jede Person, Firma oder Gesellschaft, die die Website zu irgendeinem Zweck nutzt."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
+msgstr ""
+"<b>Nutzer</b> bezeichnet jede Person, Firma oder Gesellschaft, die die "
+"Website zu irgendeinem Zweck nutzt."
 
 #: templates/core/workshop_box.html:9
 msgid "Order Django Girls Workshop Box for your event!"
 msgstr "Bestellen Sie die Django Girls Workshop Box für Ihre Veranstaltung!"
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
-msgstr "Holen Sie sich einen goldenen Umschlag mit DjangoGirls-Aufklebern, goldenen Buchstabenballons, Aufklebern unserer Partner und Buttons. <br /> Alles was du brauchst, um deinen Workshop DjangoGirlsy zu machen! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
+msgstr ""
+"Holen Sie sich einen goldenen Umschlag mit DjangoGirls-Aufklebern, goldenen "
+"Buchstabenballons, Aufklebern unserer Partner und Buttons. <br /> Alles was "
+"du brauchst, um deinen Workshop DjangoGirlsy zu machen! 🌸✨"
 
 #: templates/core/workshop_box.html:27
 msgid "How it works?"
 msgstr "Wie funktioniert das?"
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
-msgstr "Wir haben die Django-Girls-Produkte in großen Mengen gekauft, was ihren Preis massiv gesenkt hat. So spart jeder Zeit und Geld und ihr könnt euch auf mehr tolle Dinge konzentrieren. Die Box kann an Django-Girls-Workshops auf der ganzen Welt verschickt werden: kleine Goodies und Beigaben werden eure Sponsorengelder nicht mehr belasten! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
+msgstr ""
+"Wir haben die Django-Girls-Produkte in großen Mengen gekauft, was ihren "
+"Preis massiv gesenkt hat. So spart jeder Zeit und Geld und ihr könnt euch "
+"auf mehr tolle Dinge konzentrieren. Die Box kann an Django-Girls-Workshops "
+"auf der ganzen Welt verschickt werden: kleine Goodies und Beigaben werden "
+"eure Sponsorengelder nicht mehr belasten! YAY! ✨💰"
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
-msgstr "Wir haben ausgerechnet, dass eine Veranstaltung mit 30 Personen rund 150 GBP für all diese Dinge kosten würde, und manchmal sind sie schwer zu bekommen. Wir sind in der Lage, sie alle für etwa 50 Dollar zu kaufen und zu versenden."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
+msgstr ""
+"Wir haben ausgerechnet, dass eine Veranstaltung mit 30 Personen rund 150 GBP "
+"für all diese Dinge kosten würde, und manchmal sind sie schwer zu bekommen. "
+"Wir sind in der Lage, sie alle für etwa 50 Dollar zu kaufen und zu versenden."
 
 #: templates/core/workshop_box.html:44
 msgid "What's in the box?"
@@ -3065,24 +5829,47 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr "Sie müssen auch die Versandkosten hinzufügen. 📮"
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
-msgstr "Wenn Ihre Veranstaltung in einem <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">Entwicklungsland</a> stattfindet oder wenn Sie versucht haben, Sponsoren zu finden, aber keine finden, können Sie eine kostenlose Box beantragen (Sie müssen für den Versand bezahlen)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
+msgstr ""
+"Wenn Ihre Veranstaltung in einem <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">Entwicklungsland</a> "
+"stattfindet oder wenn Sie versucht haben, Sponsoren zu finden, aber keine "
+"finden, können Sie eine kostenlose Box beantragen (Sie müssen für den "
+"Versand bezahlen)."
 
 #: templates/core/workshop_box.html:78
 msgid "How to get one?"
 msgstr "Wie bekommt man eine?"
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
-msgstr "Toll, dass du einen bestellen möchtest! Um das zu tun, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">geh zu unserem Shop</a>. <b>Wir empfehlen dir dringend, sie mindestens 6 Wochen vor deiner Veranstaltung zu kaufen</b>: Wenn du das nicht tust, können wir nicht garantieren, dass deine Box pünktlich zu deiner Veranstaltung geliefert wird."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
+msgstr ""
+"Toll, dass du einen bestellen möchtest! Um das zu tun, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">geh zu unserem "
+"Shop</a>. <b>Wir empfehlen dir dringend, sie mindestens 6 Wochen vor deiner "
+"Veranstaltung zu kaufen</b>: Wenn du das nicht tust, können wir nicht "
+"garantieren, dass deine Box pünktlich zu deiner Veranstaltung geliefert wird."
 
 #: templates/core/workshop_box.html:86
 msgid "Requirements to apply for a free box:"
 msgstr "Voraussetzungen für die Beantragung einer kostenlosen Box:"
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
-msgstr "Ihre Veranstaltung muss in einem Entwicklungsland stattfinden oder Sie haben es versucht, aber keinen Sponsor gefunden."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
+msgstr ""
+"Ihre Veranstaltung muss in einem Entwicklungsland stattfinden oder Sie haben "
+"es versucht, aber keinen Sponsor gefunden."
 
 #: templates/core/workshop_box.html:89
 msgid "You need to have a venue for your workshop"
@@ -3093,12 +5880,23 @@ msgid "Application process for your event needs to be open"
 msgstr "Das Bewerbungsverfahren für Ihre Veranstaltung muss offen sein"
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
-msgstr "Die Bestellung muss mindestens 6 Wochen vor dem Workshop erfolgen, um die Versandzeit zu berücksichtigen."
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
+msgstr ""
+"Die Bestellung muss mindestens 6 Wochen vor dem Workshop erfolgen, um die "
+"Versandzeit zu berücksichtigen."
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
-msgstr "<b>Wenn Sie alle diese Voraussetzungen erfüllen</b>, <a href=\"mailto:hello@djangogirls.org\">schicken Sie uns eine E-Mail</a>, in der Sie Ihre Situation beschreiben: Wir werden Ihre Bewerbung prüfen und uns bald mit Ihnen in Verbindung setzen. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
+msgstr ""
+"<b>Wenn Sie alle diese Voraussetzungen erfüllen</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">schicken Sie uns eine E-Mail</a>, in der Sie Ihre "
+"Situation beschreiben: Wir werden Ihre Bewerbung prüfen und uns bald mit "
+"Ihnen in Verbindung setzen. 💕"
 
 #: templates/default/about.html:4
 msgid "Free programming workshop for women"
@@ -3117,8 +5915,12 @@ msgid "Applications are now open!"
 msgstr "Bewerbungen sind jetzt möglich!"
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
-msgstr "Das Bewerbungsverfahren endet am 23. Juli und Sie werden bis zum 28. Juli (oder früher) über die Annahme oder Ablehnung informiert!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
+msgstr ""
+"Das Bewerbungsverfahren endet am 23. Juli und Sie werden bis zum 28. Juli "
+"(oder früher) über die Annahme oder Ablehnung informiert!"
 
 #: templates/default/apply.html:10
 msgid "Register"
@@ -3129,124 +5931,245 @@ msgid "Be a Mentor!"
 msgstr "Sei ein Mentor!"
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
-msgstr "Wir würden uns freuen, wenn Sie uns als Mentor unterstützen möchten! <a href=\"%(contact_url)s\">Kontaktieren Sie uns</a> bei Interesse ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+msgstr ""
+"Wir würden uns freuen, wenn Sie uns als Mentor unterstützen möchten! <a "
+"href=\"%(contact_url)s\">Kontaktieren Sie uns</a> bei Interesse ❤️"
 
 #: templates/default/coach.html:16 templates/default/values.html:5
 msgid "Django Girls"
 msgstr "Django Mädchen"
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
-msgstr "Dieser Workshop ist ein Teil einer größeren Initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. Es ist eine gemeinnützige Organisation und die Veranstaltungen werden von Freiwilligen an verschiedenen Orten der Welt organisiert."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
+msgstr ""
+"Dieser Workshop ist ein Teil einer größeren Initiative: <a href=\"https://"
+"djangogirls.org/\">Django Girls</a>. Es ist eine gemeinnützige Organisation "
+"und die Veranstaltungen werden von Freiwilligen an verschiedenen Orten der "
+"Welt organisiert."
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
-msgstr "Um den Quellcode des Programms zu sehen, finden Sie uns auf Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgstr ""
+"Um den Quellcode des Programms zu sehen, finden Sie uns auf Github: <a "
+"href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
-msgstr "Wenn Sie Django Girls in Ihre Stadt bringen wollen, <a href=\"%(contact_url)s\">schreiben Sie uns eine Nachricht</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
+msgstr ""
+"Wenn Sie Django Girls in Ihre Stadt bringen wollen, <a "
+"href=\"%(contact_url)s\">schreiben Sie uns eine Nachricht</a>"
 
 #: templates/default/faq.html:6
 msgid "Do I need to know anything about websites or programming?"
 msgstr "Muss ich etwas über Websites oder Programmierung wissen?"
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
-msgstr "Nein! Workshops sind für Anfänger. Sie müssen nichts darüber wissen. Wenn Sie jedoch ein wenig technisches Wissen haben (d. h. wissen, was HTML oder CSS sind), können Sie sich trotzdem anmelden!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
+msgstr ""
+"Nein! Workshops sind für Anfänger. Sie müssen nichts darüber wissen. Wenn "
+"Sie jedoch ein wenig technisches Wissen haben (d. h. wissen, was HTML oder "
+"CSS sind), können Sie sich trotzdem anmelden!"
 
 #: templates/default/faq.html:18
 msgid "I am not living in Germany, can I attend?"
 msgstr "Ich wohne nicht in Deutschland, kann ich teilnehmen?"
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
-msgstr "Ja, natürlich! Die Workshops werden auf Englisch abgehalten. Wenn Sie also keine Probleme haben, Englisch zu sprechen und zu verstehen, sollten Sie sich anmelden. Wenn Sie finanzielle Unterstützung benötigen, um nach Berlin zu kommen, oder wenn Sie Hilfe bei der Buchung von Flügen oder Hotels in Berlin benötigen, lassen Sie es uns wissen. Wir sind bereit, Ihnen zu helfen!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
+msgstr ""
+"Ja, natürlich! Die Workshops werden auf Englisch abgehalten. Wenn Sie also "
+"keine Probleme haben, Englisch zu sprechen und zu verstehen, sollten Sie "
+"sich anmelden. Wenn Sie finanzielle Unterstützung benötigen, um nach Berlin "
+"zu kommen, oder wenn Sie Hilfe bei der Buchung von Flügen oder Hotels in "
+"Berlin benötigen, lassen Sie es uns wissen. Wir sind bereit, Ihnen zu helfen!"
 
 #: templates/default/faq.html:31
 msgid "Should I bring my own laptop?"
 msgstr "Sollte ich meinen eigenen Laptop mitbringen?"
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
-msgstr "Ja. Wir haben keine Hardware, daher erwarten wir, dass Sie Ihren Computer mitbringen. Es ist für uns auch wichtig, dass Sie alles, was Sie während der Workshops schreiben und erstellen, mit nach Hause nehmen."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
+msgstr ""
+"Ja. Wir haben keine Hardware, daher erwarten wir, dass Sie Ihren Computer "
+"mitbringen. Es ist für uns auch wichtig, dass Sie alles, was Sie während der "
+"Workshops schreiben und erstellen, mit nach Hause nehmen."
 
 #: templates/default/faq.html:45
 msgid "Do I need to have something installed on my laptop?"
 msgstr "Muss ich etwas auf meinem Laptop installiert haben?"
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
-msgstr "Es wäre hilfreich, wenn Sie Django vor den Workshops installiert hätten, aber wir erwarten nicht, dass Sie irgendetwas selbst installieren, sondern werden dafür sorgen, dass einer unserer Coaches Ihnen dabei hilft."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
+msgstr ""
+"Es wäre hilfreich, wenn Sie Django vor den Workshops installiert hätten, "
+"aber wir erwarten nicht, dass Sie irgendetwas selbst installieren, sondern "
+"werden dafür sorgen, dass einer unserer Coaches Ihnen dabei hilft."
 
 #: templates/default/faq.html:58
 msgid "Is EuroPython conference good for a total beginner?"
 msgstr "Ist die EuroPython-Konferenz für einen Anfänger geeignet?"
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
-msgstr "Als Workshop-Teilnehmer erhalten Sie eine Freikarte für die EuroPython - Konferenz für Python-Programmierer. Auch wenn Sie neu in der Programmierung sind, ist die Konferenz ein guter Ort, um viele interessante Leute in der Branche zu treffen und sich inspirieren zu lassen."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
+msgstr ""
+"Als Workshop-Teilnehmer erhalten Sie eine Freikarte für die EuroPython - "
+"Konferenz für Python-Programmierer. Auch wenn Sie neu in der Programmierung "
+"sind, ist die Konferenz ein guter Ort, um viele interessante Leute in der "
+"Branche zu treffen und sich inspirieren zu lassen."
 
 #: templates/default/faq.html:70
 msgid "Is food provided?"
 msgstr "Wird Essen angeboten?"
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
-msgstr "Ja, dank EuroPython werden während der Workshops Snacks und Mittagessen serviert."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgstr ""
+"Ja, dank EuroPython werden während der Workshops Snacks und Mittagessen "
+"serviert."
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
-msgstr "♥ Django Girls Europe wird organisiert von <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> und <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> mit der Unterstützung von <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe ist ein Teil von <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
+msgstr ""
+"♥ Django Girls Europe wird organisiert von <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> und <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> mit der Unterstützung von <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe ist ein Teil "
+"von <a href=\"/\">Django Girls</a>."
 
 #: templates/default/partners.html:3
 msgid "Sponsors"
 msgstr "Förderer"
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
-msgstr "Ohne die Unterstützung von Menschen und Organisationen, die uns mit Geld, Wissen und Zeit bei der Verwirklichung dieses Projekts geholfen haben, wären wir nicht hier. Wenn Sie dazu beitragen und unser Ziel unterstützen möchten, <a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
+msgstr ""
+"Ohne die Unterstützung von Menschen und Organisationen, die uns mit Geld, "
+"Wissen und Zeit bei der Verwirklichung dieses Projekts geholfen haben, wären "
+"wir nicht hier. Wenn Sie dazu beitragen und unser Ziel unterstützen möchten, "
+"<a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf</a>"
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
-msgstr "Wenn Sie eine Frau sind und lernen wollen, wie man Websites erstellt, haben wir gute Nachrichten für Sie: Wir veranstalten einen eintägigen Workshop für Anfänger!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
+msgstr ""
+"Wenn Sie eine Frau sind und lernen wollen, wie man Websites erstellt, haben "
+"wir gute Nachrichten für Sie: Wir veranstalten einen eintägigen Workshop für "
+"Anfänger!"
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
-msgstr "Sie findet am <strong>TAG, MONAT, JAHR</strong> im <strong>VENUE</strong> in <strong>STADT</strong> statt."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
+msgstr ""
+"Sie findet am <strong>TAG, MONAT, JAHR</strong> im <strong>VENUE</strong> in "
+"<strong>STADT</strong> statt."
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
-msgstr "Wir glauben, dass die IT-Branche sehr davon profitieren wird, wenn mehr Frauen in die Technik einsteigen. Wir möchten Ihnen die Möglichkeit geben, das Programmieren zu lernen und eine von uns zu werden &ndash; Programmiererinnen!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
+msgstr ""
+"Wir glauben, dass die IT-Branche sehr davon profitieren wird, wenn mehr "
+"Frauen in die Technik einsteigen. Wir möchten Ihnen die Möglichkeit geben, "
+"das Programmieren zu lernen und eine von uns zu werden &ndash; "
+"Programmiererinnen!"
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
-msgstr "Die Workshops sind kostenlos. Wenn Sie es sich nicht leisten können, nach CITY zu kommen, aber sehr motiviert sind, zu lernen und Ihr Wissen mit anderen zu teilen, haben wir vielleicht Mittel, um Ihnen bei den Reise- und Unterkunftskosten zu helfen. Warten Sie nicht zu lange: Sie können sich nur bis zum <strong>DATUM</strong> für den Workshop anmelden!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
+msgstr ""
+"Die Workshops sind kostenlos. Wenn Sie es sich nicht leisten können, nach "
+"CITY zu kommen, aber sehr motiviert sind, zu lernen und Ihr Wissen mit "
+"anderen zu teilen, haben wir vielleicht Mittel, um Ihnen bei den Reise- und "
+"Unterkunftskosten zu helfen. Warten Sie nicht zu lange: Sie können sich nur "
+"bis zum <strong>DATUM</strong> für den Workshop anmelden!"
 
 #: templates/default/values.html:33
 msgid "Apply for the workshop!"
 msgstr "Bewerben Sie sich für den Workshop!"
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
-msgstr "Wenn Sie eine Frau sind, Englisch können und einen Laptop haben, können Sie sich für unsere Veranstaltung anmelden! Du musst keine technischen Kenntnisse haben &ndash; unser Workshop ist für Leute, die neu im Programmieren sind."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
+msgstr ""
+"Wenn Sie eine Frau sind, Englisch können und einen Laptop haben, können Sie "
+"sich für unsere Veranstaltung anmelden! Du musst keine technischen "
+"Kenntnisse haben &ndash; unser Workshop ist für Leute, die neu im "
+"Programmieren sind."
 
 #: templates/default/values.html:43
 msgid "As a workshop attendee you will:"
 msgstr "Als Workshop-Teilnehmer werden Sie:"
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
-msgstr "Teilnahme an einem eintägigen Django-Workshop, bei dem Sie Ihre erste Website erstellen werden"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
+msgstr ""
+"Teilnahme an einem eintägigen Django-Workshop, bei dem Sie Ihre erste "
+"Website erstellen werden"
 
 #: templates/default/values.html:48
 msgid "be fed by us: during our event, food is provided"
-msgstr "von uns verpflegt werden: Während unserer Veranstaltung wird für Essen gesorgt"
+msgstr ""
+"von uns verpflegt werden: Während unserer Veranstaltung wird für Essen "
+"gesorgt"
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
-msgstr "Wir haben nur Platz für XX Personen, also füllen Sie das Formular bitte sorgfältig aus!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
+msgstr ""
+"Wir haben nur Platz für XX Personen, also füllen Sie das Formular bitte "
+"sorgfältig aus!"
 
 #: templates/donations/donate.html:13
 msgid "Why give to the Django Girls Foundation?"
@@ -3257,20 +6180,54 @@ msgid "Our mission:"
 msgstr "Unser Auftrag:"
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
-msgstr "Django Girls ist eine ehrenamtlich geführte <a href=\"%(foundation_url)s\">eingetragene Wohltätigkeitsorganisation</a>. Wir verwenden Ihre großzügigen Spenden, um Tausenden von Frauen das Erstellen von Websites mit Python und Django beizubringen, indem wir Ressourcen und Werkzeuge für freiwillige Organisatoren auf der ganzen Welt bereitstellen."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
+msgstr ""
+"Django Girls ist eine ehrenamtlich geführte <a "
+"href=\"%(foundation_url)s\">eingetragene Wohltätigkeitsorganisation</a>. Wir "
+"verwenden Ihre großzügigen Spenden, um Tausenden von Frauen das Erstellen "
+"von Websites mit Python und Django beizubringen, indem wir Ressourcen und "
+"Werkzeuge für freiwillige Organisatoren auf der ganzen Welt bereitstellen."
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
-msgstr "Seit Juli 2014 haben unsere Workshops %(attendees_sum|default_if_none:'0')s Frauen in %(countries_count|default_if_none:'0')s Ländern erreicht und unser <a href=\"https://tutorial.djangogirls.org/\">Online-Tutorial</a> wurde von mehr als 3.958.285 Menschen gelesen."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
+msgstr ""
+"Seit Juli 2014 haben unsere Workshops %(attendees_sum|default_if_none:'0')s "
+"Frauen in %(countries_count|default_if_none:'0')s Ländern erreicht und unser "
+"<a href=\"https://tutorial.djangogirls.org/\">Online-Tutorial</a> wurde von "
+"mehr als 3.958.285 Menschen gelesen."
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
-msgstr "Unser Schwerpunkt und unsere Mission für dieses Jahr ist die Verbesserung von Vielfalt und Inklusion bei Django Girls, um sicherzustellen, dass unsere Workshops für alle zugänglich sind, insbesondere auch für Menschen aus Randgruppen."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
+msgstr ""
+"Unser Schwerpunkt und unsere Mission für dieses Jahr ist die Verbesserung "
+"von Vielfalt und Inklusion bei Django Girls, um sicherzustellen, dass unsere "
+"Workshops für alle zugänglich sind, insbesondere auch für Menschen aus "
+"Randgruppen."
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
-msgstr "Wir sind transparent, was unsere Finanzen angeht. In unserem <a href=\"%(sixteen_seventeen_url)s\">Jahresbericht 2016-2017</a> können Sie nachlesen, wie wir Spendengelder ausgeben und welche Wirkung sie haben."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
+msgstr ""
+"Wir sind transparent, was unsere Finanzen angeht. In unserem <a "
+"href=\"%(sixteen_seventeen_url)s\">Jahresbericht 2016-2017</a> können Sie "
+"nachlesen, wie wir Spendengelder ausgeben und welche Wirkung sie haben."
 
 #: templates/donations/donate.html:54
 msgid "A woman looking at her laptop during Django Girls Lagos 2016."
@@ -3278,31 +6235,63 @@ msgstr "Eine Frau schaut auf ihren Laptop während Django Girls Lagos 2016."
 
 #: templates/donations/donate.html:62
 msgid "Start supporting Django Girls Foundation today 💕"
-msgstr "Beginnen Sie noch heute, die Django Girls Foundation zu unterstützen 💕."
+msgstr ""
+"Beginnen Sie noch heute, die Django Girls Foundation zu unterstützen 💕."
 
 #: templates/donations/donate.html:68
 msgid "Monthly donations"
 msgstr "Monatliche Spenden"
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
-msgstr "Wenn Sie eine wiederkehrende Spende einrichten möchten, empfehlen wir Ihnen, dies über unsere <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon-Seite</a> zu tun. Unsere Zusagen beginnen bei 5 USD pro Monat."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgstr ""
+"Wenn Sie eine wiederkehrende Spende einrichten möchten, empfehlen wir Ihnen, "
+"dies über unsere <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon-Seite</a> zu tun. Unsere Zusagen beginnen bei 5 "
+"USD pro Monat."
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
-msgstr "Sind Sie als Unternehmen daran interessiert, uns zu sponsern? Unsere <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">Firmenpatenschaften</a> beginnen bei 100 USD pro Monat. <a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
+#, fuzzy, python-format
+#| msgid ""
+#| "Are you a company interested in sponsoring us? Our <a href=\"https://"
+#| "drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?"
+#| "usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+#| "href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+"Sind Sie als Unternehmen daran interessiert, uns zu sponsern? Unsere <a "
+"href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/"
+"view?usp=sharing\">Firmenpatenschaften</a> beginnen bei 100 USD pro Monat. "
+"<a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
 
 #: templates/donations/donate.html:105
 msgid "One-time donations"
 msgstr "Einmalige Spenden"
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
-msgstr "Sie können uns eine einmalige Spende über PayPal an <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a> schicken."
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgstr ""
+"Sie können uns eine einmalige Spende über PayPal an <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a> schicken."
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
-msgstr "Wenn Sie eine größere Partnerschaft oder ein Unternehmenssponsoring besprechen möchten, <a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+msgstr ""
+"Wenn Sie eine größere Partnerschaft oder ein Unternehmenssponsoring "
+"besprechen möchten, <a href=\"%(contact_url)s\">bitte nehmen Sie Kontakt auf."
+"</a>"
 
 #: templates/donations/donate.html:121
 msgid "Donate now"
@@ -3321,16 +6310,14 @@ msgid "Humble Bundle Store"
 msgstr "Humble Bundle Store"
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr "Wenn du Videospiele magst, kannst du im <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a> Django Girls als deine Wohltätigkeitsorganisation auswählen! 🎮"
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr "Amazon Lächeln"
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
-msgstr "Wenn Sie bei <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a> einkaufen, spendet Amazon in Ihrem Namen an die Django Girls Foundation, wenn Sie uns als Wohltätigkeitsorganisation ausgewählt haben! Bitte unterstützen Sie unsere Arbeit und wählen Sie uns noch heute. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
+msgstr ""
+"Wenn du Videospiele magst, kannst du im <a href=\"https://www.humblebundle."
+"com/store?charity=129929\">Humble Bundle Store</a> Django Girls als deine "
+"Wohltätigkeitsorganisation auswählen! 🎮"
 
 #: templates/donations/donate.html:161
 msgid "They already support us:"
@@ -3345,12 +6332,43 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr "Django Girls Botschafterin der Ehrfurcht:"
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
-msgstr "Im September 2015 stellte die <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">Stiftung</a> eine Teilzeitkraft ein, die bei den täglichen Aufgaben der Organisation helfen sollte. Nach anderthalb Jahren kündigte Django Girls' 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\">Lucie Daeye</a>, um ihr neues Abenteuer als Systemingenieurin bei Mapbox zu beginnen."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
+msgstr ""
+"Im September 2015 stellte die <a href=\"http://blog.djangogirls.org/"
+"post/127160095788/meet-our-awesomeness-ambassador-lucie\">Stiftung</a> eine "
+"Teilzeitkraft ein, die bei den täglichen Aufgaben der Organisation helfen "
+"sollte. Nach anderthalb Jahren kündigte Django Girls' 1st Awesomeness "
+"Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-"
+"django-story-meet-lucie-daeye\">Lucie Daeye</a>, um ihr neues Abenteuer als "
+"Systemingenieurin bei Mapbox zu beginnen."
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
-msgstr "Im Juni 2017 kam <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> als Awesomeness Ambassador zu uns, um die Nachfolge von Lucie anzutreten. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> ist als Awesomeness Ambassador dafür zuständig, Anfragen von Organisatoren zu beantworten, unsere Post zu bearbeiten, unsere Prozesse zu verbessern, administrative Aufgaben zu erledigen, den Blog und den Newsletter zu aktualisieren und die Website und Ressourcen zu pflegen."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
+msgstr ""
+"Im Juni 2017 kam <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> als "
+"Awesomeness Ambassador zu uns, um die Nachfolge von Lucie anzutreten. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> ist als Awesomeness "
+"Ambassador dafür zuständig, Anfragen von Organisatoren zu beantworten, "
+"unsere Post zu bearbeiten, unsere Prozesse zu verbessern, administrative "
+"Aufgaben zu erledigen, den Blog und den Newsletter zu aktualisieren und die "
+"Website und Ressourcen zu pflegen."
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
 msgid "Your donations will help us make her position secure."
@@ -3361,24 +6379,52 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr "Django Girls Fundraising-Koordinatorin:"
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
-msgstr "Im Juni 2017 haben wir die Rolle des <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Fundraising-Koordinators</a> eingeführt, um die Fundraising-Aktivitäten der Organisation zu koordinieren. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> als unsere Fundraising-Koordinatorin wirbt Sponsoren und die Gemeinschaft an, um Finanzmittel zu erhalten, damit die Organisation nachhaltig bleibt."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
+msgstr ""
+"Im Juni 2017 haben wir die Rolle des <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Fundraising-"
+"Koordinators</a> eingeführt, um die Fundraising-Aktivitäten der Organisation "
+"zu koordinieren. <a href=\"https://blog.djangogirls.org/post/162673547790/"
+"anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> als unsere "
+"Fundraising-Koordinatorin wirbt Sponsoren und die Gemeinschaft an, um "
+"Finanzmittel zu erhalten, damit die Organisation nachhaltig bleibt."
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
-msgstr "Im August 2020 baten wir sie außerdem, uns bei der technischen Unterstützung unserer Website zu helfen und sie bei der Pflege und Aktualisierung unserer Website zu unterstützen."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
+msgstr ""
+"Im August 2020 baten wir sie außerdem, uns bei der technischen Unterstützung "
+"unserer Website zu helfen und sie bei der Pflege und Aktualisierung unserer "
+"Website zu unterstützen."
 
 #: templates/donations/donate.html:213
 msgid "Django Girls Summit:"
 msgstr "Django Girls Summit:"
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
-msgstr "Django Girls Summit ist eine zweitägige Unkonferenz, bei der sich die Organisatoren treffen und ihre Erfahrungen über Django Girls Workshops austauschen."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
+msgstr ""
+"Django Girls Summit ist eine zweitägige Unkonferenz, bei der sich die "
+"Organisatoren treffen und ihre Erfahrungen über Django Girls Workshops "
+"austauschen."
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
-msgstr "Ihre Spenden helfen uns, diese Veranstaltung zu organisieren und bedürftigen Konferenzteilnehmern finanzielle Unterstützung zukommen zu lassen."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
+msgstr ""
+"Ihre Spenden helfen uns, diese Veranstaltung zu organisieren und bedürftigen "
+"Konferenzteilnehmern finanzielle Unterstützung zukommen zu lassen."
 
 #: templates/donations/error.html:7
 msgid "Error"
@@ -3392,78 +6438,197 @@ msgstr "Entschuldigung, es ist ein Fehler aufgetreten"
 msgid "Back to donation page"
 msgstr "Zurück zur Spendenseite"
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr "Unsere globalen Partner"
+
+#: templates/donations/sponsors.html:11
+#, fuzzy, python-format
+#| msgid ""
+#| "Our global partners are companies who are supporting our work by donating "
+#| "to us either monthly through <a href=\"https://www.patreon.com/"
+#| "djangogirls\" target=\"_blank\">Patreon</a> or through annual "
+#| "sponsorships. Want to join these amazing companies in sponsoring us? Our "
+#| "<a href=\"https://drive.google.com/file/"
+#| "d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+#| "sponsorships</a> start at 100 USD per month. <a "
+#| "href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+"Unsere globalen Partner sind Unternehmen, die unsere Arbeit unterstützen, "
+"indem sie entweder monatlich über <a href=\"https://www.patreon.com/"
+"djangogirls\" target=\"_blank\">Patreon</a> oder durch jährliche "
+"Patenschaften spenden. Möchten Sie sich diesen großartigen Unternehmen "
+"anschließen und uns sponsern? Unsere <a href=\"https://drive.google.com/file/"
+"d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?"
+"usp=sharing\">Unternehmenspatenschaften</a> beginnen bei 100 USD pro Monat. "
+"<a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr "Diamant - $10.000+ pro Jahr 💞✨"
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr "Platin - $5.000+ pro Jahr 💝✨"
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr "Gold - $2.500+ pro Jahr 💖✨"
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr "Silber - $1.000+ pro Jahr 💗✨"
+
 #: templates/donations/success.html:8
+#, fuzzy, python-format
+#| msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr "Vielen Dank für Ihren Beitrag von %(Währung)s%(Betrag)s!"
 
 #: templates/emails/event_thank_you.html:3
+#, fuzzy, python-format
+#| msgid "Hello team %(city)s!"
 msgid "Hello team %(city)s!"
 msgstr "Hallo Team %(Stadt)s!"
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
-msgstr "Herzlichen Glückwunsch zu eurem eigenen Django Girls Event! Wir sind super stolz und freuen uns so sehr für dich :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
+msgstr ""
+"Herzlichen Glückwunsch zu eurem eigenen Django Girls Event! Wir sind super "
+"stolz und freuen uns so sehr für dich :)"
 
 #: templates/emails/event_thank_you.html:8
 msgid "Numbers"
 msgstr "Zahlen"
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
-msgstr "Wann immer Sie ein wenig Zeit haben, wären wir Ihnen sehr dankbar, wenn Sie <a href=\"%(base_url)s%(event_url)s\">dieses Formular ausfüllen</a> könnten, um uns mitzuteilen, wie viele Personen Ihren Workshop besucht haben. Dies wird uns helfen, den globalen Einfluss von Django Girls auf die Welt zu zeigen! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
+msgstr ""
+"Wann immer Sie ein wenig Zeit haben, wären wir Ihnen sehr dankbar, wenn Sie "
+"<a href=\"%(base_url)s%(event_url)s\">dieses Formular ausfüllen</a> könnten, "
+"um uns mitzuteilen, wie viele Personen Ihren Workshop besucht haben. Dies "
+"wird uns helfen, den globalen Einfluss von Django Girls auf die Welt zu "
+"zeigen! :)"
 
 #: templates/emails/event_thank_you.html:17
 msgid "Tell us how it went!"
 msgstr "Erzählen Sie uns, wie es gelaufen ist!"
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
-msgstr "Wir würden uns freuen, von Ihnen mehr über den Workshop zu erfahren: Wie ist er gelaufen? Hat er Ihnen gefallen? Was war Ihr Lieblingsmoment? Wir wollen *alles* hören :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
+msgstr ""
+"Wir würden uns freuen, von Ihnen mehr über den Workshop zu erfahren: Wie ist "
+"er gelaufen? Hat er Ihnen gefallen? Was war Ihr Lieblingsmoment? Wir wollen "
+"*alles* hören :)"
 
 #: templates/emails/event_thank_you.html:22
 msgid "Share your experiences"
 msgstr "Teilen Sie Ihre Erfahrungen"
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
-msgstr "Wenn du über deine Erfahrungen als Organisator schreiben oder mit der Community all die tollen Dinge teilen möchtest, die während deiner Veranstaltung passiert sind, kannst du einen Beitrag in unserem Blog schreiben. Du hast etwas Tolles gemacht: Sei nicht schüchtern und gib damit an! <a href=\"http://blog.djangogirls.org/submit\">Sie können es hier tun.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
+msgstr ""
+"Wenn du über deine Erfahrungen als Organisator schreiben oder mit der "
+"Community all die tollen Dinge teilen möchtest, die während deiner "
+"Veranstaltung passiert sind, kannst du einen Beitrag in unserem Blog "
+"schreiben. Du hast etwas Tolles gemacht: Sei nicht schüchtern und gib damit "
+"an! <a href=\"http://blog.djangogirls.org/submit\">Sie können es hier tun.</"
+"a>"
 
 #: templates/emails/event_thank_you.html:27
 msgid "Upload your photos"
 msgstr "Laden Sie Ihre Fotos hoch"
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
-msgstr "Wenn Sie Fotos von Ihrer Veranstaltung zu unserem <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr-Konto</a> hinzufügen möchten, lassen Sie es uns wissen, und wir werden Ihnen Informationen dazu geben."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
+msgstr ""
+"Wenn Sie Fotos von Ihrer Veranstaltung zu unserem <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr-Konto</a> hinzufügen möchten, lassen "
+"Sie es uns wissen, und wir werden Ihnen Informationen dazu geben."
 
 #: templates/emails/event_thank_you.html:32
 msgid "Donation"
 msgstr "Spende"
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
-msgstr "Wenn Sie bei Ihrem Workshop Geld übrig haben, können Sie es der <a href=\"%(base_url)s%(donations_url)s\">Django Girls Foundation</a> spenden, einer gemeinnützigen Organisation, die Organisatoren in der ganzen Welt unterstützt."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
+msgstr ""
+"Wenn Sie bei Ihrem Workshop Geld übrig haben, können Sie es der <a "
+"href=\"%(base_url)s%(donations_url)s\">Django Girls Foundation</a> spenden, "
+"einer gemeinnützigen Organisation, die Organisatoren in der ganzen Welt "
+"unterstützt."
 
 #: templates/emails/event_thank_you.html:41
 msgid "Discount in our store"
 msgstr "Rabatt in unserem Geschäft"
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
-msgstr "Verwenden Sie den Code \"%(discount_code)s\", um 15% Rabatt auf Ihre Bestellung <a href=\"https://store.djangogirls.org\">in unserem Shop</a> zu erhalten. Sie können diesen Code an Ihre Trainer und Teilnehmer weitergeben. Alle Erlöse gehen an die Django Girls Foundation (gemeinnützige Organisation)."
+#, fuzzy, python-format
+#| msgid ""
+#| "Use the code \"%(discount_code)s\" to get a 15%% discount on your order "
+#| "<a href=\"https://store.djangogirls.org\">in our store</a>. You can share "
+#| "this code with your coaches and attendees. All proceeds will go to Django "
+#| "Girls Foundation (non-profit organization)."
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
+msgstr ""
+"Verwenden Sie den Code \"%(discount_code)s\", um 15% Rabatt auf Ihre "
+"Bestellung <a href=\"https://store.djangogirls.org\">in unserem Shop</a> zu "
+"erhalten. Sie können diesen Code an Ihre Trainer und Teilnehmer weitergeben. "
+"Alle Erlöse gehen an die Django Girls Foundation (gemeinnützige "
+"Organisation)."
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
-msgstr "Wenn Sie eines Tages eine weitere Veranstaltung planen möchten, zögern Sie nicht, das <a href=\"%(base_url)s%(organize_url)s\">Organisationsformular erneut auszufüllen</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+msgstr ""
+"Wenn Sie eines Tages eine weitere Veranstaltung planen möchten, zögern Sie "
+"nicht, das <a href=\"%(base_url)s%(organize_url)s\">Organisationsformular "
+"erneut auszufüllen</a>."
 
 #: templates/emails/event_thank_you.html:55
 msgid "Thanks and congrats yet again, you're awesome!"
 msgstr "Vielen Dank und nochmals herzlichen Glückwunsch, Sie sind großartig!"
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr "Umarmungen, Regenbögen und Sonnenstrahlen!"
@@ -3474,44 +6639,79 @@ msgid "Hi there!"
 msgstr "Hallo zusammen!"
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
-msgstr "Herzlichen Glückwunsch! Sie können jetzt %(event)s Veranstaltung verwalten!"
+msgstr ""
+"Herzlichen Glückwunsch! Sie können jetzt %(event)s Veranstaltung verwalten!"
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr "Die Adresse der Website lautet https://djangogirls.org/%(page_url)s"
 
 #: templates/emails/existing_user.html:10
 msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
-msgstr "Um sie zu verwalten, loggen Sie sich hier ein:<br /> https://djangogirls.org/admin/"
+msgstr ""
+"Um sie zu verwalten, loggen Sie sich hier ein:<br /> https://djangogirls.org/"
+"admin/"
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr "E-Mail: %(email)s<br /> Verwenden Sie Ihr bestehendes Passwort."
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
-msgstr "Hier finden Sie eine Anleitung zur Bearbeitung der Website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
+msgstr ""
+"Hier finden Sie eine Anleitung zur Bearbeitung der Website: https://organize."
+"djangogirls.org/website/"
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
-msgstr "\n"
-"    Die E-Mail für Ihre Veranstaltung lautet %(email)s. Fragen Sie den Hauptorganisator Ihrer Veranstaltung\n"
+msgstr ""
+"\n"
+"    Die E-Mail für Ihre Veranstaltung lautet %(email)s. Fragen Sie den "
+"Hauptorganisator Ihrer Veranstaltung\n"
 "    um ein Passwort und Anweisungen für den Zugang.\n"
-""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
-msgstr "Du kannst hello@ kontaktieren, wenn du Hilfe brauchst, aber es ist normalerweise schneller, unsere <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> zu lesen oder Fragen in der <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\">Google Group of Django Girls Organizers</a> oder im <a href=\"https://djangogirls.slack.com/messages/general/\">Slack channel</a> zu stellen - dort gibt es mehr Leute, die dir helfen können! :)"
+#: templates/emails/existing_user.html:33
+#, fuzzy
+#| msgid ""
+#| "You can contact hello@ if you need assistance but it’s usually faster to "
+#| "check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or "
+#| "to post questions to the <a href=\"https://groups.google.com/forum/#!"
+#| "forum/django-girls-organizers\"> Google Group of Django Girls Organizers</"
+#| "a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack "
+#| "channel</a> - there are more people that can help you! :)"
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
+msgstr ""
+"Du kannst hello@ kontaktieren, wenn du Hilfe brauchst, aber es ist "
+"normalerweise schneller, unsere <a href=\"https://faq-organizers.djangogirls."
+"org/\">FAQ</a> zu lesen oder Fragen in der <a href=\"https://groups.google."
+"com/forum/#!forum/django-girls-organizers\">Google Group of Django Girls "
+"Organizers</a> oder im <a href=\"https://djangogirls.slack.com/messages/"
+"general/\">Slack channel</a> zu stellen - dort gibt es mehr Leute, die dir "
+"helfen können! :)"
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
-msgstr "Herzlichen Glückwunsch! Du bist jetzt eine Django Girls Organisatorin, super! Hier ist der Zugang zu deiner Website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
+msgstr ""
+"Herzlichen Glückwunsch! Du bist jetzt eine Django Girls Organisatorin, "
+"super! Hier ist der Zugang zu deiner Website:"
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr "Die Adresse Ihrer Website lautet https://djangogirls.org/%(page_url)s"
 
@@ -3520,24 +6720,67 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr "Hier anmelden:<br /> https://djangogirls.org/admin/"
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "  Email: %(email)s<br />\n"
+#| "  Password: %(password)s\n"
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
-msgstr "\n"
+msgstr ""
+"\n"
 "  E-Mail: %(email)s<br />\n"
 "  Passwort: %(Passwort)s\n"
-""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
-msgstr "Die E-Mail für Ihre Veranstaltung lautet %(email)s. Fragen Sie den Hauptorganisator Ihrer Veranstaltung nach dem Passwort und den Anweisungen für den Zugang."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
+msgstr ""
+"Die E-Mail für Ihre Veranstaltung lautet %(email)s. Fragen Sie den "
+"Hauptorganisator Ihrer Veranstaltung nach dem Passwort und den Anweisungen "
+"für den Zugang."
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
-msgstr "Wir haben dich auch zu Django Girls Slack eingeladen, wo wir miteinander chatten, kommunizieren und uns treffen!"
+#: templates/emails/new_user.html:33
+#, fuzzy, python-format
+#| msgid ""
+#| "We also invited you to Django Girls Slack, where we chat, communicate and "
+#| "meet each other!"
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+"Wir haben dich auch zu Django Girls Slack eingeladen, wo wir miteinander "
+"chatten, kommunizieren und uns treffen!"
+
+#: templates/emails/new_user.html:40
+#, fuzzy
+#| msgid ""
+#| "You can contact hello@ if you need assistance but it’s usually faster to "
+#| "check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or "
+#| "to post questions to the <a href=\"https://groups.google.com/forum/#!"
+#| "forum/django-girls-organizers\"> Google Group of Django Girls Organizers</"
+#| "a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack "
+#| "channel</a> - there are more people that can help you! :)"
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
+msgstr ""
+"Du kannst hello@ kontaktieren, wenn du Hilfe brauchst, aber es ist "
+"normalerweise schneller, unsere <a href=\"https://faq-organizers.djangogirls."
+"org/\">FAQ</a> zu lesen oder Fragen in der <a href=\"https://groups.google."
+"com/forum/#!forum/django-girls-organizers\">Google Group of Django Girls "
+"Organizers</a> oder im <a href=\"https://djangogirls.slack.com/messages/"
+"general/\">Slack channel</a> zu stellen - dort gibt es mehr Leute, die dir "
+"helfen können! :)"
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr "Hallo Team %(event)s!"
 
@@ -3546,12 +6789,23 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr "Wie geht es Ihnen? Wir hoffen, es geht Ihnen fantastisch :)"
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
-msgstr "Uns ist aufgefallen, dass die Django-Girls-Veranstaltung %(event.city)s noch keine Website hat oder noch nicht für Anmeldungen geöffnet ist. Läuft alles gut mit den Vorbereitungen?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
+msgstr ""
+"Uns ist aufgefallen, dass die Django-Girls-Veranstaltung %(event.city)s noch "
+"keine Website hat oder noch nicht für Anmeldungen geöffnet ist. Läuft alles "
+"gut mit den Vorbereitungen?"
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
-msgstr "Lassen Sie uns wissen, wie es läuft. Wenn du bei etwas nicht weiterkommst, können wir dir bestimmt helfen! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
+msgstr ""
+"Lassen Sie uns wissen, wie es läuft. Wenn du bei etwas nicht weiterkommst, "
+"können wir dir bestimmt helfen! :)"
 
 #: templates/emails/offer_help_email.html:17
 msgid "Hugs, cupcakes and sparkles"
@@ -3561,25 +6815,94 @@ msgstr "Umarmungen, Törtchen und Glitzer"
 msgid "Hello,"
 msgstr "Hallo,"
 
+#: templates/emails/organize/application_confirmation.html:6
+#, fuzzy, python-format
+#| msgid ""
+#| "Thank you for submitting the application to organize Django Girls in "
+#| "%(city)s! Yay!"
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+"Vielen Dank, dass Sie sich für die Organisation von Django Girls in "
+"%(Stadt)s beworben haben! Juhu!"
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
-msgstr "Wir werden Ihre Bewerbung nun prüfen und uns in etwa einer Woche bei Ihnen melden. Django Girls ist eine ehrenamtlich geführte Wohltätigkeitsorganisation und wir tun unser Bestes, um zeitnah zu antworten. In der Zwischenzeit können Sie sich mit unseren kostenlosen Ressourcen für Organisatoren vertraut machen."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
+msgstr ""
+"Wir werden Ihre Bewerbung nun prüfen und uns in etwa einer Woche bei Ihnen "
+"melden. Django Girls ist eine ehrenamtlich geführte "
+"Wohltätigkeitsorganisation und wir tun unser Bestes, um zeitnah zu "
+"antworten. In der Zwischenzeit können Sie sich mit unseren kostenlosen "
+"Ressourcen für Organisatoren vertraut machen."
 
 #: templates/emails/organize/application_confirmation.html:16
 msgid "There are three requirements for becoming an organizer of Django Girls:"
-msgstr "Es gibt drei Voraussetzungen, um Organisatorin von Django Girls zu werden:"
+msgstr ""
+"Es gibt drei Voraussetzungen, um Organisatorin von Django Girls zu werden:"
 
 #: templates/emails/organize/application_confirmation.html:18
 msgid "Being an awesome person - already done! :)"
 msgstr "Ein großartiger Mensch sein - schon erledigt! :)"
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
-msgstr "Die Veranstaltung sollte für die Teilnehmer <b>kostenlos</b> sein, und <b>Frauen sollten bei der Bewerbung bevorzugt werden</b> (aber auch Männer können sich bewerben). Sie sollten auch das <a href=\"http://tutorial.djangogirls.org/\">Tutorial, das wir für Workshops vorbereitet haben</a>, verwenden und idealerweise in kleinen Gruppen von Teilnehmern und Trainern arbeiten (jede Gruppe arbeitet in ihrem eigenen Tempo)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
+msgstr ""
+"Die Veranstaltung sollte für die Teilnehmer <b>kostenlos</b> sein, und "
+"<b>Frauen sollten bei der Bewerbung bevorzugt werden</b> (aber auch Männer "
+"können sich bewerben). Sie sollten auch das <a href=\"http://tutorial."
+"djangogirls.org/\">Tutorial, das wir für Workshops vorbereitet haben</a>, "
+"verwenden und idealerweise in kleinen Gruppen von Teilnehmern und Trainern "
+"arbeiten (jede Gruppe arbeitet in ihrem eigenen Tempo)."
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
-msgstr "Teile unsere Werte: Django Girls Veranstaltungen sind <b>inklusiv</b>, <b>freundlich</b> und bieten eine <b>sichere</b> Umgebung, die einem <a href=\"https://djangogirls.org/pages/coc/\">Verhaltenskodex</a> folgt. Vergessen Sie nicht, dass Django Girls Veranstaltungen nicht nur darauf abzielen, Menschen das Programmieren beizubringen, sondern dies auch auf eine <b>freundliche</b> und <b>positive</b> Weise zu tun."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+"Teile unsere Werte: Django Girls Veranstaltungen sind <b>inklusiv</b>, "
+"<b>freundlich</b> und bieten eine <b>sichere</b> Umgebung, die einem <a "
+"href=\"https://djangogirls.org/pages/coc/\">Verhaltenskodex</a> folgt. "
+"Vergessen Sie nicht, dass Django Girls Veranstaltungen nicht nur darauf "
+"abzielen, Menschen das Programmieren beizubringen, sondern dies auch auf "
+"eine <b>freundliche</b> und <b>positive</b> Weise zu tun."
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
+msgstr ""
+"Unser <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"beschreibt recht gut den Prozess der Organisation eines Workshops. Sie "
+"können auch die Erfahrungen anderer Organisatoren in unserem Blog lesen: <a "
+"href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-"
+"workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/"
+"post/143835232733/django-girls-wroc%%C5%%82aw-3-192-"
+"applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> "
+"oder <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-"
+"awesome-tips-tricks-from-seasoned\">Budapest</a>."
 
 #: templates/emails/organize/application_notification.html:3
 #: templates/emails/organize/application_notification.html:64
@@ -3646,7 +6969,9 @@ msgstr "Haben Sie einen bestimmten Veranstaltungsort im Sinn?"
 
 #: templates/emails/organize/application_notification.html:56
 msgid "Do you have a plan which companies will you approach for sponsorship?"
-msgstr "Haben Sie einen Plan, welche Unternehmen Sie für ein Sponsoring ansprechen werden?"
+msgstr ""
+"Haben Sie einen Plan, welche Unternehmen Sie für ein Sponsoring ansprechen "
+"werden?"
 
 #: templates/emails/organize/application_notification.html:60
 #: templates/organize/form/step5_workshop.html:139
@@ -3655,96 +6980,163 @@ msgid "Do you have potential coaches in mind?"
 msgstr "Haben Sie potenzielle Trainer im Sinn?"
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
-msgstr "Herzlichen Glückwunsch! Ihre Bewerbung für die Organisation eines Django Girls Workshops in Ihrer Stadt wurde angenommen. Wir freuen uns, Sie bei uns zu haben!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
+msgstr ""
+"Herzlichen Glückwunsch! Ihre Bewerbung für die Organisation eines Django "
+"Girls Workshops in Ihrer Stadt wurde angenommen. Wir freuen uns, Sie bei uns "
+"zu haben!"
 
 #: templates/emails/organize/event_deployed.html:9
 msgid "Below you can find all details and access to your chapter."
-msgstr "Nachstehend finden Sie alle Einzelheiten und den Zugang zu Ihrem Kapitel."
+msgstr ""
+"Nachstehend finden Sie alle Einzelheiten und den Zugang zu Ihrem Kapitel."
 
 #: templates/emails/organize/event_deployed.html:11
 msgid "1) Email address"
 msgstr "1) E-Mail Adresse"
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr "Ihre E-Mail-Adresse lautet %(email)s."
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
-msgstr "\n"
-"    Hier können Sie sich anmelden: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+msgstr ""
+"\n"
+"    Hier können Sie sich anmelden: <a href=\"http://mail.djangogirls.org/"
+"\">http://mail.djangogirls.org/</a><br/>\n"
 "    Benutzername: %(email)s (@djangogirls.com funktioniert auch!)<br/>\n"
-""
 
 #: templates/emails/organize/event_deployed.html:22
 msgid "Password:"
 msgstr "Kennwort:"
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
-msgstr "Frühere Organisatoren sollten ein Passwort für dieses Konto haben. Lassen Sie uns wissen, wenn Sie es zurücksetzen müssen."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
+msgstr ""
+"Frühere Organisatoren sollten ein Passwort für dieses Konto haben. Lassen "
+"Sie uns wissen, wenn Sie es zurücksetzen müssen."
 
 #: templates/emails/organize/event_deployed.html:30
 msgid "You can also add this inbox to your email client:"
-msgstr "Sie können diesen Posteingang auch zu Ihrem E-Mail-Programm hinzufügen:"
+msgstr ""
+"Sie können diesen Posteingang auch zu Ihrem E-Mail-Programm hinzufügen:"
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
-msgstr "Oder Sie können eingehende Post an Ihr privates E-Mail-Konto weiterleiten, indem Sie diese Anweisungen befolgen."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
+msgstr ""
+"Oder Sie können eingehende Post an Ihr privates E-Mail-Konto weiterleiten, "
+"indem Sie diese Anweisungen befolgen."
 
 #: templates/emails/organize/event_deployed.html:39
 msgid "2) Website"
 msgstr "2) Website"
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
-msgstr "Ihre Website-Adresse lautet <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+msgstr ""
+"Ihre Website-Adresse lautet <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
-msgstr "Sie sollten eine separate E-Mail mit einem automatisch generierten Passwort und Anweisungen zum Einloggen erhalten."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
+msgstr ""
+"Sie sollten eine separate E-Mail mit einem automatisch generierten Passwort "
+"und Anweisungen zum Einloggen erhalten."
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
-msgstr "Ihre Website ist derzeit für die Öffentlichkeit verborgen, Sie können sie nur sehen, wenn Sie eingeloggt sind. Wenn Sie sie für alle zugänglich machen möchten, gehen Sie hier und bearbeiten Sie Ihre Website, indem Sie die Option \"ist live\" ändern."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
+msgstr ""
+"Ihre Website ist derzeit für die Öffentlichkeit verborgen, Sie können sie "
+"nur sehen, wenn Sie eingeloggt sind. Wenn Sie sie für alle zugänglich machen "
+"möchten, gehen Sie hier und bearbeiten Sie Ihre Website, indem Sie die "
+"Option \"ist live\" ändern."
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
-msgstr "Weitere Anweisungen zur Bearbeitung Ihrer Website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgstr ""
+"Weitere Anweisungen zur Bearbeitung Ihrer Website: <a href=\"https://"
+"organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/"
+"</a>"
 
 #: templates/emails/organize/event_deployed.html:65
 msgid "3) Organizers community"
 msgstr "3) Gemeinschaft der Organisatoren"
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
-msgstr "Django Girls hat eine wachsende Gemeinschaft von mehr als 300 Organisatorinnen. Sie sollten eine Einladung erhalten, einer privaten Gruppe auf Google Groups und Slack beizutreten - hier können Sie sich mit anderen Organisatorinnen austauschen und sie um Hilfe oder Rat bitten. Nutzen Sie es weise und ausgiebig!"
+#, fuzzy
+#| msgid ""
+#| "Django Girls has a growing community of more than 300 organizers. You "
+#| "should receive an invitation to join a private group on Google Groups and "
+#| "Slack -- this is where you can chat with other organisers, ask for their "
+#| "help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
+msgstr ""
+"Django Girls hat eine wachsende Gemeinschaft von mehr als 300 "
+"Organisatorinnen. Sie sollten eine Einladung erhalten, einer privaten Gruppe "
+"auf Google Groups und Slack beizutreten - hier können Sie sich mit anderen "
+"Organisatorinnen austauschen und sie um Hilfe oder Rat bitten. Nutzen Sie es "
+"weise und ausgiebig!"
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr "4) Aufschieben oder Absagen"
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
-msgstr "Wenn Sie Ihre Veranstaltung absagen oder verschieben müssen, ist das überhaupt kein Problem! Schicken Sie uns einfach eine E-Mail und wir helfen Ihnen weiter."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
+msgstr ""
+"Wenn Sie Ihre Veranstaltung absagen oder verschieben müssen, ist das "
+"überhaupt kein Problem! Schicken Sie uns einfach eine E-Mail und wir helfen "
+"Ihnen weiter."
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr "5) Benötigen Sie weitere Hilfe?"
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
-msgstr "Vergessen Sie nicht die FAQ des Organizers, das Handbuch oder stellen Sie Fragen in unserer Google-Gruppe der Django Girls Organizer oder im Slack-Kanal - dort gibt es immer mehr Leute, die Ihnen helfen können! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
+msgstr ""
+"Vergessen Sie nicht die FAQ des Organizers, das Handbuch oder stellen Sie "
+"Fragen in unserer Google-Gruppe der Django Girls Organizer oder im Slack-"
+"Kanal - dort gibt es immer mehr Leute, die Ihnen helfen können! :)"
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr "Viel Glück!"
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr "Django Girls Team"
 
@@ -3753,56 +7145,128 @@ msgid "Hello there,"
 msgstr "Hallo zusammen,"
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
-msgstr "Vielen Dank, dass Sie sich die Zeit genommen haben, eine Bewerbung für die Organisation des Django Girls %(city)s Workshops einzureichen."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
+msgstr ""
+"Vielen Dank, dass Sie sich die Zeit genommen haben, eine Bewerbung für die "
+"Organisation des Django Girls %(city)s Workshops einzureichen."
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
-msgstr "Wir haben Ihren Antrag geprüft und sind der Meinung, dass Sie noch ein wenig mehr planen müssen, bevor wir Ihnen eine positive Antwort geben können. Bitte lesen Sie unser <a href=\"https://organize.djangogirls.org/\">Veranstalterhandbuch</a> und vergewissern Sie sich, dass Sie alle Voraussetzungen für die Ausrichtung eines Workshops sorgfältig erfüllen, und lesen Sie dann die Erfahrungen anderer Veranstalter in unserem Blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> oder <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>, um zu sehen, wie viel Arbeit mit der Organisation des Workshops verbunden ist."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
+msgstr ""
+"Wir haben Ihren Antrag geprüft und sind der Meinung, dass Sie noch ein wenig "
+"mehr planen müssen, bevor wir Ihnen eine positive Antwort geben können. "
+"Bitte lesen Sie unser <a href=\"https://organize.djangogirls.org/"
+"\">Veranstalterhandbuch</a> und vergewissern Sie sich, dass Sie alle "
+"Voraussetzungen für die Ausrichtung eines Workshops sorgfältig erfüllen, und "
+"lesen Sie dann die Erfahrungen anderer Veranstalter in unserem Blog: <a "
+"href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-"
+"workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/"
+"post/143835232733/django-girls-wroc%%C5%%82aw-3-192-"
+"applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> "
+"oder <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-"
+"awesome-tips-tricks-from-seasoned\">Budapest</a>, um zu sehen, wie viel "
+"Arbeit mit der Organisation des Workshops verbunden ist."
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
-msgstr "Wenn Sie weitere Pläne haben (z. B. ein mögliches Datum, einen Veranstaltungsort, Trainer oder Sponsoren), melden Sie sich bei uns, indem Sie das Formular erneut ausfüllen."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
+msgstr ""
+"Wenn Sie weitere Pläne haben (z. B. ein mögliches Datum, einen "
+"Veranstaltungsort, Trainer oder Sponsoren), melden Sie sich bei uns, indem "
+"Sie das Formular erneut ausfüllen."
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
-msgstr "Einen schönen Tag noch und vielen Dank, dass Sie sich an uns gewandt haben <br /> Django Girls Team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
+msgstr ""
+"Einen schönen Tag noch und vielen Dank, dass Sie sich an uns gewandt haben "
+"<br /> Django Girls Team"
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr "Hallo Team %(event)s!"
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
-msgstr "Ich hoffe, es geht euch allen fantastisch und ihr habt euch nach der Organisation eures Django Girls-Workshops eine wohlverdiente Pause gegönnt :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
+msgstr ""
+"Ich hoffe, es geht euch allen fantastisch und ihr habt euch nach der "
+"Organisation eures Django Girls-Workshops eine wohlverdiente Pause gegönnt :)"
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
-msgstr "Nur eine freundliche Erinnerung daran, <a href=\"%(base)s%(event_url)s\">dieses Formular auszufüllen</a>, um uns mitzuteilen, wie viele Personen an Ihrem Workshop teilgenommen haben. Dies wird uns helfen, den globalen Einfluss, den Django Girls auf die Welt hat, zu zeigen! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
+msgstr ""
+"Nur eine freundliche Erinnerung daran, <a "
+"href=\"%(base)s%(event_url)s\">dieses Formular auszufüllen</a>, um uns "
+"mitzuteilen, wie viele Personen an Ihrem Workshop teilgenommen haben. Dies "
+"wird uns helfen, den globalen Einfluss, den Django Girls auf die Welt hat, "
+"zu zeigen! :)"
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr "Django Girls - beginne deine Reise mit der Programmierung"
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
-msgstr "Django Girls ist ein eintägiger Workshop über Programmierung in Python und Django, der sich an Frauen richtet."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
+msgstr ""
+"Django Girls ist ein eintägiger Workshop über Programmierung in Python und "
+"Django, der sich an Frauen richtet."
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr "Umschaltbare Navigation"
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
-msgstr "Django Girls ist ein eintägiger Workshop über die Programmierung in Python und Django für Frauen."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
+msgstr ""
+"Django Girls ist ein eintägiger Workshop über die Programmierung in Python "
+"und Django für Frauen."
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
-msgstr "Django Girls ist ein eintägiger Workshop über Programmierung in Python und Django für Frauen"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
+msgstr ""
+"Django Girls ist ein eintägiger Workshop über Programmierung in Python und "
+"Django für Frauen"
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
-msgstr "Mach mit und werde eine Entwicklerin! Erstellen Sie Ihre erste Website in Python und Django in einer freundlichen, sicheren Umgebung."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
+msgstr ""
+"Mach mit und werde eine Entwicklerin! Erstellen Sie Ihre erste Website in "
+"Python und Django in einer freundlichen, sicheren Umgebung."
 
 #: templates/global/footer.html:10
 msgid "Foundation"
@@ -3816,13 +7280,13 @@ msgstr "Newsletter"
 msgid "Chat with us!"
 msgstr "Chatten Sie mit uns!"
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr "Verhaltenskodex"
-
 #: templates/global/footer.html:14
 msgid "Contact"
 msgstr "Kontakt"
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
+msgstr "Stellenbörse"
 
 #: templates/global/footer.html:20
 msgid "Support us"
@@ -3839,6 +7303,10 @@ msgstr "Spenden Sie auf Patreon"
 #: templates/global/footer.html:25
 msgid "Sponsor us"
 msgstr "Sponsern Sie uns"
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
+msgstr "Unsere Förderer"
 
 #: templates/global/footer.html:30
 msgid "Community"
@@ -3865,22 +7333,31 @@ msgid "Privacy & Cookies"
 msgstr "Datenschutz & Cookies"
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr "<b>%(future_events_count)s</b> kommende Ereignisse"
 
 #: templates/global/footer.html:61
+#, fuzzy, python-format
+#| msgid "<b>%(past_events_count)s</b> past events"
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr "<b>%(vergangene_Ereignisse_zählen)s</b> vergangene Ereignisse"
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
-msgstr "<b>%(Bewerber_summe|default_if_none:'0')s</b> Bewerber"
+#: templates/global/footer.html:62
+#, fuzzy, python-format
+#| msgid "<b>%(applicants_sum)s</b> applicants"
+msgid "<b>%(applicants_sum)s</b> applicants"
+msgstr "<b>%(Bewerber_summe)s</b> Bewerber"
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
-msgstr "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, fuzzy, python-format
+#| msgid "<b>%(attendees_sum)s</b> attendees"
+msgid "<b>%(attendees_sum)s</b> attendees"
+msgstr "<b>%(teilnehmer_summe)s</b> teilnehmer"
 
 #: templates/global/footer.html:64
+#, fuzzy, python-format
+#| msgid "<b>%(countries_count)s</b> countries"
 msgid "<b>%(countries_count)s</b> countries"
 msgstr "<b>%(Länder_Zahl)s</b> Länder"
 
@@ -3892,9 +7369,13 @@ msgstr "Organisieren Sie"
 msgid "Blog"
 msgstr "Blog"
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
-msgstr "Unterstützen Sie uns 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr "Stellenangebote"
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
+msgstr "Spenden Sie für uns 💕."
 
 #: templates/global/menu.html:31
 msgid "Donate"
@@ -3913,32 +7394,70 @@ msgid "Q: How can I register?"
 msgstr "F: Wie kann ich mich anmelden?"
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
-msgstr "A: Du möchtest an einem Workshop in deiner Stadt teilnehmen? Sehr gut! Sie können sich auf der Website der Veranstaltung anmelden. Wenn es keine Website gibt, bedeutet das, dass die Anmeldungen noch nicht geöffnet sind. Schauen Sie in ein paar Tagen noch einmal nach oder schicken Sie eine E-Mail an die lokalen Organisatoren des Workshops, an dem Sie teilnehmen möchten."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
+msgstr ""
+"A: Du möchtest an einem Workshop in deiner Stadt teilnehmen? Sehr gut! Sie "
+"können sich auf der Website der Veranstaltung anmelden. Wenn es keine "
+"Website gibt, bedeutet das, dass die Anmeldungen noch nicht geöffnet sind. "
+"Schauen Sie in ein paar Tagen noch einmal nach oder schicken Sie eine E-Mail "
+"an die lokalen Organisatoren des Workshops, an dem Sie teilnehmen möchten."
 
 #: templates/includes/_faq.html:23
 msgid "Q: I missed the deadline! Can I still apply to a workshop?"
-msgstr "F: Ich habe die Frist verpasst! Kann ich mich trotzdem für einen Workshop bewerben?"
+msgstr ""
+"F: Ich habe die Frist verpasst! Kann ich mich trotzdem für einen Workshop "
+"bewerben?"
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
-msgstr "A: Leider können Sie sich nicht anmelden: Die Veranstaltungen erhalten viele Anmeldungen und haben bereits eine Warteliste, falls ein Teilnehmer absagen muss. Sie können unseren <a href=\"%(newsletter_url)s\">Newsletter</a> abonnieren, um zu erfahren, wo die nächsten Veranstaltungen geplant sind."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
+msgstr ""
+"A: Leider können Sie sich nicht anmelden: Die Veranstaltungen erhalten viele "
+"Anmeldungen und haben bereits eine Warteliste, falls ein Teilnehmer absagen "
+"muss. Sie können unseren <a href=\"%(newsletter_url)s\">Newsletter</a> "
+"abonnieren, um zu erfahren, wo die nächsten Veranstaltungen geplant sind."
 
 #: templates/includes/_faq.html:41
 msgid "Q: I want to coach or sponsor an event!"
 msgstr "F: Ich möchte eine Veranstaltung betreuen oder sponsern!"
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
-msgstr "A: Sie sind toll! Schicken Sie einfach eine E-Mail an die lokalen Organisatoren des Workshops!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
+msgstr ""
+"A: Sie sind toll! Schicken Sie einfach eine E-Mail an die lokalen "
+"Organisatoren des Workshops!"
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
-msgstr "F: Ich folge Django Girls Tutorial und etwas ist nicht in meinem Code arbeiten: können Sie mir helfen, es zu debuggen?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
+msgstr ""
+"F: Ich folge Django Girls Tutorial und etwas ist nicht in meinem Code "
+"arbeiten: können Sie mir helfen, es zu debuggen?"
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
-msgstr "A: Leider kann Ihnen das Django Girls Support Team nicht helfen: unsere Aufgabe ist es, anderen Organisatoren bei der Planung ihres Workshops zu helfen. Wenn Sie während des Tutorials Hilfe benötigen, gehen Sie zum <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: eine Gruppe von Freiwilligen wartet dort auf Sie und wird gerne alle Ihre Fragen beantworten ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
+msgstr ""
+"A: Leider kann Ihnen das Django Girls Support Team nicht helfen: unsere "
+"Aufgabe ist es, anderen Organisatoren bei der Planung ihres Workshops zu "
+"helfen. Wenn Sie während des Tutorials Hilfe benötigen, gehen Sie zum <a "
+"href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</"
+"a>: eine Gruppe von Freiwilligen wartet dort auf Sie und wird gerne alle "
+"Ihre Fragen beantworten ;)"
 
 #: templates/includes/_no_event.html:5
 msgid "Don't see an event in your city?"
@@ -3949,8 +7468,10 @@ msgid "Sign up for our newsletter"
 msgstr "Melden Sie sich für unseren Newsletter an"
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
-msgstr "Bleiben Sie auf dem Laufenden über alles, was im Django Girls Tal passiert:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
+msgstr ""
+"Bleiben Sie auf dem Laufenden über alles, was im Django Girls Tal passiert:"
 
 #: templates/includes/_no_event.html:16
 msgid "Your e-mail"
@@ -3961,36 +7482,97 @@ msgid "Your city"
 msgstr "Deine Stadt"
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
-msgstr "Jeder kann sein eigenes Django-Girls-Event organisieren und es mit seiner Community teilen."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
+msgstr ""
+"Jeder kann sein eigenes Django-Girls-Event organisieren und es mit seiner "
+"Community teilen."
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
 msgstr "Weitere Informationen"
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+" Django Girls stellt weltweit neue Mitarbeiter ein! Möchten Sie Ihren Job "
+"hier veröffentlicht sehen?\n"
+"            <a href=\"/kontakt/\">Kontaktieren Sie uns</a> um ein globaler "
+"Partner von Django Girls zu werden\n"
+"            und rekrutieren Sie die besten Talente für Ihr Unternehmen. "
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr "Hier bewerben"
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr "Weitere Informationen"
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr "Im Moment sind leider keine Stellen zu besetzen."
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
+msgstr "Die Stellenanzeige existiert leider nicht."
 
 #: templates/organize/commitment.html:20
 msgid "Django Girls Organizer Commitement"
 msgstr "Django Girls Organisatorisches Engagement"
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
-msgstr "Django Girls ist eine Initiative, die darauf abzielt, Frauen, die noch nie programmiert haben, in die Welt der Technologie einzuführen und die Vielfalt in der Tech-Industrie zu erhöhen. Zu diesem Zweck organisieren wir Workshops und laden Frauen ein, in einem sicheren, freundlichen und integrativen Umfeld zu lernen, wie man mit HTML, CSS, Python und Django <strong>das Internet aufbaut</strong>."
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgstr ""
+"Django Girls ist eine Initiative, die darauf abzielt, Frauen, die noch nie "
+"programmiert haben, in die Welt der Technologie einzuführen und die Vielfalt "
+"in der Tech-Industrie zu erhöhen. Zu diesem Zweck organisieren wir Workshops "
+"und laden Frauen ein, in einem sicheren, freundlichen und integrativen "
+"Umfeld zu lernen, wie man mit HTML, CSS, Python und Django <strong>das "
+"Internet aufbaut</strong>."
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
-msgstr "Als Django Girls-Organisatorin verpflichten Sie sich, die Werte von Django Girls zu fördern und voranzutreiben:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
+msgstr ""
+"Als Django Girls-Organisatorin verpflichten Sie sich, die Werte von Django "
+"Girls zu fördern und voranzutreiben:"
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
-msgstr "Der von Ihnen organisierte Workshop soll eine sichere, integrative, freundliche und positive Erfahrung für alle Teilnehmer und Trainer bieten."
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
+msgstr ""
+"Der von Ihnen organisierte Workshop soll eine sichere, integrative, "
+"freundliche und positive Erfahrung für alle Teilnehmer und Trainer bieten."
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
-msgstr "<span>Der <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span> wird von allen am Workshop Beteiligten verlangt."
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+msgstr ""
+"<span>Der <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span> "
+"wird von allen am Workshop Beteiligten verlangt."
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
-msgstr "Du wirst dich bemühen, bei der Organisation deines tollen Workshops jede Menge Spaß zu haben!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgstr ""
+"Du wirst dich bemühen, bei der Organisation deines tollen Workshops jede "
+"Menge Spaß zu haben!"
 
 #: templates/organize/commitment.html:49
 msgid "Sign the commitement"
@@ -4001,12 +7583,20 @@ msgid "Welcome to Django Girls!"
 msgstr "Willkommen bei Django Girls!"
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
-msgstr "Wir freuen uns, Sie als Teil der Django Girls Familie begrüßen zu dürfen! Wir haben die Website für Ihre Veranstaltung eingerichtet, und ein Informationspaket mit den Zugangsdaten ist gerade auf dem Weg zu Ihrem Posteingang."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
+msgstr ""
+"Wir freuen uns, Sie als Teil der Django Girls Familie begrüßen zu dürfen! "
+"Wir haben die Website für Ihre Veranstaltung eingerichtet, und ein "
+"Informationspaket mit den Zugangsdaten ist gerade auf dem Weg zu Ihrem "
+"Posteingang."
 
 #: templates/organize/confirmation-of-acceptance.html:14
 msgid "In the information pack, you will receive access to the following:"
-msgstr "Mit dem Informationspaket erhalten Sie Zugang zu folgenden Informationen:"
+msgstr ""
+"Mit dem Informationspaket erhalten Sie Zugang zu folgenden Informationen:"
 
 #: templates/organize/confirmation-of-acceptance.html:18
 msgid "Your brand new shiny Django Girls Kraków event website"
@@ -4018,27 +7608,122 @@ msgstr "Das E-Mail-Konto für Ihre Veranstaltung: kraków@djangogirls.org"
 
 #: templates/organize/confirmation-of-acceptance.html:24
 msgid "Our private community of organizers on Slack (a group chat application)"
-msgstr "Unsere private Gemeinschaft von Organisatoren auf Slack (eine Gruppen-Chat-Anwendung)"
+msgstr ""
+"Unsere private Gemeinschaft von Organisatoren auf Slack (eine Gruppen-Chat-"
+"Anwendung)"
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
-msgstr "Workshop Box, ein Startpaket mit Leckereien und Dekorationen für Ihre Veranstaltung"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
+msgstr ""
+"Workshop Box, ein Startpaket mit Leckereien und Dekorationen für Ihre "
+"Veranstaltung"
 
 #: templates/organize/confirmation-of-acceptance.html:31
 msgid "We hope you’re as excited as we are about starting this adventure!"
-msgstr "Wir hoffen, Sie sind genauso aufgeregt wie wir, dass dieses Abenteuer beginnt!"
+msgstr ""
+"Wir hoffen, Sie sind genauso aufgeregt wie wir, dass dieses Abenteuer "
+"beginnt!"
 
 #: templates/organize/confirmation-of-acceptance.html:33
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr "Viel Glück und wir sehen uns auf Slack 👋<br />Django Girls Team"
+
+#: templates/organize/event_funding.html:6
+#, fuzzy
+#| msgid "Some stickers from our global partners"
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr "Einige Aufkleber von unseren globalen Partnern"
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr "Anmeldung zur Organisation eines Workshops"
 
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr "Haben Sie schon einmal einen Django Girls Workshop organisiert?"
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
-msgstr "Wenn ja, wird das Formular viel kürzer sein, da wir bereits eine Menge über dich wissen! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
+msgstr ""
+"Wenn ja, wird das Formular viel kürzer sein, da wir bereits eine Menge über "
+"dich wissen! :)"
 
 #: templates/organize/form/step1_previous_event.html:80
 #: templates/organize/form/step2_application.html:111
@@ -4046,26 +7731,34 @@ msgstr "Wenn ja, wird das Formular viel kürzer sein, da wir bereits eine Menge 
 msgid "Go to next step"
 msgstr "Weiter zum nächsten Schritt"
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr "Anmeldung zur Organisation eines Workshops"
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
-msgstr "Erzählen Sie uns ein wenig über sich selbst. Was ist Ihr Hintergrund und Ihre tägliche Beschäftigung?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
+msgstr ""
+"Erzählen Sie uns ein wenig über sich selbst. Was ist Ihr Hintergrund und "
+"Ihre tägliche Beschäftigung?"
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
-msgstr "Was hat Sie motiviert oder inspiriert, dies zu tun? Was ist Ihr Ziel bei der Organisation einer Veranstaltung?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
+msgstr ""
+"Was hat Sie motiviert oder inspiriert, dies zu tun? Was ist Ihr Ziel bei der "
+"Organisation einer Veranstaltung?"
 
 #: templates/organize/form/step2_application.html:73
 msgid "Check boxes next to all the things that describe you"
 msgstr "Kreuzen Sie alle Dinge an, die Sie beschreiben"
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
-msgstr "Wenn Sie schon einmal bei der Organisation eines anderen Workshops oder einer Veranstaltung geholfen haben oder sich in Ihrer Gemeinde engagieren, würden wir uns freuen, davon zu hören!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
+msgstr ""
+"Wenn Sie schon einmal bei der Organisation eines anderen Workshops oder "
+"einer Veranstaltung geholfen haben oder sich in Ihrer Gemeinde engagieren, "
+"würden wir uns freuen, davon zu hören!"
 
 #: templates/organize/form/step3_organizers.html:25
 msgid "Who is going to organize this workshop?"
@@ -4094,6 +7787,7 @@ msgstr "Nachname"
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr "E-Mail Adresse"
 
@@ -4102,8 +7796,15 @@ msgid "Your organizing team"
 msgstr "Ihr Organisationsteam"
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
-msgstr "Wer wird diese Veranstaltung mit Ihnen organisieren? Bitte vergewissern Sie sich bei Ihren Mitorganisatoren, dass sie damit einverstanden sind, dass Sie ihre Daten hier angeben. Sie können dann auf die E-Mails Ihrer Veranstaltung zugreifen und die Website Ihrer Veranstaltung bearbeiten."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
+msgstr ""
+"Wer wird diese Veranstaltung mit Ihnen organisieren? Bitte vergewissern Sie "
+"sich bei Ihren Mitorganisatoren, dass sie damit einverstanden sind, dass Sie "
+"ihre Daten hier angeben. Sie können dann auf die E-Mails Ihrer Veranstaltung "
+"zugreifen und die Website Ihrer Veranstaltung bearbeiten."
 
 #: templates/organize/form/step4_workshop_type.html:25
 msgid "Remote or In-Person Workshop?"
@@ -4129,10 +7830,6 @@ msgstr "Weitermachen!"
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
 msgstr "Erzählen Sie uns alles über Ihre Django Girls Veranstaltung!"
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
-msgstr "Bitte beachten Sie, dass wir zur Zeit nur Bewerbungen für Fernworkshops entgegennehmen."
 
 #: templates/organize/form/step5_workshop.html:46
 #: templates/organize/form/step5_workshop_remote.html:46
@@ -4161,8 +7858,14 @@ msgstr "Wann?"
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
-msgstr "Es sollten <b>mindestens 3 Monate</b> zwischen jetzt und dem Datum Ihrer Veranstaltung liegen, und <b>6 Monate</b> nach dem letzten Workshop in dieser Region. Bitte geben Sie Ihr Datum im Format tt/mm/jjjj ein."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
+msgstr ""
+"Es sollten <b>mindestens 3 Monate</b> zwischen jetzt und dem Datum Ihrer "
+"Veranstaltung liegen, und <b>6 Monate</b> nach dem letzten Workshop in "
+"dieser Region. Bitte geben Sie Ihr Datum im Format tt/mm/jjjj ein."
 
 #: templates/organize/form/step5_workshop.html:89
 #: templates/organize/form/step5_workshop_remote.html:89
@@ -4171,52 +7874,66 @@ msgstr "Datum der Veranstaltung"
 
 #: templates/organize/form/step5_workshop.html:104
 msgid "Tell us about your ideas on where to host the event in your city."
-msgstr "Erzählen Sie uns von Ihren Ideen, wo die Veranstaltung in Ihrer Stadt stattfinden soll."
+msgstr ""
+"Erzählen Sie uns von Ihren Ideen, wo die Veranstaltung in Ihrer Stadt "
+"stattfinden soll."
 
 #: templates/organize/form/step5_workshop.html:121
 #: templates/organize/form/step5_workshop_remote.html:103
 msgid "Do you already know which companies you will approach for sponsorship?"
-msgstr "Wissen Sie schon, welche Unternehmen Sie für ein Sponsoring ansprechen werden?"
+msgstr ""
+"Wissen Sie schon, welche Unternehmen Sie für ein Sponsoring ansprechen "
+"werden?"
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
-msgstr "Es muss noch nicht sehr konkret sein, aber wir würden uns über Ihre Ideen freuen."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgstr ""
+"Es muss noch nicht sehr konkret sein, aber wir würden uns über Ihre Ideen "
+"freuen."
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
-msgstr "Haben Sie sie angesprochen und gefragt, ob sie an einer Mitarbeit interessiert wären?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
+msgstr ""
+"Haben Sie sie angesprochen und gefragt, ob sie an einer Mitarbeit "
+"interessiert wären?"
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr "Wie werden Sie Ihren persönlichen Workshop während der Covid-19-Pandemie durchführen?"
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr "Bitte geben Sie an, wie Sie die Sicherheit der Teilnehmer und Trainer Ihres persönlichen Workshops während der Covid-19-Pandemie gewährleisten wollen."
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
-msgstr "Wie wollen Sie Ihren Workshop inklusiv gestalten und die Vielfalt fördern?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
+msgstr ""
+"Wie wollen Sie Ihren Workshop inklusiv gestalten und die Vielfalt fördern?"
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
-msgstr "Bitte teilen Sie uns mit, wie Sie sicherstellen wollen, dass Ihr Workshop Menschen aus marginalisierten Gemeinschaften einbezieht und die Vielfalt fördert."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
+msgstr ""
+"Bitte teilen Sie uns mit, wie Sie sicherstellen wollen, dass Ihr Workshop "
+"Menschen aus marginalisierten Gemeinschaften einbezieht und die Vielfalt "
+"fördert."
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr "Gibt es noch etwas, das Sie uns mitteilen möchten?"
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
-msgstr "Bitte geben Sie alle zusätzlichen Informationen an, die Sie uns mitteilen möchten und von denen Sie glauben, dass sie für Ihre Bewerbung hilfreich sein könnten."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
+msgstr ""
+"Bitte geben Sie alle zusätzlichen Informationen an, die Sie uns mitteilen "
+"möchten und von denen Sie glauben, dass sie für Ihre Bewerbung hilfreich "
+"sein könnten."
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr "Fertig!"
@@ -4226,92 +7943,186 @@ msgid "How will you host your workshop remotely?"
 msgstr "Wie werden Sie Ihren Workshop aus der Ferne veranstalten?"
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
-msgstr "Bitte geben Sie an, wie Sie Ihren Workshop aus der Ferne veranstalten wollen, d. h. welche Tools Sie verwenden werden."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
+msgstr ""
+"Bitte geben Sie an, wie Sie Ihren Workshop aus der Ferne veranstalten "
+"wollen, d. h. welche Tools Sie verwenden werden."
 
 #: templates/organize/form/thank_you.html:15
 msgid "You rock!"
 msgstr "Sie rocken!"
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
-msgstr "Vielen Dank, dass Sie sich die Zeit genommen haben, Ihre Bewerbung für die Organisation des Django Girls Workshops in Ihrer Stadt einzureichen. Wir werden Ihre Bewerbung nun prüfen und uns in Kürze bei Ihnen melden."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
+msgstr ""
+"Vielen Dank, dass Sie sich die Zeit genommen haben, Ihre Bewerbung für die "
+"Organisation des Django Girls Workshops in Ihrer Stadt einzureichen. Wir "
+"werden Ihre Bewerbung nun prüfen und uns in Kürze bei Ihnen melden."
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
-msgstr "Wenn Sie in der Zwischenzeit mit der Planung Ihres Workshops beginnen möchten, finden Sie hier einige Informationen, die Ihnen helfen können:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
+msgstr ""
+"Wenn Sie in der Zwischenzeit mit der Planung Ihres Workshops beginnen "
+"möchten, finden Sie hier einige Informationen, die Ihnen helfen können:"
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
-msgstr "Lesen Sie unser <a href=\"https://organize.djangogirls.org/\">Organisationshandbuch</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgstr ""
+"Lesen Sie unser <a href=\"https://organize.djangogirls.org/"
+"\">Organisationshandbuch</a>"
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
-msgstr "<span>Lesen Sie die Erfahrungen anderer Organisatoren in <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> und <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
+msgstr ""
+"<span>Lesen Sie die Erfahrungen anderer Organisatoren in <a href=\"http://"
+"blog.djangogirls.org/post/152858499038/django-girls-seoul-"
+"workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/"
+"post/143835232733/django-girls-wroc%%C5%%82aw-3-192-"
+"applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> "
+"und <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-"
+"awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
-msgstr "Lernen Sie unseren <a href=\"https://coach.djangogirls.org/\">Coaching-Leitfaden</a> kennen"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgstr ""
+"Lernen Sie unseren <a href=\"https://coach.djangogirls.org/\">Coaching-"
+"Leitfaden</a> kennen"
 
 #: templates/organize/index.html:9
 msgid "Organize Django Girls workshop"
 msgstr "Django Girls Workshop organisieren"
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr "Django Girls-Veranstaltungen werden von Gruppen wunderbarer Freiwilliger in Städten auf der ganzen Welt organisiert. Die Veranstaltungen sind immer nicht gewinnorientiert und für die Teilnehmer kostenlos. Wir <strong><u>BEZAHLEN KEINE</u></strong> Trainer, Sprecher oder Organisatoren. Die Teilnehmer brauchen keine Vorkenntnisse im Programmieren und es gibt keine Altersbeschränkung. Alles, was die Teilnehmer brauchen, ist ein Laptop und etwas Neugierde!"
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
-msgstr "Ab 2020 können die Django-Girls-Workshops nur noch aus der Ferne abgehalten werden. Dies ist auf die anhaltende globale Pandemie zurückzuführen und ermöglicht die Fortführung der Workshops bei gleichzeitiger Gewährleistung der Sicherheit unserer Organisatoren, Freiwilligen und Teilnehmer. Wir werden diese Entscheidung im Jahr 2021 überprüfen und hoffen, auch persönliche Workshops zuzulassen, sobald es sicher ist, dies zu tun."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
+msgstr ""
+"Django Girls-Veranstaltungen werden von Gruppen wunderbarer Freiwilliger in "
+"Städten auf der ganzen Welt organisiert. Die Veranstaltungen sind immer "
+"nicht gewinnorientiert und für die Teilnehmer kostenlos. Wir "
+"<strong><u>BEZAHLEN KEINE</u></strong> Trainer, Sprecher oder Organisatoren. "
+"Die Teilnehmer brauchen keine Vorkenntnisse im Programmieren und es gibt "
+"keine Altersbeschränkung. Alles, was die Teilnehmer brauchen, ist ein Laptop "
+"und etwas Neugierde!"
 
 #: templates/organize/index.html:24
 msgid "In-Person Workshops"
 msgstr "Persönliche Workshops"
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
-msgstr "Ein Präsenzworkshop ist ein Workshop, bei dem Teilnehmer, Trainer und Organisatoren am selben Ort zusammenkommen. Die Teilnehmer können in Teams zusammenarbeiten, und die Unterstützung durch die Trainer erfolgt von Angesicht zu Angesicht."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
+msgstr ""
+"Ein Präsenzworkshop ist ein Workshop, bei dem Teilnehmer, Trainer und "
+"Organisatoren am selben Ort zusammenkommen. Die Teilnehmer können in Teams "
+"zusammenarbeiten, und die Unterstützung durch die Trainer erfolgt von "
+"Angesicht zu Angesicht."
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
-msgstr "Diese Workshops sollten nur durchgeführt werden, wenn es sicher ist, und Sie können aufgefordert werden, in Ihrem Antrag nachzuweisen, warum Sie diese Art von Workshops für sicher halten, und welche Sicherheitsmaßnahmen Sie gegebenenfalls ergreifen werden."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
+msgstr ""
+"Diese Workshops sollten nur durchgeführt werden, wenn es sicher ist, und Sie "
+"können aufgefordert werden, in Ihrem Antrag nachzuweisen, warum Sie diese "
+"Art von Workshops für sicher halten, und welche Sicherheitsmaßnahmen Sie "
+"gegebenenfalls ergreifen werden."
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
-msgstr "Wenn Sie sich nicht sicher sind, ob es sicher ist, einen Workshop vor Ort abzuhalten, können Sie stattdessen auch einen Fern-Workshop veranstalten."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
+msgstr ""
+"Wenn Sie sich nicht sicher sind, ob es sicher ist, einen Workshop vor Ort "
+"abzuhalten, können Sie stattdessen auch einen Fern-Workshop veranstalten."
 
 #: templates/organize/index.html:47
 msgid "Remote Workshops"
 msgstr "Ferngesteuerte Workshops"
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
-msgstr "Ein Remote-Workshop ist ein Online-Workshop, bei dem sich die Teilnehmer, Trainer und Organisatoren an verschiedenen Orten befinden."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
+msgstr ""
+"Ein Remote-Workshop ist ein Online-Workshop, bei dem sich die Teilnehmer, "
+"Trainer und Organisatoren an verschiedenen Orten befinden."
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
-msgstr "Diese Art von Workshop eignet sich besser für Situationen, in denen es nicht sicher, erschwinglich oder logistisch möglich ist, einen Workshop vor Ort zu veranstalten, oder in denen Schwierigkeiten bei der Suche nach Sponsoren ein Hindernis für die Teilnahme an einem Workshop vor Ort darstellen würden. Remote-Workshops bieten auch mehr Flexibilität in Bezug auf den Standort der Teilnehmer und Trainer."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
+msgstr ""
+"Diese Art von Workshop eignet sich besser für Situationen, in denen es nicht "
+"sicher, erschwinglich oder logistisch möglich ist, einen Workshop vor Ort zu "
+"veranstalten, oder in denen Schwierigkeiten bei der Suche nach Sponsoren ein "
+"Hindernis für die Teilnahme an einem Workshop vor Ort darstellen würden. "
+"Remote-Workshops bieten auch mehr Flexibilität in Bezug auf den Standort der "
+"Teilnehmer und Trainer."
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
-msgstr "Seit Juli 2014 organisieren <span>%(organizers_count)s</span> Freiwillige <span>%(past_events_count)s</span> Django Girls Workshops. Mach mit und <a href=\"%(prerequisites_url)s\">bring Django Girls in deine Stadt!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+msgstr ""
+"Seit Juli 2014 organisieren <span>%(organizers_count)s</span> Freiwillige "
+"<span>%(past_events_count)s</span> Django Girls Workshops. Mach mit und <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls in deine Stadt!</a>"
 
 #: templates/organize/index.html:73
 msgid "The Value of Organizing Django Girls"
 msgstr "Der Wert der Organisation von Django Girls"
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
-msgstr "Schließen Sie sich einer Gruppe von über 500 leidenschaftlichen, freundlichen und hilfsbereiten Organisatoren aus der ganzen Welt an."
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
+msgstr ""
+"Schließen Sie sich einer Gruppe von über 500 leidenschaftlichen, "
+"freundlichen und hilfsbereiten Organisatoren aus der ganzen Welt an."
 
 #: templates/organize/index.html:80
 msgid "Make a real impact to advance the diversity in the tech industry"
-msgstr "Einen echten Beitrag zur Förderung der Vielfalt in der Tech-Branche leisten"
+msgstr ""
+"Einen echten Beitrag zur Förderung der Vielfalt in der Tech-Branche leisten"
 
 #: templates/organize/index.html:83
 msgid "Play a huge role in fostering tech community in your local area"
-msgstr "Sie spielen eine wichtige Rolle bei der Förderung der Tech-Community in Ihrem lokalen Umfeld."
+msgstr ""
+"Sie spielen eine wichtige Rolle bei der Förderung der Tech-Community in "
+"Ihrem lokalen Umfeld."
 
 #: templates/organize/index.html:92
 msgid "Resources for organizers"
@@ -4334,52 +8145,93 @@ msgid "Django Girls Workshop Tutorial"
 msgstr "Django Girls Workshop Tutorial"
 
 #: templates/organize/index.html:108
+#, fuzzy
+#| msgid "Apply for the workshop!"
+msgid "Apply for Event Sponsorship"
+msgstr "Bewerben Sie sich für den Workshop!"
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr "Private Mailingliste &amp; Slack"
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
-msgstr "Django Girls hat mir zu mehr Selbstvertrauen verholfen und mir einen Schub gegeben, weiter zu lernen. Ich habe meinen eigenen Blog erstellt und dann Workshops vorbereitet und anderen Frauen das Programmieren beigebracht. Mit diesem Haufen positiver Menschen ist nichts unmöglich!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
+msgstr ""
+"Django Girls hat mir zu mehr Selbstvertrauen verholfen und mir einen Schub "
+"gegeben, weiter zu lernen. Ich habe meinen eigenen Blog erstellt und dann "
+"Workshops vorbereitet und anderen Frauen das Programmieren beigebracht. Mit "
+"diesem Haufen positiver Menschen ist nichts unmöglich!"
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr "Agata Grdal, Organisatorin von Django Girls Wrocław"
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr "Erfahrungen von Django Girls Veranstaltern"
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
-msgstr "Die Organisatoren von Django Girls Windhoek, Namibia, berichten über ihre Erfahrungen bei der Organisation einer Veranstaltung in Afrika. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Weiterlesen&nbsp;\"</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
+msgstr ""
+"Die Organisatoren von Django Girls Windhoek, Namibia, berichten über ihre "
+"Erfahrungen bei der Organisation einer Veranstaltung in Afrika. <a "
+"href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-"
+"in-windhoek-namibia\">Weiterlesen&nbsp;\"</a>"
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
-msgstr "A Toolkit of Awesome: Tipps & Tricks von erfahrenen Django Girls Organisatoren in Budapest, Ungarn. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Weiterlesen&nbsp;\"</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
+msgstr ""
+"A Toolkit of Awesome: Tipps & Tricks von erfahrenen Django Girls "
+"Organisatoren in Budapest, Ungarn. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-"
+"seasoned\">Weiterlesen&nbsp;\"</a>"
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
-msgstr "Erfahren Sie, wie die Django Girls Seoul eine lokale Tech-Community aufgebaut haben, indem sie Veranstaltungen als ihr wichtigstes Instrument einsetzten. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Weiterlesen&nbsp;\"</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+msgstr ""
+"Erfahren Sie, wie die Django Girls Seoul eine lokale Tech-Community "
+"aufgebaut haben, indem sie Veranstaltungen als ihr wichtigstes Instrument "
+"einsetzten. <a href=\"http://blog.djangogirls.org/post/152858499038/django-"
+"girls-seoul-workshop-2\">Weiterlesen&nbsp;\"</a>"
 
 #: templates/organize/prerequisites.html:29
 msgid "Prerequisities to organize a Django Girls workshop"
 msgstr "Voraussetzungen für die Organisation eines Django Girls Workshops"
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
-msgstr "Juhu! Ihr wollt einen Django Girls Workshop organisieren! Das ist wunderbar. Bevor wir loslegen können, gibt es ein paar Dinge, die wir gerne mit Ihnen abklären würden, um sicherzustellen, dass Ihr Workshop so reibungslos wie möglich geplant wird:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
+msgstr ""
+"Juhu! Ihr wollt einen Django Girls Workshop organisieren! Das ist wunderbar. "
+"Bevor wir loslegen können, gibt es ein paar Dinge, die wir gerne mit Ihnen "
+"abklären würden, um sicherzustellen, dass Ihr Workshop so reibungslos wie "
+"möglich geplant wird:"
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr "Bestätigen Sie, dass Sie wissen, dass wir zur Zeit nur Bewerbungen für Fernworkshops annehmen:"
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr "Die Veranstaltung, die Sie organisieren, wird ferngesteuert sein"
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
-msgstr "Bestätigen Sie, dass Sie die folgenden Kapitel unseres <a href=\"http://organize.djangogirls.org/\">Organisatorenhandbuchs</a> gelesen haben:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgstr ""
+"Bestätigen Sie, dass Sie die folgenden Kapitel unseres <a href=\"http://"
+"organize.djangogirls.org/\">Organisatorenhandbuchs</a> gelesen haben:"
 
 #: templates/organize/prerequisites.html:51
 msgid "Introduction to Organizer’s Manual"
@@ -4399,23 +8251,34 @@ msgstr "Häufig gestellte Fragen"
 
 #: templates/organize/prerequisites.html:76
 msgid "Confirm that you meet following requirements to organize a workshop:"
-msgstr "Bestätigen Sie, dass Sie die folgenden Anforderungen erfüllen, um einen Workshop zu organisieren:"
+msgstr ""
+"Bestätigen Sie, dass Sie die folgenden Anforderungen erfüllen, um einen "
+"Workshop zu organisieren:"
 
 #: templates/organize/prerequisites.html:81
 msgid "You’re at least 18 years old"
 msgstr "Sie sind mindestens 18 Jahre alt"
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
-msgstr "Ihr Workshop ist für die Teilnehmer kostenlos, und Frauen werden bei der Teilnahme bevorzugt"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
+msgstr ""
+"Ihr Workshop ist für die Teilnehmer kostenlos, und Frauen werden bei der "
+"Teilnahme bevorzugt"
 
 #: templates/organize/prerequisites.html:93
 msgid "The event you’re organizing will be non-profit"
 msgstr "Die Veranstaltung, die Sie organisieren, ist nicht gewinnorientiert."
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
-msgstr "Sie werden keine Trainer, Redner oder Organisatoren bezahlen, daher werden Sie auch kein Geld von Sponsoren für die Bezahlung von Trainern, Rednern oder Organisatoren verlangen."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
+msgstr ""
+"Sie werden keine Trainer, Redner oder Organisatoren bezahlen, daher werden "
+"Sie auch kein Geld von Sponsoren für die Bezahlung von Trainern, Rednern "
+"oder Organisatoren verlangen."
 
 #: templates/organize/prerequisites.html:111
 msgid "Get started!"
@@ -4426,8 +8289,17 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr "Aussetzung von Anträgen für In-Person-Workshops"
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
-msgstr "Bitte beachten Sie, dass wir aufgrund der globalen Covid-19-Pandemie alle Anmeldungen für Workshops vor Ort ausgesetzt haben. Wir haben unser Organisatorenhandbuch aktualisiert, um Fernworkshops als mögliche Alternative zu unterstützen. Bitte ziehen Sie in Erwägung, sich stattdessen für einen Fernworkshop zu bewerben."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
+msgstr ""
+"Bitte beachten Sie, dass wir aufgrund der globalen Covid-19-Pandemie alle "
+"Anmeldungen für Workshops vor Ort ausgesetzt haben. Wir haben unser "
+"Organisatorenhandbuch aktualisiert, um Fernworkshops als mögliche "
+"Alternative zu unterstützen. Bitte ziehen Sie in Erwägung, sich stattdessen "
+"für einen Fernworkshop zu bewerben."
 
 #: templates/organize/suspend.html:18
 msgid "Any inconveniences caused are sincerely regretted."
@@ -4438,16 +8310,25 @@ msgid "Password Reset Complete"
 msgstr "Passwort zurücksetzen abgeschlossen"
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
-msgstr "Alles erledigt! Jetzt können Sie wieder <a href=\"%(admin_url)s\">geil sein.</a> &#x1F496; Danke für alles, was Sie tun!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
+msgstr ""
+"Alles erledigt! Jetzt können Sie wieder <a href=\"%(admin_url)s\">geil sein."
+"</a> &#x1F496; Danke für alles, was Sie tun!"
 
 #: templates/registration/password_reset_confirm.html:4
 msgid "Password Reset"
 msgstr "Passwort zurücksetzen"
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
-msgstr "Also gut, das große Ereignis. Geben Sie ein neues, super sicheres und super einprägsames (nur für Sie!) Passwort ein."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
+msgstr ""
+"Also gut, das große Ereignis. Geben Sie ein neues, super sicheres und super "
+"einprägsames (nur für Sie!) Passwort ein."
 
 #: templates/registration/password_reset_confirm.html:11
 msgid "Set my new password!"
@@ -4459,16 +8340,30 @@ msgid "Check Your"
 msgstr "Prüfen Sie Ihr"
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
-msgstr "Wir haben soeben Anweisungen zum Zurücksetzen an Ihre E-Mail geschickt. Wenn Sie Probleme haben, <a href=%(reset_url)s>versuchen Sie es noch einmal</a> und wenn Sie immer noch nichts bekommen, <a href=\"%(contact_url)s\">sagen Sie Hallo</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
+msgstr ""
+"Wir haben soeben Anweisungen zum Zurücksetzen an Ihre E-Mail geschickt. Wenn "
+"Sie Probleme haben, <a href=%(reset_url)s>versuchen Sie es noch einmal</a> "
+"und wenn Sie immer noch nichts bekommen, <a href=\"%(contact_url)s\">sagen "
+"Sie Hallo</a>!"
 
 #: templates/registration/password_reset_form.html:4
 msgid "Forget your password?"
 msgstr "Haben Sie Ihr Passwort vergessen?"
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
-msgstr "Hast du in letzter Zeit zu oft an Törtchen und High Fives gedacht? Kein Problem, wir können ein neues Passwort für Sie erstellen. Gib deine E-Mail-Adresse ein und wir schicken dir Anweisungen zum Zurücksetzen."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
+msgstr ""
+"Hast du in letzter Zeit zu oft an Törtchen und High Fives gedacht? Kein "
+"Problem, wir können ein neues Passwort für Sie erstellen. Gib deine E-Mail-"
+"Adresse ein und wir schicken dir Anweisungen zum Zurücksetzen."
 
 #: templates/registration/password_reset_form.html:11
 msgid "Reset password link time!"
@@ -4481,401 +8376,1869 @@ msgstr "Antrag auf GitHub-Sponsoring"
 
 #: templates/sponsor/sponsor-request.html:5
 msgid "Fill the form available on this page to apply for a GitHub grant."
-msgstr "Füllen Sie das auf dieser Seite verfügbare Formular aus, um einen GitHub-Zuschuss zu beantragen."
+msgstr ""
+"Füllen Sie das auf dieser Seite verfügbare Formular aus, um einen GitHub-"
+"Zuschuss zu beantragen."
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
-msgstr "GitHub kann einen Django Girls Workshop pro Stadt mit einem Zuschuss von 250$ unterstützen. Bewerbungen müssen 2 Monate vor dem Datum des Workshops eingehen, um berücksichtigt zu werden."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
+msgstr ""
+"GitHub kann einen Django Girls Workshop pro Stadt mit einem Zuschuss von "
+"250$ unterstützen. Bewerbungen müssen 2 Monate vor dem Datum des Workshops "
+"eingehen, um berücksichtigt zu werden."
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
-msgstr "Bevor Sie sich bewerben, muss Ihre Website fertig und online sein. Dann müssen Sie <a href=\"%(events_url)s\">überprüfen, ob in Ihrer Stadt bereits eine Veranstaltung stattgefunden hat</a> und ob sie Geld von GitHub erhalten hat (prüfen Sie den Abschnitt \"Sponsoren\")."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
+msgstr ""
+"Bevor Sie sich bewerben, muss Ihre Website fertig und online sein. Dann "
+"müssen Sie <a href=\"%(events_url)s\">überprüfen, ob in Ihrer Stadt bereits "
+"eine Veranstaltung stattgefunden hat</a> und ob sie Geld von GitHub erhalten "
+"hat (prüfen Sie den Abschnitt \"Sponsoren\")."
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
-msgstr "Wenn Ihre Veranstaltung die erste in Ihrer Stadt ist oder wenn die vorherigen Veranstaltungen nicht von GitHub gesponsert wurden, können Sie sich bewerben."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
+msgstr ""
+"Wenn Ihre Veranstaltung die erste in Ihrer Stadt ist oder wenn die "
+"vorherigen Veranstaltungen nicht von GitHub gesponsert wurden, können Sie "
+"sich bewerben."
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
-msgstr "Hinweis: Das Ausfüllen dieses Formulars wird lange dauern. Sie müssen einige Dokumente herunterladen und bearbeiten (Rechnung, Bankdaten usw.)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
+msgstr ""
+"Hinweis: Das Ausfüllen dieses Formulars wird lange dauern. Sie müssen einige "
+"Dokumente herunterladen und bearbeiten (Rechnung, Bankdaten usw.)."
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
-msgstr "Wir senden diese Anfragen alle zwei Wochen an GitHub. <b>Nächste Frist: %(Frist)s.</b>"
+#, fuzzy, python-format
+#| msgid ""
+#| "We send those requests once every two weeks to GitHub. <b>Next deadline: "
+#| "%(deadline)s.</b>"
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
+msgstr ""
+"Wir senden diese Anfragen alle zwei Wochen an GitHub. <b>Nächste Frist: "
+"%(Frist)s.</b>"
 
 #: templates/story/stories.html:9
 msgid "Django Girls Story"
 msgstr "Django Girls Geschichte"
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
-msgstr "\"Your Django Story\" ist eine von Freiwilligen geführte Interviewserie für den Django Girls Blog, in der Frauen vorgestellt werden, die mit Python und Django großartige Dinge machen."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
+msgstr ""
+"\"Your Django Story\" ist eine von Freiwilligen geführte Interviewserie für "
+"den Django Girls Blog, in der Frauen vorgestellt werden, die mit Python und "
+"Django großartige Dinge machen."
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
-msgstr "Jede Woche stellen wir eine neue Entwicklerin oder einen neuen Entwickler vor, die bzw. der uns erzählt, wie sie bzw. er zum Programmieren gekommen ist, was sie bzw. er gemacht hat, bevor sie bzw. er Programmierer wurde, an welchen coolen Dingen sie bzw. er gerade arbeitet und vieles mehr. Jedes Interview enthält auch Ratschläge für angehende Entwickler, was immer eine tolle Lektüre ist!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
+msgstr ""
+"Jede Woche stellen wir eine neue Entwicklerin oder einen neuen Entwickler "
+"vor, die bzw. der uns erzählt, wie sie bzw. er zum Programmieren gekommen "
+"ist, was sie bzw. er gemacht hat, bevor sie bzw. er Programmierer wurde, an "
+"welchen coolen Dingen sie bzw. er gerade arbeitet und vieles mehr. Jedes "
+"Interview enthält auch Ratschläge für angehende Entwickler, was immer eine "
+"tolle Lektüre ist!"
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
-msgstr "Viele der Frauen, die wir vorgestellt haben, haben in Django Girls-Workshops angefangen und später ihre eigenen Unternehmen gegründet, Vollzeitstellen als Entwicklerinnen erhalten und Django Girls-Veranstaltungen geleitet."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
+msgstr ""
+"Viele der Frauen, die wir vorgestellt haben, haben in Django Girls-Workshops "
+"angefangen und später ihre eigenen Unternehmen gegründet, Vollzeitstellen "
+"als Entwicklerinnen erhalten und Django Girls-Veranstaltungen geleitet."
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
-msgstr "Wenn Sie jemanden für \"Ihre Django-Story\" vorschlagen möchten (oder sich selbst nominieren möchten!), nehmen Sie bitte <a href=\"mailto:story@djangogirls.org\">Kontakt mit uns auf!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
+msgstr ""
+"Wenn Sie jemanden für \"Ihre Django-Story\" vorschlagen möchten (oder sich "
+"selbst nominieren möchten!), nehmen Sie bitte <a href=\"mailto:"
+"story@djangogirls.org\">Kontakt mit uns auf!</a>"
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
-msgstr "Brasilianisches Portugiesisch"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
-msgstr "Koreanisch"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
+msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
-msgstr "Persisch"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
+msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
-msgstr "Russisch"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
+msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
-msgstr "Spanisch"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
+msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
-msgstr "Django Girls Verhaltenskodex"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
+msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
-msgstr "Dieses Dokument ist auch verfügbar in:"
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
+msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
-msgstr "Django Girls soll eine einladende Veranstaltung sein, bei der sich Menschen in einer freundlichen Umgebung treffen. Dementsprechend erwarten wir, dass sich alle Teilnehmerinnen während des gesamten Workshops respektvoll und höflich gegenüber anderen Teilnehmerinnen verhalten."
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+#, fuzzy
+#| msgid "Actions"
+msgid "Options"
+msgstr "Aktionen"
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
-msgstr "Um klarzustellen, was erwartet wird, sind alle Delegierten/Teilnehmer, Redner, Aussteller, Organisatoren und Freiwilligen bei allen Django Girls-Veranstaltungen verpflichtet, den folgenden Verhaltenskodex einzuhalten. Die Organisatoren werden diesen Kodex vor und während der Veranstaltung durchsetzen."
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/core/coc.html:57
-msgid "In short"
-msgstr "Kurz gesagt"
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
-msgstr "Django Girls hat es sich zur Aufgabe gemacht, eine belästigungsfreie Workshop-Erfahrung für alle zu bieten, unabhängig von Geschlecht, sexueller Orientierung, Behinderung, körperlichem Aussehen, Körpergröße, Rasse oder Religion."
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+#, fuzzy
+#| msgid "Comment"
+msgid "Commands"
+msgstr "Kommentar"
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
-msgstr "Wir dulden keine Belästigung von Workshop-Teilnehmern in irgendeiner Form."
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
-msgstr "Sexuelle Sprache und Bilder sind in keinem Workshop, auch nicht bei Vorträgen, angebracht."
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
-msgstr "Seien Sie freundlich zu anderen. Beleidigen oder erniedrigen Sie andere Teilnehmer nicht. Verhalten Sie sich professionell. Veröffentlichen Sie keine Fotos von Personen ohne deren Zustimmung. Denken Sie daran, dass Belästigungen und sexistische, rassistische oder ausgrenzende Witze bei Django Girls nicht angebracht sind."
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
-msgstr "Konferenzteilnehmer, die gegen diese Regeln verstoßen, können nach Ermessen der Workshop-Organisatoren mit Sanktionen belegt oder ohne Rückerstattung vom Workshop ausgeschlossen werden."
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
-msgstr "Längere Version"
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
-msgstr "Zu den Belästigungen gehören beleidigende verbale Äußerungen in Bezug auf Geschlecht, sexuelle Orientierung, Behinderung, körperliches Aussehen, Körpergröße, Rasse, Religion, sexuelle Bilder im öffentlichen Raum, absichtliche Einschüchterung, Stalking, Verfolgung, belästigendes Fotografieren oder Aufnehmen, anhaltende Störung von Gesprächen oder anderen Veranstaltungen, unangemessener Körperkontakt und unerwünschte sexuelle Aufmerksamkeit."
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
-msgstr "Von Teilnehmern, die aufgefordert werden, belästigendes Verhalten zu unterlassen, wird erwartet, dass sie dem sofort nachkommen."
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
-msgstr "Seien Sie vorsichtig bei der Wahl der Worte, die Sie verwenden. Denken Sie daran, dass sexistische, rassistische und andere ausgrenzende Witze für Ihre Mitmenschen beleidigend sein können. Übermäßiges Fluchen und beleidigende Witze sind bei Django Girls nicht angebracht."
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
-msgstr "Bei belästigendem Verhalten eines Teilnehmers können die Organisatoren des Workshops alle Maßnahmen ergreifen, die sie für angemessen halten, einschließlich einer Verwarnung des Täters oder des Ausschlusses vom Workshop ohne Rückerstattung."
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
-msgstr "Wir erwarten von den Teilnehmern, dass sie diese Regeln an allen Veranstaltungsorten und bei allen gesellschaftlichen Veranstaltungen im Zusammenhang mit dem Workshop einhalten."
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
-msgstr "Meldung von Belästigungen"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
-msgstr "Wenn Sie belästigt werden, feststellen, dass eine andere Person belästigt wird, oder andere Bedenken haben, wenden Sie sich bitte sofort an Ihren Trainer oder einen der Organisatoren. Wenn Ihr Anliegen das Organisationsteam betrifft, senden Sie bitte eine E-Mail mit Einzelheiten an coc@djangogirls.org."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
-msgstr "Die Mitarbeiter sind gut darüber informiert, wie mit dem Vorfall umzugehen ist und wie mit der Situation weiter verfahren werden kann. Die Konferenzmitarbeiter helfen den Teilnehmern gerne dabei, sich mit dem Sicherheitsdienst des Hotels/der Veranstaltungsstätte oder den örtlichen Strafverfolgungsbehörden in Verbindung zu setzen, stellen Begleitpersonen zur Verfügung oder helfen auf andere Weise denjenigen, die belästigt werden, sich für die Dauer der Konferenz sicher zu fühlen. Wir schätzen Ihre Teilnahme an der Konferenz."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
-msgstr "Vielen Dank, dass Sie sich für die Organisation von Django Girls in %(Stadt)s beworben haben! Juhu!"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
-msgstr "Unser <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> beschreibt recht gut den Prozess der Organisation eines Workshops. Sie können auch die Erfahrungen anderer Organisatoren in unserem Blog lesen: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> oder <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
-
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
-msgstr "Bestätigung Ihrer Bewerbung für %(page_title)s"
-
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing argument"
 msgstr "Fehlende Parameter"
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
-msgstr "Die Anträge wurden aktualisiert"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing option"
+msgstr "Fehlende Parameter"
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
-msgstr "Bei Ihrem RSVP-Link ist ein Fehler aufgetreten. Bitte kontaktieren Sie uns unter %(email)s mit Ihrem Namen."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing parameter"
+msgstr "Fehlende Parameter"
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
-msgstr "Ihre Teilnahme an dem Workshop wurde bestätigt! Wir können es kaum erwarten, Sie zu treffen. Wir werden Sie in Kürze über die Einzelheiten informieren."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, fuzzy, python-brace-format
+#| msgid "Missing parameters"
+msgid "Missing {param_type}"
+msgstr "Fehlende Parameter"
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
-msgstr "Ihre Antwort wurde gespeichert. Vielen Dank, dass Sie uns Bescheid gegeben haben. Ihr Platz wird einer anderen Person auf der Warteliste zugewiesen."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, fuzzy, python-brace-format
+#| msgid "Missing parameters"
+msgid "Missing parameter: {param_name}"
+msgstr "Fehlende Parameter"
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
-msgstr "Organisator %(user_name)s wurde entfernt"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
-msgstr "%(user_name)s wurde zu Ihrer Veranstaltung hinzugefügt, juhu! Sie wurden auch zu Slack eingeladen und sollten in einer E-Mail die Anmeldedaten erhalten, um sich anzumelden."
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
-msgstr "Organisatoren hinzufügen"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
-msgstr "Keine Übersetzung für Sprache %(lang)s"
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
-msgstr "Der Antrag für %(Stadt)s, %(Land)s wurde nach %(Status)s verschoben"
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
-msgstr "Django Girls admin"
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
-msgstr "Django Girls Verwaltung"
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
-msgstr "Auch wenn die Gesamtzahl der eingegangenen Antworten eine repräsentative Stichprobe der Django Girls Alumni darstellt, ist es wahrscheinlich, dass die meisten Frauen, die an unserer Umfrage teilgenommen haben, auch nach der Teilnahme an unseren Workshops in der Tech-Branche aktiv geblieben sind und die Ergebnisse daher positiv verzerrt sein könnten."
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
-msgstr "<span class=\"highlighted-number\">$806</span> von <span class=\"highlighted-number\">$1.500</span> monatliches Ziel zugesagt"
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
-msgstr "Sie sponsern uns bereits! 💕"
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+#, fuzzy
+#| msgid "Password confirmation"
+msgid "Repeat for confirmation"
+msgstr "Passwortbestätigung"
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
-msgstr "Diese unglaublichen Unternehmen helfen uns aktiv dabei, das Verhältnis in der Technologiebranche zu ändern, indem sie uns auf andere Weise unterstützen. <br /> Wenn Sie sich ihnen anschließen möchten, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
-msgstr "Der Slug \"page_url\" muss vorhanden sein, um diesen Dekorator zu verwenden."
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
-msgstr "Die über dieses Formular gesammelten Daten werden nur zum Zweck der Django Girls-Veranstaltungen verwendet. Wir verwenden Websites und Dienste von Drittanbietern, um dies zu ermöglichen: zum Beispiel verwenden wir Sendgrid, um Ihnen E-Mails zu senden. Keine Sorge: Wir geben Ihre Daten nicht an Spammer weiter und verkaufen sie auch nicht! Weitere Informationen zu unseren Datenschutzrichtlinien finden Sie <a href='/privacy-cookies/'>hier</a>."
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+#, fuzzy
+#| msgid "The two password fields didn't match."
+msgid "Error: The two entered values do not match."
+msgstr "Die Passwörter stimmen nicht überein."
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
-msgstr "Bitte geben Sie einen Link zu Ihrer Regierungswebsite an, auf der dies beschrieben wird."
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
-msgstr "Die Einführungs-E-Mail für %(contact_person)s, von %(company_name)s wurde gesendet."
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
-msgstr "Die Verlängerungs-E-Mail für %(contact_person)s, von %(company_name)s wurde gesendet."
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
-msgstr "Anforderung von Werbematerial per E-Mail für %(Kontaktperson)s, von %(Firmenname)s wurde gesendet."
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
-msgstr "Die Dankes-E-Mail für %(contact_person)s, von %(company_name)s wurde gesendet."
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
-msgstr "Die Anwendung ist bereits im Einsatz"
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
-msgstr "Informationen über örtliche Beschränkungen für physische Einschränkungen aufgrund der Covid-19-Pandemie."
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
-msgstr "Bestätigung, dass Sie die Veranstaltung verschieben oder an einem anderen Ort durchführen werden, wenn sich die gesetzlichen Bestimmungen für Covid-19 ändern."
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
-msgstr "E-Mail an potenziellen Sponsor senden"
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
-msgstr "Erneuerung per E-Mail senden"
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
-msgstr "Werbematerial per E-Mail versenden"
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
-msgstr "Dankes-E-Mail senden"
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
-msgstr "Die Anwendung wird eingesetzt."
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
-msgstr "Karte der Django Girls Veranstaltungen von Januar 2016 bis Juli 2017"
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
-msgstr "Seit 2014 organisiert eine Armee von <span class=\"highlighted-number\">%(organizers_count)s Freiwilligen</span> in der Django Girls Community <span class=\"highlighted-number\">%(all_events_count)s Events.</span> Wir waren in <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">siehe sie alle auf einer Karte</a>)."
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
-msgstr "Insgesamt besuchten <span class=\"highlighted-number\">%(attendees_sum)s unglaubliche Frauen</span> Veranstaltungen, die von Mitgliedern unserer Gemeinschaft organisiert wurden."
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
-msgstr "Wir haben das <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> veröffentlicht, das alle Informationen enthält, die für die Organisation eines Django Girls Workshops erforderlich sind. Indem Sie sich als Organisatorin melden, werden Sie Teil einer lebendigen und unterstützenden Gemeinschaft von %(organizers_count)s Organisatoren auf der ganzen Welt!"
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
-msgstr "<span class=\"highlighted-number\">$1.661</span> des <span class=\"highlighted-number\">$2.500</span> Monatsziels zugesagt"
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
-msgstr "Hören Sie sich unseren Podcast an!"
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
-msgstr "Wir haben einen neuen <a href=\"https://anchor.fm/djangogirls\">Podcast</a>, der von den Treuhändern <a href=\"http://blog.djangogirls.org/post/138923168468\">Aisha</a> und <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> moderiert wird und in dem sie mit vielen großartigen Menschen aus unserer Gemeinschaft sprechen. Schauen Sie sich den <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> für den <a href=\"https://anchor.fm/djangogirls\">Podcast</a> an, der auf verschiedenen Plattformen wie <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a> und <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> verfügbar ist."
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+#, fuzzy
+#| msgid "Messaging"
+msgid "Messages"
+msgstr "Nachrichtenübermittlung"
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
-msgstr "Sind Sie als Unternehmen daran interessiert, uns zu sponsern? Unsere <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">Firmenpatenschaften</a> beginnen bei 100 USD pro Monat. <a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
-msgstr "Unsere globalen Partner"
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+#, fuzzy
+#| msgid "Statistics"
+msgid "Static Files"
+msgstr "Statistiken"
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
-msgstr "Unsere globalen Partner sind Unternehmen, die unsere Arbeit unterstützen, indem sie entweder monatlich über <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> oder durch jährliche Patenschaften spenden. Möchten Sie sich diesen großartigen Unternehmen anschließen und uns sponsern? Unsere <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">Unternehmenspatenschaften</a> beginnen bei 100 USD pro Monat. <a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+#, fuzzy
+#| msgid "Foundation"
+msgid "Syndication"
+msgstr "Stiftung"
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
-msgstr "Diamant - $10.000+ pro Jahr 💞✨"
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
-msgstr "Platin - $5.000+ pro Jahr 💝✨"
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
-msgstr "Gold - $2.500+ pro Jahr 💖✨"
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
-msgstr "Silber - $1.000+ pro Jahr 💗✨"
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
-msgstr "Stellenbörse"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
-msgstr "Unsere Förderer"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
-msgstr "<b>%(Bewerber_summe)s</b> Bewerber"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
-msgstr "<b>%(teilnehmer_summe)s</b> teilnehmer"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+#, fuzzy
+#| msgid "email address"
+msgid "Enter a valid email address."
+msgstr "E-Mail Adresse"
 
-#: templates/global/menu.html:25
-msgid "Jobs"
-msgstr "Stellenangebote"
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
-msgstr "Spenden Sie für uns 💕."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
-msgstr " Django Girls stellt weltweit neue Mitarbeiter ein! Möchten Sie Ihren Job hier veröffentlicht sehen?\n"
-"            <a href=\"/kontakt/\">Kontaktieren Sie uns</a> um ein globaler Partner von Django Girls zu werden\n"
-"            und rekrutieren Sie die besten Talente für Ihr Unternehmen. "
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
-msgstr "Hier bewerben"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
-msgstr "Weitere Informationen"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
-msgstr "Im Moment sind leider keine Stellen zu besetzen."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
-msgstr "Die Stellenanzeige existiert leider nicht."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
-msgstr "Welche örtlichen Beschränkungen gelten für Sie?"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
-msgstr "Bitte geben Sie auch einen Link zu Ihrer Regierungswebsite an, auf der dies beschrieben wird."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
-msgstr "Werden Sie Ihren Workshop in ein anderes Land verlegen oder verschieben, wenn sich die Situation in Ihrem Land ändert?"
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
-msgstr "Bestätigen Sie, dass Sie den Workshop verschieben oder an einem anderen Ort abhalten werden, wenn sich die Covid-19-Situation in Ihrer Stadt ändert."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
-msgstr " Ich bestätige, dass ich, sollten sich die örtlichen Beschränkungen ändern, so dass der Workshop nicht mehr sicher durchgeführt werden kann, auf einen Fern-Workshop ausweiche oder diesen verschiebe, bis die Beschränkungen aufgehoben sind und der Workshop sicher durchgeführt werden kann."
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
 
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+#, fuzzy
+#| msgid "This field is required."
+msgid "This field cannot be null."
+msgstr "Dieses Feld ist verpflichtend."
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+#, fuzzy
+#| msgid "Donation"
+msgid "Duration"
+msgstr "Spende"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Floating point number"
+msgstr "Deine Telefonnummer:"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+#, fuzzy
+#| msgid "address"
+msgid "IPv4 address"
+msgstr "Adresse"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+#, fuzzy
+#| msgid "address"
+msgid "IP address"
+msgstr "Adresse"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+#, fuzzy
+#| msgid "Subject"
+msgid "A JSON object"
+msgstr "Betreff"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+#, fuzzy
+#| msgid "One-time donations"
+msgid "One-to-one relationship"
+msgstr "Einmalige Spenden"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
+msgstr ""
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Enter a whole number."
+msgstr "Deine Telefonnummer:"
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+#, fuzzy
+#| msgid "Status"
+msgid "Sat"
+msgstr "Status"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+#, fuzzy
+#| msgid "Numbers"
+msgid "November"
+msgstr "Zahlen"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+#, fuzzy
+#| msgid "Summary"
+msgid "mar"
+msgstr "Zusammenfassung"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+#, fuzzy
+#| msgid "Summary"
+msgid "may"
+msgstr "Zusammenfassung"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+#, fuzzy
+#| msgid "Contact"
+msgid "oct"
+msgstr "Kontakt"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+#, fuzzy
+#| msgid "Numbers"
+msgctxt "alt. month"
+msgid "November"
+msgstr "Zahlen"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
+msgstr ""
+
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, fuzzy, python-format
+#| msgid "month"
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "Monat"
+msgstr[1] "Monat"
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Django Documentation"
+msgstr "Django Girls Stiftung"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+#, fuzzy
+#| msgid "Get started!"
+msgid "Get started with Django"
+msgstr "Los geht's!"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+#, fuzzy
+#| msgid "Community"
+msgid "Django Community"
+msgstr "Gemeinschaft"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""
+
+#~ msgid "\"City\" slug must be present to user this decorator."
+#~ msgstr ""
+#~ "Der Slug \"City\" muss vorhanden sein, um diesen Dekorator zu verwenden."
+
+#~ msgid ""
+#~ "Data collected through this form is used only for the purpose of Django "
+#~ "Girls events. We're using Third Party Sites and Services to make it "
+#~ "happen: for example, we're using Mandrill to send you emails. Don't "
+#~ "worry: We don't share your data with spammers, and we don't sell it! More "
+#~ "info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#~ msgstr ""
+#~ "Die über dieses Formular gesammelten Daten werden nur zum Zweck der "
+#~ "Django Girls-Veranstaltungen verwendet. Wir verwenden Websites und "
+#~ "Dienste von Drittanbietern, um dies zu ermöglichen: zum Beispiel "
+#~ "verwenden wir Mandrill, um Ihnen E-Mails zu senden. Keine Sorge: Wir "
+#~ "geben Ihre Daten nicht an Spammer weiter und wir verkaufen sie nicht! "
+#~ "Weitere Informationen zu unseren Datenschutzrichtlinien finden Sie <a "
+#~ "href='/privacy-cookies/'>hier</a>."
+
+#~ msgid "Map of Django Girls event from July 2014 to July 2017"
+#~ msgstr "Karte der Django Girls Veranstaltung von Juli 2014 bis Juli 2017"
+
+#~ msgid ""
+#~ "Since 2014, an army of <span class=\"highlighted-"
+#~ "number\">%(organizers_count|default_if_none:'0')s volunteers</span> in "
+#~ "the Django Girls community organized <span class=\"highlighted-"
+#~ "number\">%(all_events_count|default_if_none:'0')s events.</span> We've "
+#~ "been to <span class=\"highlighted-number\">%(cities_count|"
+#~ "default_if_none:'0')s cities</span> in <span class=\"highlighted-"
+#~ "number\">%(country_count|default_if_none:'0')s countries</span> (<a "
+#~ "href=\"%(event_map_url)s\">see them all on a map</a>)."
+#~ msgstr ""
+#~ "Seit 2014 organisiert eine Armee von <span class=\"highlighted-"
+#~ "number\">%(organizers_count|default_if_none:'0')s Freiwilligen</span> in "
+#~ "der Django Girls Community <span class=\"highlighted-"
+#~ "number\">%(all_events_count|default_if_none:'0')s Events.</span> Wir "
+#~ "waren in <span class=\"highlighted-number\">%(cities_count|"
+#~ "default_if_none:'0')s cities</span> in <span class=\"highlighted-"
+#~ "number\">%(country_count|default_if_none:'0')s countries</span> (<a "
+#~ "href=\"%(event_map_url)s\">siehe sie alle auf einer Karte</a>)."
+
+#~ msgid ""
+#~ "A total of <span class=\"highlighted-number\">%(attendees_sum|"
+#~ "default_if_none:'0')s incredible women attended</span> events organized "
+#~ "by members of our community."
+#~ msgstr ""
+#~ "Insgesamt haben <span class=\"highlighted-number\">%(attendees_sum|"
+#~ "default_if_none:'0')s unglaubliche Frauen an den von Mitgliedern unserer "
+#~ "Gemeinschaft organisierten Veranstaltungen teilgenommen</span>."
+
+#~ msgid ""
+#~ "We open sourced the <a href=\"http://organize.djangogirls.org/"
+#~ "\">Organizer Manual</a> that provides you with all information required "
+#~ "to organize Django Girls workshop. By volunteering to organize, you're "
+#~ "joining a vibrant and supportive community of %(organizers_count|"
+#~ "default_if_none:'0')s organizers all over the world!"
+#~ msgstr ""
+#~ "Wir haben das <a href=\"http://organize.djangogirls.org/\">Organizer "
+#~ "Manual</a> veröffentlicht, das alle Informationen enthält, die für die "
+#~ "Organisation von Django Girls Workshops erforderlich sind. Indem du dich "
+#~ "als Organisatorin meldest, trittst du einer lebendigen und "
+#~ "unterstützenden Gemeinschaft von %(organizers_count|default_if_none:'0')s "
+#~ "Organisatorinnen auf der ganzen Welt bei!"
+
+#~ msgid "Amazon Smile"
+#~ msgstr "Amazon Lächeln"
+
+#~ msgid ""
+#~ "When you shop at <a href=\"https://smile.amazon.co.uk/"
+#~ "ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django "
+#~ "Girls Foundation on your behalf if you select us as your chosen charity! "
+#~ "Please help support our work by choosing us today. 🛒"
+#~ msgstr ""
+#~ "Wenn Sie bei <a href=\"https://smile.amazon.co.uk/"
+#~ "ch/1163260-0\">AmazonSmile</a> einkaufen, spendet Amazon in Ihrem Namen "
+#~ "an die Django Girls Foundation, wenn Sie uns als "
+#~ "Wohltätigkeitsorganisation ausgewählt haben! Bitte unterstützen Sie "
+#~ "unsere Arbeit und wählen Sie uns noch heute. 🛒"
+
+#~ msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#~ msgstr "<b>%(Bewerber_summe|default_if_none:'0')s</b> Bewerber"
+
+#~ msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#~ msgstr "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+
+#~ msgid "Support us 💕"
+#~ msgstr "Unterstützen Sie uns 💕"
+
+#~ msgid ""
+#~ "Please know that we are only accepting applications for remote workshops "
+#~ "at this time."
+#~ msgstr ""
+#~ "Bitte beachten Sie, dass wir zur Zeit nur Bewerbungen für Fernworkshops "
+#~ "entgegennehmen."
+
+#~ msgid ""
+#~ "How will you host your in-person workshop during the Covid-19 pandemic?"
+#~ msgstr ""
+#~ "Wie werden Sie Ihren persönlichen Workshop während der Covid-19-Pandemie "
+#~ "durchführen?"
+
+#~ msgid ""
+#~ "Please provide information on how you plan to ensure safety for attendees "
+#~ "and coaches for your in-person workshop during the Covid-19 pandemic."
+#~ msgstr ""
+#~ "Bitte geben Sie an, wie Sie die Sicherheit der Teilnehmer und Trainer "
+#~ "Ihres persönlichen Workshops während der Covid-19-Pandemie gewährleisten "
+#~ "wollen."
+
+#~ msgid ""
+#~ "As of 2020, Django Girls workshops can only be held remotely. This is due "
+#~ "to the ongoing Global Pandemic, and allows workshops continue while "
+#~ "ensuring the safety of our organisers, volunteers and participants. We "
+#~ "will review this decision in 2021, and hope to also allow for in-person "
+#~ "workshops as soon as it is safe to do so."
+#~ msgstr ""
+#~ "Ab 2020 können die Django-Girls-Workshops nur noch aus der Ferne "
+#~ "abgehalten werden. Dies ist auf die anhaltende globale Pandemie "
+#~ "zurückzuführen und ermöglicht die Fortführung der Workshops bei "
+#~ "gleichzeitiger Gewährleistung der Sicherheit unserer Organisatoren, "
+#~ "Freiwilligen und Teilnehmer. Wir werden diese Entscheidung im Jahr 2021 "
+#~ "überprüfen und hoffen, auch persönliche Workshops zuzulassen, sobald es "
+#~ "sicher ist, dies zu tun."
+
+#~ msgid ""
+#~ "Confirm that you understand that we are only accepting applications for "
+#~ "remote workshops at this time:"
+#~ msgstr ""
+#~ "Bestätigen Sie, dass Sie wissen, dass wir zur Zeit nur Bewerbungen für "
+#~ "Fernworkshops annehmen:"
+
+#~ msgid "The event you're organizing will be remote"
+#~ msgstr "Die Veranstaltung, die Sie organisieren, wird ferngesteuert sein"
+
+#~ msgid "Django Girls administration"
+#~ msgstr "Django Girls Verwaltung"
+
+#~ msgid ""
+#~ "<span class=\"highlighted-number\">$806</span> of <span "
+#~ "class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#~ msgstr ""
+#~ "<span class=\"highlighted-number\">$806</span> von <span "
+#~ "class=\"highlighted-number\">$1.500</span> monatliches Ziel zugesagt"
+
+#~ msgid "Please provide a link to your government website outlining this."
+#~ msgstr ""
+#~ "Bitte geben Sie einen Link zu Ihrer Regierungswebsite an, auf der dies "
+#~ "beschrieben wird."
+
+#~ msgid ""
+#~ "Are you a company interested in sponsoring us? Our <a href=\"https://"
+#~ "drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?"
+#~ "usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+#~ "href=\"%(contact_url)s\">Contact us!</a> 📨"
+#~ msgstr ""
+#~ "Sind Sie als Unternehmen daran interessiert, uns zu sponsern? Unsere <a "
+#~ "href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/"
+#~ "view?usp=sharing\">Firmenpatenschaften</a> beginnen bei 100 USD pro "
+#~ "Monat. <a href=\"%(kontakt_url)s\">Kontaktieren Sie uns!</a> 📨"
+
+#~ msgid "What are your current local restrictions?"
+#~ msgstr "Welche örtlichen Beschränkungen gelten für Sie?"
+
+#~ msgid ""
+#~ "Please also provide a link to your government website outlining this."
+#~ msgstr ""
+#~ "Bitte geben Sie auch einen Link zu Ihrer Regierungswebsite an, auf der "
+#~ "dies beschrieben wird."
+
+#~ msgid ""
+#~ "Will you change your workshop to remote or postpone if the situation "
+#~ "changes in your country?"
+#~ msgstr ""
+#~ "Werden Sie Ihren Workshop in ein anderes Land verlegen oder verschieben, "
+#~ "wenn sich die Situation in Ihrem Land ändert?"
+
+#~ msgid ""
+#~ "Confirm you will postpone or host remote workshop if Covid-19 situation "
+#~ "changes in your city."
+#~ msgstr ""
+#~ "Bestätigen Sie, dass Sie den Workshop verschieben oder an einem anderen "
+#~ "Ort abhalten werden, wenn sich die Covid-19-Situation in Ihrer Stadt "
+#~ "ändert."
+
+#~ msgid ""
+#~ " I confirm that should my local restrictions change to prevent the "
+#~ "workshop from going ahead in person safely, I will change to a remote "
+#~ "workshop, or postpone until restrictions are lifted and it is safe to go "
+#~ "ahead."
+#~ msgstr ""
+#~ " Ich bestätige, dass ich, sollten sich die örtlichen Beschränkungen "
+#~ "ändern, so dass der Workshop nicht mehr sicher durchgeführt werden kann, "
+#~ "auf einen Fern-Workshop ausweiche oder diesen verschiebe, bis die "
+#~ "Beschränkungen aufgehoben sind und der Workshop sicher durchgeführt "
+#~ "werden kann."

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -1,49 +1,84 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: es\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+#, fuzzy
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr "El slug \"City\" debe estar presente para utilizar este decorador."
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
 msgstr "Solicitud para este correo electrónico ya existente."
 
-#. Will '[City]' be replaced at some point?
+#: applications/forms.py:80
+#, fuzzy, python-format
+#| msgid "Applications for %(title)s"
+msgid "Confirmation of your application for %(page_title)s"
+msgstr "Solicitudes para %(title)s"
+
 #: applications/models.py:19
 msgid "Apply for a spot at Django Girls [City]!"
 msgstr "Solicita un lugar en django Girls [Ciudad]!"
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
-msgstr "¡Hurra! Estamos muy emocionados de que quieras formar parte de nuestro taller. Por favor, tenga en cuenta que completar el siguiente formulario no te da un lugar en el taller, pero si una oportunidad de conseguir uno. El proceso de solicitud está abierto desde {INSERT DATE} hasta {INSERT DATE}. Si tienes curiosidad sobre los criterios que usamos para elegir a los solicitantes, puedes leer sobre esto en <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. ¡Buena suerte!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
+msgstr ""
+"¡Hurra! Estamos muy emocionados de que quieras formar parte de nuestro "
+"taller. Por favor, tenga en cuenta que completar el siguiente formulario no "
+"te da un lugar en el taller, pero si una oportunidad de conseguir uno. El "
+"proceso de solicitud está abierto desde {INSERT DATE} hasta {INSERT DATE}. "
+"Si tienes curiosidad sobre los criterios que usamos para elegir a los "
+"solicitantes, puedes leer sobre esto en <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. ¡Buena suerte!"
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
 "Django Girls"
-msgstr "¡Hola!\n"
+msgstr ""
+"¡Hola!\n"
 "\n"
-"Esta es una confirmación de su solicitud para <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. !Hurra! Ya es un gran paso, ¡estamos orgullosos de ti!\n"
+"Esta es una confirmación de su solicitud para <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. !Hurra! Ya es un gran paso, ¡estamos "
+"orgullosos de ti!\n"
 "\n"
-"Tenga en cuenta que esto no es una confirmación de participación en el evento, sino una confirmación de que recibimos su solicitud.\n"
+"Tenga en cuenta que esto no es una confirmación de participación en el "
+"evento, sino una confirmación de que recibimos su solicitud.\n"
 "\n"
-"Pronto recibirás un correo electrónico del equipo que organiza Django Girls {CITY}. Siempre puede comunicarse con ellos respondiendo a este correo electrónico o escribiendo a {your event mail}.  \n"
+"Pronto recibirás un correo electrónico del equipo que organiza Django Girls "
+"{CITY}. Siempre puede comunicarse con ellos respondiendo a este correo "
+"electrónico o escribiendo a {your event mail}.  \n"
 "Para su referencia, adjuntamos sus respuestas a continuación.\n"
 "\n"
 "¡Abrazos, cupcakes y choca los cinco!\n"
@@ -78,7 +113,9 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr "Enumere todas las opciones disponibles, separadas por punto y coma (;)"
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+#, fuzzy
+#| msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr "Es utilizado solo con el tipo de pregunta 'Opciones'"
 
 #: applications/models.py:98
@@ -91,7 +128,9 @@ msgstr "Posición de la pregunta"
 
 #: applications/models.py:111
 msgid "You can only get choices for fields that have question_type == choices."
-msgstr "Solo puede obtener opciones para los campos que tienen question_type == opciones."
+msgstr ""
+"Solo puede obtener opciones para los campos que tienen question_type == "
+"opciones."
 
 #: applications/models.py:118 templates/applications/applications.html:37
 #: templates/applications/applications.html:86
@@ -138,25 +177,31 @@ msgstr "Estado de la solicitud"
 msgid "RSVP status"
 msgstr "RSVP estado"
 
-#: applications/models.py:259
+#: applications/models.py:258
+msgid "5 being the most positive, 1 being the most negative."
+msgstr ""
+
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr "¿Algún comentario adicional?"
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr "Contenido del correo electrónico"
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
-msgstr "Puedes utilizar la sintaxis HTML en este mensaje. Vista previa a la derecha."
+msgstr ""
+"Puedes utilizar la sintaxis HTML en este mensaje. Vista previa a la derecha."
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr "Destinatarios"
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
-msgstr "Sólo personas asignadas al grupo elegido recibirán este correo electrónico."
+msgstr ""
+"Sólo personas asignadas al grupo elegido recibirán este correo electrónico."
 
 #: applications/questions.py:13
 msgid "Applications"
@@ -171,8 +216,13 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr "¿Quieres recibir novedades del equipo de Django Girls?"
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
-msgstr "¡Sin spam, juramento de meñiques! Solo consejos de programación útiles y las últimas noticias del mundo de Django Girls. Lo enviamos una vez cada dos semanas."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
+msgstr ""
+"¡Sin spam, juramento de meñiques! Solo consejos de programación útiles y las "
+"últimas noticias del mundo de Django Girls. Lo enviamos una vez cada dos "
+"semanas."
 
 #: applications/questions.py:59
 msgid "Yes, please!"
@@ -219,12 +269,22 @@ msgid "What is your current level of experience with programming?"
 msgstr "¿Cuál es tu nivel actual de experiencia con la programación?"
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
-msgstr "Soy un principiante, no sé nada al respecto; He practicado HTML o CSS antes; He practicado algo de JavaScript antes; He hecho algunas lecciones de Python; He creado un sitio web antes; Yo trabajo como programador"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
+msgstr ""
+"Soy un principiante, no sé nada al respecto; He practicado HTML o CSS antes; "
+"He practicado algo de JavaScript antes; He hecho algunas lecciones de "
+"Python; He creado un sitio web antes; Yo trabajo como programador"
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
-msgstr "Si marcó otra opción que no sea principiante, ¿podrías contarnos un poco más sobre tus conocimientos de programación?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
+msgstr ""
+"Si marcó otra opción que no sea principiante, ¿podrías contarnos un poco más "
+"sobre tus conocimientos de programación?"
 
 #: applications/questions.py:115
 msgid "What is your current occupation?"
@@ -247,28 +307,60 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr "¿Cómo planeas compartir lo que has aprendido con los demás?"
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
-msgstr "Django Girls es una organización dirigida por voluntarios y buscamos personas que sean activas y puedan ayudarnos a ayudar a más mujeres a ingresar al campo. Queremos que compartas lo que aprendes en el taller con otros de diferentes maneras: organizando un evento de Django Girls en tu ciudad, hablando de Django Girls en tus reuniones locales, escribiendo un blog o simplemente enseñando a tus amigos."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
+msgstr ""
+"Django Girls es una organización dirigida por voluntarios y buscamos "
+"personas que sean activas y puedan ayudarnos a ayudar a más mujeres a "
+"ingresar al campo. Queremos que compartas lo que aprendes en el taller con "
+"otros de diferentes maneras: organizando un evento de Django Girls en tu "
+"ciudad, hablando de Django Girls en tus reuniones locales, escribiendo un "
+"blog o simplemente enseñando a tus amigos."
 
 #: applications/questions.py:138
 msgid "How did you hear about Django Girls?"
 msgstr "¿Cómo se enteró de Django Girls?"
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
-msgstr "Reconozco que algunos de mis datos se utilizarán en sitios y servicios de terceros."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
+msgstr ""
+"Reconozco que algunos de mis datos se utilizarán en sitios y servicios de "
+"terceros."
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
-msgstr "Los datos recopilados a través de este formulario se utilizan solo para los eventos de Django Girls. Usamos Sitios y Servicios de Terceros para que esto suceda: por ejemplo, usamos Mandrill para enviarte correos electrónicos. No te preocupes: ¡No compartimos tus datos con spammers y no los vendemos! Más información sobre nuestra política de privacidad <a href='/privacy-cookies/'>aquí</a>."
+#: applications/questions.py:147
+#, fuzzy
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
+msgstr ""
+"Los datos recopilados a través de este formulario se utilizan solo para los "
+"eventos de Django Girls. Usamos Sitios y Servicios de Terceros para que esto "
+"suceda: por ejemplo, usamos Mandrill para enviarte correos electrónicos. No "
+"te preocupes: ¡No compartimos tus datos con spammers y no los vendemos! Más "
+"información sobre nuestra política de privacidad <a href='/privacy-"
+"cookies/'>aquí</a>."
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr "Si"
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
-msgstr "Es importante que todos los asistentes cumplan con la <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
+msgstr ""
+"Es importante que todos los asistentes cumplan con la <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
 
 #: applications/questions.py:164
 msgid "I've read and understood the Django Girls Code of Conduct"
@@ -276,35 +368,68 @@ msgstr "He leído y entendido el Código de Conducta de Django Girls"
 
 #: applications/views.py:42
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
-msgstr "¡Hurra! Su solicitud se ha guardado. ¡Pronto tendrás noticias nuestras!"
+msgstr ""
+"¡Hurra! Su solicitud se ha guardado. ¡Pronto tendrás noticias nuestras!"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr "Número de Solicitud"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr "Estado de la Solicitud"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr "RSVP Estado"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr "Puntuación media"
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr "Parámetros faltantes"
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr "Se han actualizado las aplicaciones"
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr "Sin @, sin http://, sólo el nombre de usuario"
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr "Para una mejor visualización, manténgalo cuadrado"
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
 msgstr "Entrenadores"
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
+msgstr ""
 
 #: contact/forms.py:15
 msgid "Django Girls workshop in..."
@@ -322,6 +447,10 @@ msgstr "Organizadores locales de Django Girls"
 msgid "Django Girls HQ (Support Team)"
 msgstr "Django Girls HQ (equipo de soporte)"
 
+#: contact/models.py:21
+msgid "required for contacting a chapter"
+msgstr ""
+
 #: contact/models.py:27
 msgid "Who do you want to contact?"
 msgstr "¿A quién quieres contactar?"
@@ -332,7 +461,9 @@ msgstr "Gracias por su correo electrónico. Estaremos en contacto en breve."
 
 #: contact/views.py:19
 msgid "Ooops. We couldn't send your email :( Please try again later"
-msgstr "Vaya. No pudimos enviar su correo electrónico :( Vuelva a intentarlo más tarde"
+msgstr ""
+"Vaya. No pudimos enviar su correo electrónico :( Vuelva a intentarlo más "
+"tarde"
 
 #: core/admin/event.py:82
 msgid "past event?"
@@ -346,7 +477,7 @@ msgstr "tiene estadísticas?"
 msgid "page URL"
 msgstr "URL de la página"
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr "Información del evento"
 
@@ -370,9 +501,56 @@ msgstr "Estadísticas"
 msgid "You cannot remove yourself from a team."
 msgstr "No puedes eliminarte a ti mismo de un equipo."
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr "El organizador %(user_name)s ha sido eliminado"
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
 msgstr "Eliminar organizadores"
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr "Agregar organizadores"
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr "Cambie esto solo si sabe lo que está haciendo"
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr "Los dos campos de contraseña no coinciden."
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr "Contraseña"
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr "Confirmación de contraseña"
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr "Ingrese la misma contraseña que la anterior, para verificación."
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
+msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
 msgid "Personal info"
@@ -385,10 +563,6 @@ msgstr "Permisos"
 #: core/admin/user.py:19
 msgid "Important dates"
 msgstr "Fechas importantes"
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
-msgstr "Cambie esto solo si sabe lo que está haciendo"
 
 #: core/default_eventpage_content.py:60
 msgid "About"
@@ -426,57 +600,98 @@ msgstr "Nombre y apellido del organizador"
 msgid "E-mail address"
 msgstr "Correo electrónico"
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr "Los dos campos de contraseña no coinciden."
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr "Contraseña"
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr "Confirmación de contraseña"
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr "Ingrese la misma contraseña que la anterior, para verificación."
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr "Hablemos del equipo. Primero el organizador principal:"
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
-msgstr "La fecha del evento no puede contener solo el año. Por favor, proporcione al menos un mes y un año."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
+msgstr ""
+"La fecha del evento no puede contener solo el año. Por favor, proporcione al "
+"menos un mes y un año."
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
-msgstr "La fecha de su evento está demasiado cerca. La fecha del taller debe ser de al menos 3 meses (90 días) a partir de ahora."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
+msgstr ""
+"La fecha de su evento está demasiado cerca. La fecha del taller debe ser de "
+"al menos 3 meses (90 días) a partir de ahora."
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr "La fecha del evento debería ser en el futuro"
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr "Lista de eventos de Django Girls en todo el mundo"
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr "No hay traducción para el idioma %(lang)s"
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr "Inglés"
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr "Portugués brasileño"
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr "Francés"
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr "Alemán"
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr "Coreano"
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr "Persa"
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
 msgstr "Portugués"
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr "Ruso"
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr "Español"
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
 
 #: organize/admin.py:16
 msgid "Move selected application to on hold"
@@ -486,22 +701,32 @@ msgstr "Mover la solicitud seleccionada a en espera"
 msgid "Move selected application to in review"
 msgstr "Mover la solicitud seleccionada a en revisión"
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr "Información de la solicitud"
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr "Solicitud"
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr "Organizador principal"
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+#, fuzzy
+msgid "The application is already deployed"
+msgstr "Solicitud cerrada."
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
 msgstr "Se proporcionó un estado no válido para la solicitud"
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+msgstr ""
 
 #: organize/constants.py:4
 msgid "I've never been to a Django Girls event"
@@ -547,127 +772,191 @@ msgstr "Rechazado"
 msgid "Deployed"
 msgstr "Desplegado"
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr "Sí, organicé Django Girls"
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+#, fuzzy
+#| msgid "No, it’s my first time organizing Django Girls"
+msgid "No, it's my first time organizing Django Girls"
 msgstr "No, es mi primera vez organizando Django Girls"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr "Remoto"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr "En Persona"
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr "Elija un evento"
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr "Tienes que elegir un evento."
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr "Elija un pais"
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
-msgstr "No puede postularse para organizar otro evento cuando ya tiene otra solicitud de evento abierta."
+#: organize/forms.py:109
+#, fuzzy
+#| msgid ""
+#| "Your event date is too close. Workshop date should be at least 3 months "
+#| "(90 days) from now."
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
+msgstr ""
+"La fecha de su evento está demasiado cerca. La fecha del taller debe ser de "
+"al menos 3 meses (90 días) a partir de ahora."
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
-msgstr "Sus talleres deben tener una diferencia de al menos 6 meses. Lea nuestro Manual del organizador."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
+msgstr ""
+"No puede postularse para organizar otro evento cuando ya tiene otra "
+"solicitud de evento abierta."
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+"Sus talleres deben tener una diferencia de al menos 6 meses. Lea nuestro "
+"Manual del organizador."
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr "Acerca del organizador"
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr "Motivaciones para organizar"
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr "Participación en Django Girls"
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr "Experiencia en la organización de otros eventos"
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr "Información sobre tu posible sede"
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr "Información sobre tu posible patrocinador"
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr "Información sobre tus posibles entrenadores"
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr "Información sobre cómo hospedará su taller remoto"
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
-msgstr "Información sobre cómo garantizará la seguridad de los participantes' y entrenadores' durante la pandemia de Covid-19"
+#: organize/models.py:117
+#, fuzzy
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
+msgstr ""
+"Información sobre cómo garantizará la seguridad de los participantes' y "
+"entrenadores' durante la pandemia de Covid-19"
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
-msgstr "Información sobre cómo piensa asegurarse de que su taller sea inclusivo y promueva la diversidad"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
+msgstr ""
+"Información sobre cómo garantizará la seguridad de los participantes' y "
+"entrenadores' durante la pandemia de Covid-19"
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+"Información sobre cómo piensa asegurarse de que su taller sea inclusivo y "
+"promueva la diversidad"
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr "Alguna información adicional que crees que pueda ayudar a tu solicitud"
 
-#: organize/models.py:224
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
+#, fuzzy
+#| msgid "Accept application"
+msgid "Can accept Organize Applications"
+msgstr "Aceptar solicitud"
+
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr "Este campo es obligatorio."
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr "Coorganizador"
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr "Coorganizadores"
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr "Twitter"
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr "Pagos"
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] "%d pago"
 msgstr[1] "%d pagos"
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr "Pagos"
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr "Pagos incompletos"
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:60
+msgid "Patron"
+msgstr ""
+
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr "Marcar los pagos seleccionados como completados"
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] "%d pago marcado como completado"
 msgstr[1] "%d pagos marcados como completados"
 
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr "Marcar los pagos seleccionados como completados"
+#: patreonmanager/apps.py:7
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "Patreon Manager"
+msgstr "Donaciones de Patreon"
 
 #: patreonmanager/models.py:7 patreonmanager/models.py:23
 msgid "name"
@@ -685,9 +974,21 @@ msgstr "twitter"
 msgid "address"
 msgstr "dirección"
 
+#: patreonmanager/models.py:11
+msgid "patron since"
+msgstr ""
+
 #: patreonmanager/models.py:12
 msgid "last update"
 msgstr "última actualización"
+
+#: patreonmanager/models.py:15 patreonmanager/models.py:54
+msgid "patron"
+msgstr ""
+
+#: patreonmanager/models.py:16
+msgid "patrons"
+msgstr ""
 
 #: patreonmanager/models.py:24
 msgid "description"
@@ -738,16 +1039,21 @@ msgid "payments"
 msgstr "pagos"
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
-msgstr[0] "\n"
+msgstr[0] ""
+"\n"
 "                %(counter)s pago\n"
 "            "
-msgstr[1] "\n"
+msgstr[1] ""
+"\n"
 "                %(counter)s pagos\n"
 "            "
 
@@ -760,8 +1066,12 @@ msgid "Section background"
 msgstr "Fondo de la sección"
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
-msgstr "Utilice sólo imágenes con <a href='https://creativecommons.org/licenses/'>Licencia Creative Commons</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
+msgstr ""
+"Utilice sólo imágenes con <a href='https://creativecommons.org/"
+"licenses/'>Licencia Creative Commons</a>."
 
 #: pictures/models.py:39
 msgid "photo URL"
@@ -775,11 +1085,11 @@ msgstr "Asegúrese que el logo no supere los 200 pixeles de ancho"
 msgid "No logo"
 msgstr "Sin logo"
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr "historia"
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr "historias"
 
@@ -792,24 +1102,45 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr "¡Perdón! La página que estás buscando no está disponible."
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr "Ver todos los <a href=\"%(events_url)s\"> próximos eventos</a>."
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
-msgstr "<a href=\"%(organise_url)s\">Averiguar</a> sobre la organización de un taller de Django Girls en tu ciudad."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
+msgstr ""
+"<a href=\"%(organise_url)s\">Averiguar</a> sobre la organización de un "
+"taller de Django Girls en tu ciudad."
 
 #: templates/admin/applications/form/view_submissions.html:5
 msgid "Submitted applications"
 msgstr "Solicitudes enviadas"
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
-msgstr "Para ver las solicitudes que se han enviado a su taller, elija un evento de la lista a continuación:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
+msgstr ""
+"Para ver las solicitudes que se han enviado a su taller, elija un evento de "
+"la lista a continuación:"
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
-msgstr "Para ver las solicitudes enviadas, primero debe <a href=\"%(add_url)s\">agregar un formulario de solicitud</a>."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+"Para ver las solicitudes enviadas, primero debe <a "
+"href=\"%(add_url)s\">agregar un formulario de solicitud</a>."
+
+#: templates/admin/base_site.html:5
+#, fuzzy
+#| msgid "Django Girls administration"
+msgid "Django Girls admin"
+msgstr "Administración de Django Girls"
 
 #: templates/admin/core/event/view_add_organizers.html:6
 msgid "Add a new organizer to your event"
@@ -817,7 +1148,9 @@ msgstr "Agregar un nuevo organizador a tu evento"
 
 #: templates/admin/core/event/view_add_organizers.html:7
 msgid "We will send them access instructions through automated email."
-msgstr "Les enviaremos instrucciones de acceso a través de correo electrónico automatizado."
+msgstr ""
+"Les enviaremos instrucciones de acceso a través de correo electrónico "
+"automatizado."
 
 #: templates/admin/core/event/view_add_organizers.html:33
 msgid "Add organizer"
@@ -828,7 +1161,9 @@ msgid "Remove event organizers"
 msgstr "Eliminar organizadores de eventos"
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+#, fuzzy
+#| msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr "Aquí puedes eliminar los organizadores de eventos existentes."
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -836,6 +1171,7 @@ msgid "To get started, choose an event:"
 msgstr "Para comenzar, elija un evento:"
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, python-format
 msgid "Organizers of %(event_name)s"
 msgstr "Organizadores de %(event_name)s"
 
@@ -852,12 +1188,52 @@ msgid "Action"
 msgstr "Acción"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
-msgstr "'Estás seguro de que deseas eliminar el organizador %(org_email)s del evento %(event_name)s?'"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
+msgstr ""
+"'Estás seguro de que deseas eliminar el organizador %(org_email)s del evento "
+"%(event_name)s?'"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr "Quitar"
+
+#: templates/admin/core/organizerissue/change_form.html:12
+#: templates/admin/globalpartners/globalpartner/change_form.html:12
+#: templates/admin/organize/eventapplication/change_form.html:11
+msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+#, fuzzy
+#| msgid "Main organizer"
+msgid "Blacklist Organizer"
+msgstr "Organizador principal"
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+#, fuzzy
+msgid "Send Renewal email"
+msgstr "Crear nuevo correo electrónico"
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+#, fuzzy
+msgid "Send Promotional Material email"
+msgstr "Crear nuevo correo electrónico"
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+#, fuzzy
+msgid "Send Thank You email"
+msgstr "Crear nuevo correo electrónico"
 
 #: templates/admin/organize/eventapplication/change_form.html:15
 msgid "Accept application"
@@ -875,24 +1251,42 @@ msgstr "Mover a En Espera"
 msgid "Reject application"
 msgstr "Rechazar solicitud"
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+#, fuzzy
+msgid "Application deployed."
+msgstr "Solicitud cerrada."
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr "Solicitud cerrada."
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
-msgstr "\n"
+msgstr ""
+"\n"
 "            Aprobar %(app_city)s, %(app_country)s solicitud?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, fuzzy, python-format
+#| msgid ""
+#| "\n"
+#| "                Are you sure you want to approve the "
+#| "%(application.city)s, %(application.country)s application?\n"
+#| "            "
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
-msgstr "\n"
-"            ¿Estás seguro de que quieres aprobar el (application.city)s, %(application.country)s solicitud?\n"
+msgstr ""
+"\n"
+"            ¿Estás seguro de que quieres aprobar el (application.city)s, "
+"%(application.country)s solicitud?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:19
@@ -901,19 +1295,29 @@ msgid "Yes, I'm sure"
 msgstr "Si, estoy seguro"
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
-msgstr "\n"
-"                Rechazar la solicitud %(application.city)s, %(application.country)s?\n"
+msgstr ""
+"\n"
+"                Rechazar la solicitud %(application.city)s, "
+"%(application.country)s?\n"
 "            "
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
-msgstr "\n"
-"                Estás seguro de que deseas rechazar la solicitud %(application.city)s, %(application.country)s?\n"
+msgstr ""
+"\n"
+"                Estás seguro de que deseas rechazar la solicitud "
+"%(application.city)s, %(application.country)s?\n"
 "            "
 
 #: templates/applications/application_detail.html:29
@@ -921,10 +1325,12 @@ msgid "Scores"
 msgstr "Puntos"
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr "Puntaje promedio: %(avg_score)s"
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr "Tu puntaje: %(user_score.score)s"
 
@@ -945,7 +1351,12 @@ msgstr "Comentario"
 msgid "Save"
 msgstr "Guardar"
 
+#: templates/applications/application_detail.html:65
+msgid "Save & draw next"
+msgstr ""
+
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr "Solicitudes para %(title)s"
 
@@ -1001,6 +1412,10 @@ msgstr "correo electrónico"
 msgid "Application status"
 msgstr "Estado de la solicitud"
 
+#: templates/applications/applications.html:57
+msgid "RSVP"
+msgstr ""
+
 #: templates/applications/applications.html:107
 msgid "Waiting for response"
 msgstr "Esperando respuesta"
@@ -1021,11 +1436,37 @@ msgstr "Ver Solicitud"
 msgid "Nothing to see here..."
 msgstr "Nada que ver aquí..."
 
+#: templates/applications/apply.html:26
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
+msgstr ""
+
+#: templates/applications/apply.html:35
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
+"                If you want to open registrations, go to\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
+"            "
+msgstr ""
+
 #: templates/applications/apply.html:56
 msgid "Submit your application"
 msgstr "Envíe su solicitud"
 
 #: templates/applications/communication.html:14
+#, python-format
 msgid "Send email to applicants of %(title)s"
 msgstr "Enviar correo electrónico a los solicitantes de %(title)s"
 
@@ -1059,8 +1500,17 @@ msgid "Create one!"
 msgstr "¡Crear uno!"
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr "Editar correo electrónico para %(title)s"
+
+#: templates/applications/compose_email.html:19
+msgid "Add a \"RSVP: yes\" link to email"
+msgstr ""
+
+#: templates/applications/compose_email.html:20
+msgid "Add a \"RSVP: no\" link to email"
+msgstr ""
 
 #: templates/applications/compose_email.html:21
 msgid "What's that?"
@@ -1079,11 +1529,16 @@ msgid "Email preview"
 msgstr "Vista previa de correo electrónico"
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
-msgstr "\n"
-"            Este correo electrónico fue enviado el %(sent)s por %(author)s a %(num_rec)s destinatarios.\n"
+msgstr ""
+"\n"
+"            Este correo electrónico fue enviado el %(sent)s por %(author)s a "
+"%(num_rec)s destinatarios.\n"
 "                  "
 
 #: templates/applications/compose_email.html:45
@@ -1095,22 +1550,40 @@ msgid "Emails that failed to sent:"
 msgstr "Correos electrónicos que no se enviaron:"
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
-msgstr "El evento de %(city|title)s ya se ha realizado y la página web ya no está activa."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
+msgstr ""
+"El evento de %(city|title)s ya se ha realizado y la página web ya no está "
+"activa."
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
-msgstr "\n"
-"                        La página del evento para %(city|title)s estará disponible pronto.\n"
+msgstr ""
+"\n"
+"                        La página del evento para %(city|title)s estará "
+"disponible pronto.\n"
 "                    "
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
-msgstr "Si deseas ponerte en contacto con los organizadores de este evento, puede enviarles un correo electrónico a <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
+msgstr ""
+"Si deseas ponerte en contacto con los organizadores de este evento, puede "
+"enviarles un correo electrónico a <a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr "Ver todos los demás <a href=\"%(events_url)s\">eventos próximos</a>."
 
@@ -1132,15 +1605,23 @@ msgstr "¡Hola! ¡Nos encantaría saber de ti!"
 
 #: templates/contact/contact.html:16
 msgid "To be sure your email reach the right person, check this FAQ first!"
-msgstr "Para asegurarse de que su correo electrónico llegue a la persona adecuada, ¡consulte primero estas preguntas frecuentes!"
+msgstr ""
+"Para asegurarse de que su correo electrónico llegue a la persona adecuada, "
+"¡consulte primero estas preguntas frecuentes!"
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
-msgstr "\n"
-"            Si no has encontrado lo que estabas buscando, por favor revisa nuestra extendida <a href=\"%(faq_url)s\">sección de preguntas frecuetes</a>\n"
+msgstr ""
+"\n"
+"            Si no has encontrado lo que estabas buscando, por favor revisa "
+"nuestra extendida <a href=\"%(faq_url)s\">sección de preguntas frecuetes</"
+"a>\n"
 "            o utiliza el próximo formulario. :)\n"
 "          "
 
@@ -1153,8 +1634,14 @@ msgid "Django Girls Annual Report 2015"
 msgstr "Informe Anual 2015 de Django Girls"
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
-msgstr "Gracias a los organizadores, instructores y voluntarios en países de todo el mundo, 2015 fue absolutamente un año increíble para Django Girls. Lea todo sobre nuestros desafíos y logros en 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
+msgstr ""
+"Gracias a los organizadores, instructores y voluntarios en países de todo el "
+"mundo, 2015 fue absolutamente un año increíble para Django Girls. Lea todo "
+"sobre nuestros desafíos y logros en 2015."
 
 #: templates/core/2015.html:25
 msgid "Annual Report 2015"
@@ -1168,9 +1655,40 @@ msgstr "Números 📈🗺"
 msgid "Financial Transparency 💰🔍"
 msgstr "Transparencia Financiera 💰🔍"
 
+#: templates/core/2015.html:52
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
+msgstr ""
+
 #: templates/core/2015.html:58
 msgid "Expenses 💸"
 msgstr "Gastos 💸"
+
+#: templates/core/2015.html:60
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
+msgstr ""
+
+#: templates/core/2015.html:68
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
+msgstr ""
 
 #: templates/core/2015.html:77
 msgid "Expense"
@@ -1182,12 +1700,19 @@ msgid "Amount"
 msgstr "Monto"
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr "%% de gastos"
 
 #: templates/core/2015.html:89
 msgid "Lawyer"
 msgstr "Abogado"
+
+#: templates/core/2015.html:90
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "Patreon Thank-yous"
+msgstr "Donaciones de Patreon"
 
 #: templates/core/2015.html:91
 msgid "Paypal fees"
@@ -1209,13 +1734,53 @@ msgstr "Gastos totales"
 msgid "Income 🌟👀"
 msgstr "Ingreso 🌟👀"
 
+#: templates/core/2015.html:102
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
+msgstr ""
+
+#: templates/core/2015.html:113
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
+msgstr ""
+
 #: templates/core/2015.html:122
 msgid "Income"
 msgstr "Ingreso"
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr "%% de ingreso"
+
+#: templates/core/2015.html:129
+msgid "Income from t-shirts (Sales atPyCon booth + Cotton Bureau)"
+msgstr ""
+
+#: templates/core/2015.html:130
+msgid "Elastic sponsorship of Awesomeness Ambassador"
+msgstr ""
+
+#: templates/core/2015.html:132
+#, python-brace-format
+msgid "Elastic{ON} Tour donation"
+msgstr ""
+
+#: templates/core/2015.html:133
+#, fuzzy
+#| msgid "Django Girls workshops"
+msgid "Django Girls workshops donations"
+msgstr "Talleres de Django Girls"
 
 #: templates/core/2015.html:134
 msgid "EuroPython Grant from Divio"
@@ -1225,9 +1790,21 @@ msgstr "Beca EuroPython de Divio"
 msgid "PGOpen Donation"
 msgstr "Donación PGOpen"
 
+#: templates/core/2015.html:136
+msgid "DjangoCon US Honza Král Tutorial donation"
+msgstr ""
+
 #: templates/core/2015.html:139
 msgid "Total income"
 msgstr "Ingresos totales"
+
+#: templates/core/2015.html:144
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
+msgstr ""
 
 #: templates/core/2015.html:151
 msgid "Budget for 2016 💵💡"
@@ -1237,21 +1814,319 @@ msgstr "Presupuesto para 2016 💵💡"
 msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr "En 2016, planeamos centrarnos en las siguientes iniciativas:"
 
+#: templates/core/2015.html:155
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
+msgstr ""
+
+#: templates/core/2015.html:165
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
+msgstr ""
+
+#: templates/core/2015.html:170
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
+msgstr ""
+
+#: templates/core/2015.html:175
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
+msgstr ""
+
 #: templates/core/2015.html:187
 msgid "Achievements & Events in 2015 🏆🏅"
 msgstr "Logros y eventos en 2015 🏆🏅"
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
-msgstr "2015 fue un año muy emocionante para nosotros. Aquí hay un resumen de lo que sucedió, temporada por temporada."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
+msgstr ""
+"2015 fue un año muy emocionante para nosotros. Aquí hay un resumen de lo que "
+"sucedió, temporada por temporada."
+
+#: templates/core/2015.html:197
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgstr ""
+
+#: templates/core/2015.html:205
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
+msgstr ""
+
+#: templates/core/2015.html:212
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgstr ""
+
+#: templates/core/2015.html:219
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgstr ""
+
+#: templates/core/2015.html:236
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
+msgstr ""
+
+#: templates/core/2015.html:243
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
+msgstr ""
+
+#: templates/core/2015.html:251
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
+msgstr ""
+
+#: templates/core/2015.html:257
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
+msgstr ""
+
+#: templates/core/2015.html:273
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
+msgstr ""
+
+#: templates/core/2015.html:279
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
+msgstr ""
+
+#: templates/core/2015.html:287
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
+msgstr ""
+
+#: templates/core/2015.html:293
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
+msgstr ""
+
+#: templates/core/2015.html:310
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
+msgstr ""
+
+#: templates/core/2015.html:316
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
+msgstr ""
+
+#: templates/core/2015.html:322
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
+msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
-msgstr "Pasamos de alojar nuestros correos electrónicos en un VPS proporcionado generosamente por Megiteam a Google Apps, que paso a ser gratuito para nosotros una vez que nos registramos oficialmente como organización benéfica. Esto resultó ser un gran proyecto: mover más de 100 cuentas de correo electrónico y decenas de miles de correos electrónicos sin interrumpir la organización de nadie. Esto no habría sido posible si no fuera por Adria Richards, quien se ofreció como voluntaria y nos ofreció su conocimiento y experiencia de forma gratuita. ¡Gracias, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
+msgstr ""
+"Pasamos de alojar nuestros correos electrónicos en un VPS proporcionado "
+"generosamente por Megiteam a Google Apps, que paso a ser gratuito para "
+"nosotros una vez que nos registramos oficialmente como organización "
+"benéfica. Esto resultó ser un gran proyecto: mover más de 100 cuentas de "
+"correo electrónico y decenas de miles de correos electrónicos sin "
+"interrumpir la organización de nadie. Esto no habría sido posible si no "
+"fuera por Adria Richards, quien se ofreció como voluntaria y nos ofreció su "
+"conocimiento y experiencia de forma gratuita. ¡Gracias, Adria!"
+
+#: templates/core/2015.html:337
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
+msgstr ""
 
 #: templates/core/2015.html:351
 msgid "Success stories 💖"
 msgstr "Historias de éxito 💖"
+
+#: templates/core/2015.html:353
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
+msgstr ""
+
+#: templates/core/2015.html:364
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
+msgstr ""
+
+#: templates/core/2015.html:370
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
+msgstr ""
+
+#: templates/core/2015.html:386
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
+msgstr ""
+
+#: templates/core/2015.html:392
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
+msgstr ""
+
+#: templates/core/2015.html:409
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgstr ""
+
+#: templates/core/2015.html:417
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
+msgstr ""
+
+#: templates/core/2015.html:437
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
+msgstr ""
+
+#: templates/core/2015.html:445
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
+msgstr ""
 
 #: templates/core/2015.html:461
 msgid "Summary 👍"
@@ -1261,24 +2136,218 @@ msgstr "Resumen 👍"
 msgid "2015 was an incredibly busy year for Django Girls."
 msgstr "2015 fue un año increíblemente ocupado para Django Girls."
 
+#: templates/core/2015.html:464
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
+msgstr ""
+
+#: templates/core/2015.html:466
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
+msgstr ""
+
+#: templates/core/2015.html:469
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
+msgstr ""
+
+#: templates/core/2015.html:479
+msgid "Thank you for constant support and love we receive from you!"
+msgstr ""
+
 #: templates/core/2015.html:486 templates/core/2016-2017.html:422
 msgid "Sponsors 📢️"
 msgstr "Patrocinadores 📢️"
+
+#: templates/core/2015.html:488 templates/core/2016-2017.html:424
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
+msgstr ""
+
+#: templates/core/2015.html:496 templates/core/2016-2017.html:432
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:503 templates/core/2016-2017.html:439
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:509 templates/core/2016-2017.html:446
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:515 templates/core/2016-2017.html:453
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:521 templates/core/2016-2017.html:460
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:527 templates/core/2016-2017.html:467
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:533 templates/core/2016-2017.html:474
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:539 templates/core/2016-2017.html:481
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
+msgstr ""
+
+#: templates/core/2015.html:545 templates/core/2016-2017.html:488
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
+msgstr ""
+
+#: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
+#, fuzzy
+#| msgid "Impact Report 2016-2017"
+msgid "Django Girls Impact Report 2016-2017"
+msgstr "Informe de impacto 2016-2017"
+
+#: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
+#, fuzzy
+#| msgid ""
+#| "Thanks to the organizers, coaches, and volunteers in countries all over "
+#| "the world, 2015 was an absolutely incredible year for Django Girls. Read "
+#| "all about our challenges and achievements from 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
+msgstr ""
+"Gracias a los organizadores, instructores y voluntarios en países de todo el "
+"mundo, 2015 fue absolutamente un año increíble para Django Girls. Lea todo "
+"sobre nuestros desafíos y logros en 2015."
 
 #: templates/core/2016-2017.html:26
 msgid "Impact Report 2016-2017"
 msgstr "Informe de impacto 2016-2017"
 
+#: templates/core/2016-2017.html:29
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
+msgstr ""
+
+#: templates/core/2016-2017.html:38
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
+msgstr ""
+
 #: templates/core/2016-2017.html:50
 msgid "✨ Highlights ✨"
 msgstr "✨ Destacados ✨"
+
+#: templates/core/2016-2017.html:52
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
+msgstr ""
+
+#: templates/core/2016-2017.html:57
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
+msgstr ""
+
+#: templates/core/2016-2017.html:62
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
+msgstr ""
+
+#: templates/core/2016-2017.html:67
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgstr ""
+
+#: templates/core/2016-2017.html:72
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
+msgstr ""
+
+#: templates/core/2016-2017.html:77
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr "Crecimiento 📈"
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+#, fuzzy
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr "Mapa del evento de Django Girls de julio de 2014 a julio de 2017"
 
 #: templates/core/2016-2017.html:94
@@ -1323,7 +2392,9 @@ msgstr "Usuarios únicos leyendo nuestro tutorial"
 
 #: templates/core/2016-2017.html:109
 msgid "* Gathering events data on number of participants is delayed."
-msgstr "* La recopilación de datos de eventos sobre el número de participantes está retrazado."
+msgstr ""
+"* La recopilación de datos de eventos sobre el número de participantes está "
+"retrazado."
 
 #: templates/core/2016-2017.html:116
 msgid "Foundation's Activities 👩‍💻👩‍💻👩‍💻"
@@ -1333,6 +2404,26 @@ msgstr "Actividades de la Fundación 👩‍💻👩‍💻👩‍💻"
 msgid "🌎 Maintenance & translation of our free online resources"
 msgstr "🌎 Mantenimiento y traducción de nuestros recursos online gratuitos"
 
+#: templates/core/2016-2017.html:122
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
+msgstr ""
+
+#: templates/core/2016-2017.html:130
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
+msgstr ""
+
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
 msgid "Your browser does not support the video tag."
 msgstr "Su navegador no soporta la etiqueta de vídeo."
@@ -1341,9 +2432,37 @@ msgstr "Su navegador no soporta la etiqueta de vídeo."
 msgid "🎁 Organiser Starter Kits"
 msgstr "🎁 Kits inicial del organizador"
 
+#: templates/core/2016-2017.html:150
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
+msgstr ""
+
+#: templates/core/2016-2017.html:160
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
+msgstr ""
+
 #: templates/core/2016-2017.html:169
 msgid "💰 Fundraising"
 msgstr "💰 Recaudación de fondos"
+
+#: templates/core/2016-2017.html:171
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
+msgstr ""
 
 #: templates/core/2016-2017.html:183
 msgid "Activity"
@@ -1359,7 +2478,9 @@ msgstr "Donaciones de Patreon"
 
 #: templates/core/2016-2017.html:189
 msgid "Patreon donation have been steadly decreasing in the last months"
-msgstr "La donación de Patreon ha ido disminuyendo constantemente en los últimos meses"
+msgstr ""
+"La donación de Patreon ha ido disminuyendo constantemente en los últimos "
+"meses"
 
 #: templates/core/2016-2017.html:190
 msgid "Django Girls Store"
@@ -1373,62 +2494,470 @@ msgstr "Kits inicial del organizador"
 msgid "Participants Survey"
 msgstr "Encuesta a los participantes"
 
+#: templates/core/2016-2017.html:204
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
+msgstr ""
+
+#: templates/core/2016-2017.html:212
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
+msgstr ""
+
 #: templates/core/2016-2017.html:227
 msgid "Participants’ Involvement in Tech Activities"
 msgstr "Participación en actividades tecnológicas"
 
+#: templates/core/2016-2017.html:231
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
+msgstr ""
+
+#: templates/core/2016-2017.html:239
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
+msgstr ""
+
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
-msgstr "Estas estadísticas muestran que nuestros talleres están generando interés en tecnología y programación en los participantes que los asisten. Esto les lleva a organizar otros talleres y eventos, así como asistir a eventos tecnológicos para algunas de las mujeres. Estos hallazgos <b> demuestran que los talleres de Django Girls han sido un éxito</b> para aumentar el número de mujeres involucradas en ingeniería y programación."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
+msgstr ""
+"Estas estadísticas muestran que nuestros talleres están generando interés en "
+"tecnología y programación en los participantes que los asisten. Esto les "
+"lleva a organizar otros talleres y eventos, así como asistir a eventos "
+"tecnológicos para algunas de las mujeres. Estos hallazgos <b> demuestran que "
+"los talleres de Django Girls han sido un éxito</b> para aumentar el número "
+"de mujeres involucradas en ingeniería y programación."
 
 #: templates/core/2016-2017.html:258
 msgid "Participants’ learning to code after the workshop"
 msgstr "participantes aprenden a codificar después del taller."
 
+#: templates/core/2016-2017.html:265
+#, fuzzy
+#| msgid ""
+#| "We were also interested in learning other ways the participants had been "
+#| "impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
+msgstr ""
+"También estábamos interesados ​​en conocer otras formas en las que los "
+"participantes se vieron afectados al asistir a un taller de Django Girls."
+
+#: templates/core/2016-2017.html:268
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
+msgstr ""
+
+#: templates/core/2016-2017.html:273
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
+msgstr ""
+
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
-msgstr "Los hallazgos mostraron que la mayoría de las mujeres que asisten a los talleres de Django Girls continúan aprendiendo a codificar después. Las mujeres continuaron aprendiendo de diversas formas; algunos por su cuenta, inscribiéndose en cursos de codificación en línea o inscribiéndose en universidades. Estos hallazgos muestran que Django Girls de hecho está aumentando el número de mujeres en el campo de la programación, que algún día serán empleadas como programadoras después de que hayan desarrollado sus habilidades de programación."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
+msgstr ""
+"Los hallazgos mostraron que la mayoría de las mujeres que asisten a los "
+"talleres de Django Girls continúan aprendiendo a codificar después. Las "
+"mujeres continuaron aprendiendo de diversas formas; algunos por su cuenta, "
+"inscribiéndose en cursos de codificación en línea o inscribiéndose en "
+"universidades. Estos hallazgos muestran que Django Girls de hecho está "
+"aumentando el número de mujeres en el campo de la programación, que algún "
+"día serán empleadas como programadoras después de que hayan desarrollado sus "
+"habilidades de programación."
+
+#: templates/core/2016-2017.html:291
+#, fuzzy
+#| msgid "Participants’ learning to code after the workshop"
+msgid "Participants’ Employment in Tech after attending workshops"
+msgstr "participantes aprenden a codificar después del taller."
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
-msgstr "La pregunta más importante que nos interesaba responder era saber cuántas de las mujeres comenzaron a trabajar en tecnología como desarrolladoras después de asistir al taller."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
+msgstr ""
+"La pregunta más importante que nos interesaba responder era saber cuántas de "
+"las mujeres comenzaron a trabajar en tecnología como desarrolladoras después "
+"de asistir al taller."
+
+#: templates/core/2016-2017.html:304
+#, fuzzy, python-format
+#| msgid ""
+#| "The biggest question we were interested to answer was to know how many of "
+#| "the women started working in tech as developers after attending the "
+#| "workshop."
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
+msgstr ""
+"La pregunta más importante que nos interesaba responder era saber cuántas de "
+"las mujeres comenzaron a trabajar en tecnología como desarrolladoras después "
+"de asistir al taller."
+
+#: templates/core/2016-2017.html:307
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
+msgstr ""
+
+#: templates/core/2016-2017.html:317
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
+msgstr ""
 
 #: templates/core/2016-2017.html:326
 msgid "Impact of Django Girls workshops on Participants’ lives"
-msgstr "Impacto de los talleres de Django Girls en la vida de los participantes"
+msgstr ""
+"Impacto de los talleres de Django Girls en la vida de los participantes"
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
-msgstr "También estábamos interesados ​​en conocer otras formas en las que los participantes se vieron afectados al asistir a un taller de Django Girls."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
+msgstr ""
+"También estábamos interesados ​​en conocer otras formas en las que los "
+"participantes se vieron afectados al asistir a un taller de Django Girls."
+
+#: templates/core/2016-2017.html:338
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
+msgstr ""
+
+#: templates/core/2016-2017.html:341
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
+msgstr ""
+
+#: templates/core/2016-2017.html:350
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
+msgstr ""
 
 #: templates/core/2016-2017.html:362
 msgid "Summary"
 msgstr "Resumen"
 
+#: templates/core/2016-2017.html:364
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
+msgstr ""
+
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
-msgstr "En nuestro tercer cumpleaños, le pedimos a nuestra comunidad de Twitter que nos contara las formas en que Django Girls impactaron sus vidas. La respuesta que recibimos fue abrumadoramente positiva:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
+msgstr ""
+"En nuestro tercer cumpleaños, le pedimos a nuestra comunidad de Twitter que "
+"nos contara las formas en que Django Girls impactaron sus vidas. La "
+"respuesta que recibimos fue abrumadoramente positiva:"
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
 msgstr "Ver más historias de éxito"
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr "Código de conducta de Django Girls"
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+#, fuzzy
+#| msgid "Django Girls Code of Conduct"
+msgid "Code of Conduct"
+msgstr "Código de conducta de Django Girls"
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr "Este documento también está disponible en:"
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+"Django Girls tiene como objetivo ser un evento acogedor, donde las personas "
+"se reúnan en un ambiente amigable. En consecuencia, esperamos que todos los "
+"participantes muestren respeto y cortesía hacia los demás participantes "
+"durante todo el taller."
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+"Para aclarar lo que se espera, todos los delegados / asistentes, oradores, "
+"expositores, organizadores y voluntarios en cualquier evento de Django Girls "
+"deben cumplir con el siguiente Código de Conducta. Los organizadores harán "
+"cumplir este código antes y durante todo el evento."
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr "En breve"
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+"Django Girls se dedica a brindar una experiencia de taller libre de acoso "
+"para todos, independientemente de su género, orientación sexual, "
+"discapacidad, apariencia física, tamaño corporal, raza o religión."
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr "No toleramos el acoso a los participantes del taller de ninguna forma."
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+"El lenguaje y las imágenes sexuales no son apropiados para ningún lugar de "
+"taller, incluidas las charlas."
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+"Se amable con otros. No insultes ni menosprecies a otros asistentes. "
+"Compórtate profesionalmente. No publique fotografías de personas sin su "
+"consentimiento. Recuerda que el acoso y las bromas sexistas, racistas o "
+"excluyentes no son apropiadas para Django Girls."
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr "Versión más larga"
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+"El acoso incluye comentarios verbales ofensivos relacionados con género, "
+"orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, "
+"religión, imágenes sexuales en espacios públicos, intimidación deliberada, "
+"acecho, seguimiento, fotografía o grabación de acoso, interrupción sostenida "
+"de conversaciones u otros acontecimientos, contacto físico inapropiado y "
+"atención sexual no deseada."
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+"Se espera que los participantes a los que se les solicite detener cualquier "
+"comportamiento de acoso cumplan de inmediato."
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr "Denuncia de acoso"
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
+msgstr ""
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
 #: templates/global/menu.html:26
 msgid "Contribute"
 msgstr "Contribuir"
 
+#: templates/core/contribute.html:11
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgstr ""
+
 #: templates/core/contribute.html:22
 msgid "Support us!"
 msgstr "Apoyanos!"
+
+#: templates/core/contribute.html:31
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
+msgstr ""
+
+#: templates/core/contribute.html:39
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
+msgstr ""
 
 #: templates/core/contribute.html:46
 msgid "Organize!"
 msgstr "Organizar!"
 
+#: templates/core/contribute.html:54
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
+msgstr ""
+
+#: templates/core/contribute.html:61
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
+msgstr ""
+
 #: templates/core/contribute.html:72
 msgid "Coach!"
 msgstr "Entrenador!"
+
+#: templates/core/contribute.html:80
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
+msgstr ""
+
+#: templates/core/contribute.html:86
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
+msgstr ""
+
+#: templates/core/contribute.html:92
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
+msgstr ""
 
 #: templates/core/contribute.html:99
 msgid "Work on the website!"
@@ -1438,6 +2967,18 @@ msgstr "¡Trabaja en el sitio web!"
 msgid "Computer screen with a console and a webpage."
 msgstr "Pantalla de computadora con consola y página web."
 
+#: templates/core/contribute.html:107
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
+msgstr ""
+
+#: templates/core/contribute.html:113
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
+msgstr ""
+
 #: templates/core/contribute.html:123
 msgid "Fix the tutorial!"
 msgstr "¡Arregla el tutorial!"
@@ -1446,17 +2987,64 @@ msgstr "¡Arregla el tutorial!"
 msgid "A note book and a pen."
 msgstr "Un cuaderno y un bolígrafo."
 
+#: templates/core/contribute.html:131
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
+msgstr ""
+
+#: templates/core/contribute.html:136
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
+msgstr ""
+
 #: templates/core/contribute.html:140
 msgid "Translate the tutorial!"
 msgstr "Traduce el tutorial!"
 
 #: templates/core/contribute.html:143
 msgid "A computer screen saying hello and golden balloons saying yay!."
-msgstr "Una pantalla de computadora que dice hola y globos dorados que dicen ¡yay !."
+msgstr ""
+"Una pantalla de computadora que dice hola y globos dorados que dicen ¡yay !."
+
+#: templates/core/contribute.html:148
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
+msgstr ""
+
+#: templates/core/contribute.html:155
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgstr ""
+
+#: templates/core/contribute.html:166
+msgid "Help on Gitter!"
+msgstr ""
 
 #: templates/core/contribute.html:169
 msgid "A web page opened on a computer."
 msgstr "Una página web abierta en una computadora."
+
+#: templates/core/contribute.html:174
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
+msgstr ""
+
+#: templates/core/contribute.html:180
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
+msgstr ""
 
 #: templates/core/contribute.html:188
 msgid "Want to do more?"
@@ -1466,25 +3054,73 @@ msgstr "¿Quieres hacer más?"
 msgid "A pile a tattoo."
 msgstr "Un montón de tatuajes."
 
+#: templates/core/contribute.html:196
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
+msgstr ""
+
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
-msgstr "¡No olvide leer las reglas descritas en la primera columna antes de agregar una nueva tarjeta! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
+msgstr ""
+"¡No olvide leer las reglas descritas en la primera columna antes de agregar "
+"una nueva tarjeta! ❤"
 
 #: templates/core/crowdfunding_donors.html:11
 msgid "💖 Special thanks to all our amazing supporters! 💖"
-msgstr "💖 ¡Un agradecimiento especial a todos nuestros increíbles seguidores! 💖"
+msgstr ""
+"💖 ¡Un agradecimiento especial a todos nuestros increíbles seguidores! 💖"
+
+#: templates/core/crowdfunding_donors.html:15
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
+msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
 msgid "Our awesome supporters ✨"
 msgstr "Nuestros increíbles seguidores ✨"
 
+#: templates/core/event.html:23
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
+msgstr ""
+
+#: templates/core/event.html:48
+#, fuzzy, python-format
+#| msgid ""
+#| "It is important that all attendees comply with the <a href='/coc/'>Django "
+#| "Girls Code of Conduct</a>"
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
+msgstr ""
+"Es importante que todos los asistentes cumplan con la <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
+
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
-msgstr "Contactar con las organizadoras: <a href=\"mailto:%(email)s\">%(email)s</a>"
+msgstr ""
+"Contactar con las organizadoras: <a href=\"mailto:%(email)s\">%(email)s</a>"
 
 #: templates/core/events.html:10 templates/core/index.html:91
 msgid "Upcoming events"
 msgstr "Próximos eventos"
+
+#: templates/core/events.html:12 templates/core/index.html:93
+msgid "MAP"
+msgstr ""
 
 #: templates/core/events.html:30
 msgid "Past events"
@@ -1494,6 +3130,26 @@ msgstr "Eventos pasados"
 msgid "Django Girls events"
 msgstr "Eventos de Django Girls"
 
+#: templates/core/faq.html:4
+#, fuzzy
+#| msgid "Django Girls Store"
+msgid "Django Girls FAQ"
+msgstr "Tienda Django Girls"
+
+#: templates/core/faq.html:10
+#, fuzzy
+#| msgid "Frequently Asked Questions"
+msgid "FAQ: Frequently Asked Questions"
+msgstr "Preguntas frecuentes"
+
+#: templates/core/faq.html:14
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
+msgstr ""
+
 #: templates/core/faq.html:20
 msgid "Django Girls workshops"
 msgstr "Talleres de Django Girls"
@@ -1502,9 +3158,119 @@ msgstr "Talleres de Django Girls"
 msgid "Django Girls in general"
 msgstr "Django Girls en general"
 
+#: templates/core/faq.html:29
+#, fuzzy
+#| msgid "What is Django Girls?"
+msgid "Q: Isn't Django Girls sexist?"
+msgstr "¿Qué es Django Girls?"
+
+#: templates/core/faq.html:35
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
+msgstr ""
+
+#: templates/core/faq.html:52
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
+msgstr ""
+
+#: templates/core/faq.html:60
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
+msgstr ""
+
+#: templates/core/faq.html:71
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
+msgstr ""
+
+#: templates/core/faq.html:81
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
+msgstr ""
+
+#: templates/core/faq.html:92
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
+msgstr ""
+
+#: templates/core/faq.html:109
+#, fuzzy
+#| msgid "Django Girls events"
+msgid "Q: Are Django Girls events trans-inclusive?"
+msgstr "Eventos de Django Girls"
+
+#: templates/core/faq.html:114
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
+msgstr ""
+
 #: templates/core/faq.html:117
 msgid "We are trans-inclusive and welcome applications from all women."
-msgstr "Somos trans-inclusivos y damos la bienvenida a solicitudes de todas las mujeres."
+msgstr ""
+"Somos trans-inclusivos y damos la bienvenida a solicitudes de todas las "
+"mujeres."
+
+#: templates/core/faq.html:121
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
+msgstr ""
+
+#: templates/core/faq.html:142
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
+msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
 msgid "Django Girls Foundation"
@@ -1519,13 +3285,59 @@ msgstr "Documento de gobierno de la Fundación Django Girls"
 msgid "We inspire women to fall in love with programming."
 msgstr "Inspiramos a las mujeres a enamorarse de la programación."
 
+#: templates/core/index.html:17
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
+msgstr ""
+
 #: templates/core/index.html:29
 msgid "What is Django Girls?"
 msgstr "¿Qué es Django Girls?"
 
+#: templates/core/index.html:32
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
+msgstr ""
+
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
-msgstr "Durante cada uno de nuestros eventos, entre 30 y 60 mujeres construyen su primera aplicación web utilizando HTML, CSS, Python y Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
+msgstr ""
+"Durante cada uno de nuestros eventos, entre 30 y 60 mujeres construyen su "
+"primera aplicación web utilizando HTML, CSS, Python y Django."
+
+#: templates/core/index.html:53
+#, fuzzy
+#| msgid "Django Girls Contact"
+msgid "Django Girls impact"
+msgstr "Contacto de Django Girls"
+
+#: templates/core/index.html:56
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
+msgstr ""
+
+#: templates/core/index.html:64
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
+msgstr ""
 
 #: templates/core/index.html:69
 msgid "Read our Annual Report to learn about the impact we make"
@@ -1536,12 +3348,41 @@ msgid "Bring Django Girls to your city!"
 msgstr "¡Trae Django Girls a tu ciudad!"
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
-msgstr "¿No hay ningún evento de Django Girls en tu ciudad? ¡Tú puedes ayudar a que esto suceda!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
+msgstr ""
+"¿No hay ningún evento de Django Girls en tu ciudad? ¡Tú puedes ayudar a que "
+"esto suceda!"
+
+#: templates/core/index.html:76
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
+msgstr ""
+
+#: templates/core/index.html:82 templates/organize/index.html:89
+msgid "Apply to organize a workshop"
+msgstr ""
+
+#: templates/core/index.html:108
+#, fuzzy, python-format
+#| msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
+msgid "Show all %(future_events_count)s upcoming events"
+msgstr "Ver todos los <a href=\"%(events_url)s\"> próximos eventos</a>."
 
 #: templates/core/index.html:116
 msgid "Badass Django Ladies"
 msgstr "Chicas rudas de Django"
+
+#: templates/core/index.html:117
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
+msgstr ""
 
 #: templates/core/index.html:125
 msgid "Read all Django Stories"
@@ -1560,12 +3401,40 @@ msgid "Support our work"
 msgstr "Apoya nuestro trabajo"
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
-msgstr "Django Girls es una organización dirigida por voluntarios y dependemos de su apoyo para que esto suceda."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+"Django Girls es una organización dirigida por voluntarios y dependemos de su "
+"apoyo para que esto suceda."
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
 msgid "Make a recurring donation on Patreon"
 msgstr "Haz una donación recurrente en Patreon"
+
+#: templates/core/index.html:154
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
+msgstr ""
+
+#: templates/core/index.html:162
+msgid "Stay up to date!"
+msgstr ""
+
+#: templates/core/index.html:164
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
+msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
 msgid "email address"
@@ -1576,6 +3445,84 @@ msgstr "correo electrónico"
 msgid "Subscribe"
 msgstr "Suscribir"
 
+#: templates/core/index.html:180
+msgid "See the Django Girls Dispatch archives"
+msgstr ""
+
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr "¡Ya nos patrocinan! 💕"
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
+#: templates/core/index.html:220
+#, fuzzy
+#| msgid "They already sponsor us! 💕"
+msgid "They already support us! 💕"
+msgstr "¡Ya nos patrocinan! 💕"
+
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
+#: templates/core/newsletter.html:4
+#, fuzzy
+#| msgid "Django Girls in general"
+msgid "Django Girls Dispatch - Newsletter"
+msgstr "Django Girls en general"
+
+#: templates/core/newsletter.html:10
+#, fuzzy
+#| msgid "Django Girls Contact"
+msgid "Django Girls Dispatch"
+msgstr "Contacto de Django Girls"
+
+#: templates/core/newsletter.html:13
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
+msgstr ""
+
+#: templates/core/newsletter.html:25
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
+msgstr ""
+
 #: templates/core/newsletter.html:49
 msgid "Past editions"
 msgstr "Ediciones pasadas"
@@ -1585,8 +3532,30 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr "Políticas de privacidad y cookies del sitio web de Django Girls"
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
-msgstr "Esta Política se aplica a nuestro uso de todos y cada uno de los Datos recopilados por nosotros en relación con su uso del Sitio."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
+msgstr ""
+"Esta Política se aplica a nuestro uso de todos y cada uno de los Datos "
+"recopilados por nosotros en relación con su uso del Sitio."
+
+#: templates/core/privacy_cookies.html:14
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:20
+#, fuzzy
+#| msgid "<b>You</b> are a visitor to our Site"
+msgid "<b>You, Your</b> Are a visitor to the Site"
+msgstr "<b>Usted</b> es un visitante de nuestro sitio"
+
+#: templates/core/privacy_cookies.html:23
+#, fuzzy
+#| msgid "<b>Site</b> is djangogirls.org"
+msgid "<b>Site</b> djangogirls.org"
+msgstr "El <b>sitio</b> es djangogirls.org"
 
 #: templates/core/privacy_cookies.html:27
 msgid "Definitions and Interpretation"
@@ -1594,23 +3563,81 @@ msgstr "Definiciones e interpretación"
 
 #: templates/core/privacy_cookies.html:29
 msgid "In this Policy the following terms shall have the following meanings:"
-msgstr "En esta Política, los siguientes términos tendrán los siguientes significados:"
+msgstr ""
+"En esta Política, los siguientes términos tendrán los siguientes "
+"significados:"
+
+#: templates/core/privacy_cookies.html:33
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:38
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:43
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:48
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:53
+msgid "<b>User</b> means you or anyone who uses the Site."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:59
 msgid "Scope of this Policy"
 msgstr "Alcance de esta política"
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
-msgstr "Esta Política se aplica solo a las acciones de usted y nosotros al usar el Sitio. No se extiende a:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
+msgstr ""
+"Esta Política se aplica solo a las acciones de usted y nosotros al usar el "
+"Sitio. No se extiende a:"
+
+#: templates/core/privacy_cookies.html:64
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:71
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:74
 msgid "Data Collected"
 msgstr "Datos recolectados"
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
-msgstr "Sin limitación, el Sitio puede recopilar todos o cualquiera de los siguientes Datos de vez en cuando:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
+msgstr ""
+"Sin limitación, el Sitio puede recopilar todos o cualquiera de los "
+"siguientes Datos de vez en cuando:"
 
 #: templates/core/privacy_cookies.html:79
 msgid "name;"
@@ -1626,7 +3653,9 @@ msgstr "género;"
 
 #: templates/core/privacy_cookies.html:82
 msgid "contact information such as email addresses and telephone numbers;"
-msgstr "información de contacto como direcciones de correo electrónico y números de teléfono;"
+msgstr ""
+"información de contacto como direcciones de correo electrónico y números de "
+"teléfono;"
 
 #: templates/core/privacy_cookies.html:83
 msgid "demographic information such as post code, preferences and interests;"
@@ -1645,8 +3674,12 @@ msgid "operating system (automatically collected); and"
 msgstr "sistema operativo (recopilado automáticamente); y"
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
-msgstr "listas de URL que comienzan con un sitio de referencia, su actividad en el Sitio y el sitio al que sale (recopilado automáticamente)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
+msgstr ""
+"listas de URL que comienzan con un sitio de referencia, su actividad en el "
+"Sitio y el sitio al que sale (recopilado automáticamente)."
 
 #: templates/core/privacy_cookies.html:90
 msgid "Our Use of Data"
@@ -1656,9 +3689,30 @@ msgstr "Nuestro uso de datos"
 msgid "We will keep any personal Data you submit for 60 months."
 msgstr "Conservaremos los datos personales que envíe durante 60 meses."
 
+#: templates/core/privacy_cookies.html:95
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:101
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:106
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
+msgstr ""
+
 #: templates/core/privacy_cookies.html:108
 msgid "Specifically, Data may be used by us for the following reasons:"
-msgstr "Específicamente, los datos pueden ser utilizados por nosotros por las siguientes razones:"
+msgstr ""
+"Específicamente, los datos pueden ser utilizados por nosotros por las "
+"siguientes razones:"
 
 #: templates/core/privacy_cookies.html:110
 msgid "internal record keeping;"
@@ -1668,42 +3722,250 @@ msgstr "mantenimiento de registros internos;"
 msgid "improvement of our products / services;"
 msgstr "mejora de nuestros productos / servicios;"
 
+#: templates/core/privacy_cookies.html:112
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:113
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:114
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
+msgstr ""
+
 #: templates/core/privacy_cookies.html:115
 msgid "to customise or update the Site."
 msgstr "para personalizar o actualizar el Sitio."
+
+#: templates/core/privacy_cookies.html:118
+msgid "Third Party Sites and Services"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:121
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:129
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:136
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:142
 msgid "Links to Other Websites"
 msgstr "Enlaces a otros sitios web"
 
+#: templates/core/privacy_cookies.html:145
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
+msgstr ""
+
 #: templates/core/privacy_cookies.html:151
 msgid "Changes of Business Ownership and Control"
 msgstr "Cambios de propiedad y control de la empresa"
+
+#: templates/core/privacy_cookies.html:154
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:161
+msgid "If we do transfer Data for this reason we will not tell you in advance."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:163
 msgid "Controlling Use of Your Data"
 msgstr "Control del uso de sus datos"
 
+#: templates/core/privacy_cookies.html:164
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:167
+msgid "use of Data for direct marketing purposes; and"
+msgstr ""
+
 #: templates/core/privacy_cookies.html:168
 msgid "sharing Data with third parties."
 msgstr "compartir datos con terceros."
+
+#: templates/core/privacy_cookies.html:170
+msgid "We do not use any of your data to profile you."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:172
+msgid "Your Right to Withhold Information"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:174
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:176
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:178
+msgid "Accessing Your Own Data"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:180
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:182
 msgid "Security"
 msgstr "Seguridad"
 
+#: templates/core/privacy_cookies.html:184
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:186
+msgid "Cookies"
+msgstr ""
+
+#: templates/core/privacy_cookies.html:188
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:190
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:192
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:194
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:196
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:198
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
+msgstr ""
+
 #: templates/core/privacy_cookies.html:201
 msgid "You can choose to enable or disable Cookies in your internet browser."
-msgstr "Puede optar por habilitar o deshabilitar las cookies en su navegador de Internet."
+msgstr ""
+"Puede optar por habilitar o deshabilitar las cookies en su navegador de "
+"Internet."
+
+#: templates/core/privacy_cookies.html:202
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:203
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:204
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
+msgstr ""
+
+#: templates/core/privacy_cookies.html:208
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
+msgstr ""
 
 #: templates/core/privacy_cookies.html:214
 msgid "Changes to this Policy"
 msgstr "Cambios a esta política"
 
+#: templates/core/privacy_cookies.html:217
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
+msgstr ""
+
 #: templates/core/resources.html:9 templates/global/footer.html:39
 #: templates/global/menu.html:21
 msgid "Resources"
 msgstr "Recursos"
+
+#: templates/core/resources.html:11
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
+msgstr ""
 
 #: templates/core/resources.html:22
 msgid "Django Tutorial"
@@ -1714,21 +3976,88 @@ msgid "Tutorial Django Girls"
 msgstr "Tutorial de Django Girls"
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
-msgstr "El tutorial que estamos usando para todos nuestros talleres. Es un tutorial muy amigable para principiantes con introducciones a la línea de comandos, Python, Django, HTML y CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
+msgstr ""
+"El tutorial que estamos usando para todos nuestros talleres. Es un tutorial "
+"muy amigable para principiantes con introducciones a la línea de comandos, "
+"Python, Django, HTML y CSS."
+
+#: templates/core/resources.html:35 templates/core/resources.html:55
+#: templates/core/resources.html:77 templates/core/resources.html:97
+#, fuzzy
+#| msgid "Read all"
+msgid "Read it"
+msgstr "Lee todo"
 
 #: templates/core/resources.html:42 templates/global/footer.html:42
 msgid "Organizer's Manual"
 msgstr "Manual del organizador"
 
+#: templates/core/resources.html:45
+#, fuzzy
+#| msgid "Yes, I organized Django Girls"
+msgid "Organize Django Girls"
+msgstr "Sí, organicé Django Girls"
+
+#: templates/core/resources.html:50
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
+msgstr ""
+
+#: templates/core/resources.html:67
+#, fuzzy
+#| msgid "Contact Django Girls"
+msgid "Coaching Guide Django Girls"
+msgstr "Póngase en contacto con Django Girls"
+
+#: templates/core/resources.html:72
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
+msgstr ""
+
 #: templates/core/resources.html:84 templates/global/footer.html:44
 msgid "Tutorial Extensions"
 msgstr "Extensiones de tutoriales"
+
+#: templates/core/resources.html:87
+#, fuzzy
+#| msgid "Tutorial Django Girls"
+msgid "Tutorial Extensions Django Girls"
+msgstr "Tutorial de Django Girls"
+
+#: templates/core/resources.html:92
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
+msgstr ""
 
 #: templates/core/terms_conditions.html:4
 #: templates/core/terms_conditions.html:11
 msgid "Terms and Conditions of use of Django Girls Website"
 msgstr "Términos y condiciones de uso del sitio web de Django Girls"
+
+#: templates/core/terms_conditions.html:5
+#: templates/core/terms_conditions.html:22
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
+msgstr ""
+
+#: templates/core/terms_conditions.html:14
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
+msgstr ""
 
 #: templates/core/terms_conditions.html:18
 msgid "<b>Site</b> is djangogirls.org"
@@ -1738,9 +4067,26 @@ msgstr "El <b>sitio</b> es djangogirls.org"
 msgid "<b>You</b> are a visitor to our Site"
 msgstr "<b>Usted</b> es un visitante de nuestro sitio"
 
+#: templates/core/terms_conditions.html:29
+msgid "By entering our site you are accepting these T&Cs"
+msgstr ""
+
+#: templates/core/terms_conditions.html:33
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
+msgstr ""
+
 #: templates/core/terms_conditions.html:39
 msgid "Agreement"
 msgstr "Convenio"
+
+#: templates/core/terms_conditions.html:41
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
+msgstr ""
 
 #: templates/core/terms_conditions.html:44
 msgid "Definition"
@@ -1754,207 +4100,2001 @@ msgstr "Hay algunas definiciones al final de la página."
 msgid "You promise us:"
 msgstr "Nos prometes:"
 
+#: templates/core/terms_conditions.html:49
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
+msgstr ""
+
+#: templates/core/terms_conditions.html:50
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
+msgstr ""
+
+#: templates/core/terms_conditions.html:51
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:52
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
+msgstr ""
+
+#: templates/core/terms_conditions.html:53
+msgid "That you won’t do anything that might cause our systems to crash."
+msgstr ""
+
+#: templates/core/terms_conditions.html:54
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:55
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:56
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
+msgstr ""
+
 #: templates/core/terms_conditions.html:59
 msgid "Intellectual property"
 msgstr "Propiedad intelectual"
+
+#: templates/core/terms_conditions.html:60
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:63
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
+msgstr ""
 
 #: templates/core/terms_conditions.html:71
 msgid "Price and payment"
 msgstr "Precio y pago"
 
+#: templates/core/terms_conditions.html:73
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
+msgstr ""
+
+#: templates/core/terms_conditions.html:80
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
+msgstr ""
+
 #: templates/core/terms_conditions.html:86
 msgid "Use of communications facilities"
 msgstr "Uso de instalaciones de comunicaciones"
 
+#: templates/core/terms_conditions.html:88
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
+msgstr ""
+
+#: templates/core/terms_conditions.html:90
+msgid "you must not use language that may be offensive to other Users;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:91
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:92
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:93
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
+msgstr ""
+
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
-msgstr "no debe publicar enlaces a otros sitios que contengan cualquiera de los tipos de contenido anteriores;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
+msgstr ""
+"no debe publicar enlaces a otros sitios que contengan cualquiera de los "
+"tipos de contenido anteriores;"
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
-msgstr "los medios por los que se identifica no deben violar estos T&Cs ni ninguna ley aplicable;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
+msgstr ""
+"los medios por los que se identifica no deben violar estos T&Cs ni ninguna "
+"ley aplicable;"
+
+#: templates/core/terms_conditions.html:96
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:97
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:98
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
+msgstr ""
+
+#: templates/core/terms_conditions.html:99
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
+msgstr ""
+
+#: templates/core/terms_conditions.html:102
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
+msgstr ""
+
+#: templates/core/terms_conditions.html:104
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
+msgstr ""
+
+#: templates/core/terms_conditions.html:107
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
+msgstr ""
+
+#: templates/core/terms_conditions.html:114
+msgid "Privacy and cookies"
+msgstr ""
+
+#: templates/core/terms_conditions.html:118
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
+msgstr ""
+
+#: templates/core/terms_conditions.html:123
+msgid "Disclaimers"
+msgstr ""
+
+#: templates/core/terms_conditions.html:125
+msgid "We have tried to make sure of the following things:"
+msgstr ""
+
+#: templates/core/terms_conditions.html:128
+msgid "that the Site will meet your needs;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:129
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:130
+msgid "that the Site always works properly;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:131
+msgid "that the Site is fit for the purpose you need;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:132
+msgid "that the Site doesn’t infringe the rights of others;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:133
+msgid "that the Site will work with all systems; and"
+msgstr ""
+
+#: templates/core/terms_conditions.html:134
+msgid "that the Site is secure,"
+msgstr ""
+
+#: templates/core/terms_conditions.html:137
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
+msgstr ""
+
+#: templates/core/terms_conditions.html:140
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
+msgstr ""
+
+#: templates/core/terms_conditions.html:147
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
+msgstr ""
+
+#: templates/core/terms_conditions.html:150
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
+msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
 msgid "Events"
 msgstr "Eventos"
 
+#: templates/core/terms_conditions.html:160
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
+msgstr ""
+
+#: templates/core/terms_conditions.html:162
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
+msgstr ""
+
+#: templates/core/terms_conditions.html:164
+msgid "Problems"
+msgstr ""
+
+#: templates/core/terms_conditions.html:166
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
+msgstr ""
+
+#: templates/core/terms_conditions.html:168
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
+msgstr ""
+
+#: templates/core/terms_conditions.html:170
+msgid "Availability of the site"
+msgstr ""
+
+#: templates/core/terms_conditions.html:172
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
+msgstr ""
+
+#: templates/core/terms_conditions.html:174
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
+msgstr ""
+
+#: templates/core/terms_conditions.html:176
+msgid "Limitation of liability"
+msgstr ""
+
+#: templates/core/terms_conditions.html:178
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
+msgstr ""
+
+#: templates/core/terms_conditions.html:180
+msgid "You use the Site and its Content at your own risk."
+msgstr ""
+
+#: templates/core/terms_conditions.html:182
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
+msgstr ""
+
+#: templates/core/terms_conditions.html:184
+msgid "Linking"
+msgstr ""
+
+#: templates/core/terms_conditions.html:186
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
+msgstr ""
+
+#: templates/core/terms_conditions.html:188
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:190
+msgid "We can never guarantee that a link will work."
+msgstr ""
+
+#: templates/core/terms_conditions.html:192
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
+msgstr ""
+
+#: templates/core/terms_conditions.html:194
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
+msgstr ""
+
+#: templates/core/terms_conditions.html:196
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
+msgstr ""
+
+#: templates/core/terms_conditions.html:199
+msgid "the link mustn’t damage our reputation;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:200
+msgid "the link must be fair and legal;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:201
+msgid "you can only link from a site that you own;"
+msgstr ""
+
+#: templates/core/terms_conditions.html:202
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
+msgstr ""
+
+#: templates/core/terms_conditions.html:203
+msgid "you mustn’t frame our Site on any other site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:206
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
+msgstr ""
+
+#: templates/core/terms_conditions.html:208
+msgid "Modifications to these T&Cs & the site"
+msgstr ""
+
+#: templates/core/terms_conditions.html:211
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
+msgstr ""
+
+#: templates/core/terms_conditions.html:219
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
+msgstr ""
+
+#: templates/core/terms_conditions.html:221
+msgid "General stuff"
+msgstr ""
+
+#: templates/core/terms_conditions.html:224
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
+msgstr ""
+
+#: templates/core/terms_conditions.html:225
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
+msgstr ""
+
+#: templates/core/terms_conditions.html:226
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
+msgstr ""
+
+#: templates/core/terms_conditions.html:227
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
+msgstr ""
+
+#: templates/core/terms_conditions.html:228
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
+msgstr ""
+
+#: templates/core/terms_conditions.html:229
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
+msgstr ""
+
+#: templates/core/terms_conditions.html:230
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
+msgstr ""
+
+#: templates/core/terms_conditions.html:231
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
+msgstr ""
+
+#: templates/core/terms_conditions.html:232
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
+msgstr ""
+
+#: templates/core/terms_conditions.html:235
+msgid "The Schedule"
+msgstr ""
+
+#: templates/core/terms_conditions.html:237
+#, fuzzy
+#| msgid "Definition"
+msgid "Definitions"
+msgstr "Definición"
+
+#: templates/core/terms_conditions.html:239
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
+msgstr ""
+
+#: templates/core/terms_conditions.html:240
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:242
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:244
+msgid "<b>Organiser</b> means the organiser or promoter of an Event."
+msgstr ""
+
+#: templates/core/terms_conditions.html:247
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
+msgstr ""
+
+#: templates/core/terms_conditions.html:253
+msgid "<b>T&Cs</b> means these terms and conditions."
+msgstr ""
+
+#: templates/core/terms_conditions.html:255
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
+msgstr ""
+
+#: templates/core/workshop_box.html:9
+#, fuzzy
+#| msgid "Bring Django Girls to your city!"
+msgid "Order Django Girls Workshop Box for your event!"
+msgstr "¡Trae Django Girls a tu ciudad!"
+
+#: templates/core/workshop_box.html:11
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
+msgstr ""
+
+#: templates/core/workshop_box.html:27
+msgid "How it works?"
+msgstr ""
+
+#: templates/core/workshop_box.html:29
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
+msgstr ""
+
+#: templates/core/workshop_box.html:37
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
+msgstr ""
+
+#: templates/core/workshop_box.html:44
+#, fuzzy
+#| msgid "What's that?"
+msgid "What's in the box?"
+msgstr "¿Que es eso?"
+
+#: templates/core/workshop_box.html:46
+msgid "The shiny beautiful envelope contains many awesome things:"
+msgstr ""
+
+#: templates/core/workshop_box.html:49
+#, fuzzy
+#| msgid "Django Girls Contact"
+msgid "Django Girls logo stickers"
+msgstr "Contacto de Django Girls"
+
+#: templates/core/workshop_box.html:50
+msgid "YAY! stickers"
+msgstr ""
+
+#: templates/core/workshop_box.html:51
+msgid "Pixel Heart stickers"
+msgstr ""
+
+#: templates/core/workshop_box.html:52
+msgid "Some stickers from our global partners"
+msgstr ""
+
+#: templates/core/workshop_box.html:53
+msgid "Gold letters DJANGOGIRLS balloons, 16 inches tall"
+msgstr ""
+
+#: templates/core/workshop_box.html:54
+#, fuzzy
+#| msgid "Bring Django Girls to your city!"
+msgid "Orange Django Girls logo buttons"
+msgstr "¡Trae Django Girls a tu ciudad!"
+
+#: templates/core/workshop_box.html:55
+msgid "Little surprise, sometimes, maybe? 😄"
+msgstr ""
+
+#: templates/core/workshop_box.html:60
+msgid "How much is it?"
+msgstr ""
+
+#: templates/core/workshop_box.html:61
+msgid "The price will depend of your workshop's size. For example:"
+msgstr ""
+
+#: templates/core/workshop_box.html:63
+msgid "£30 GBP for 30 people"
+msgstr ""
+
+#: templates/core/workshop_box.html:64
+msgid "£40 GBP for 50 people"
+msgstr ""
+
+#: templates/core/workshop_box.html:65
+msgid "£65 GBP for 100 people"
+msgstr ""
+
+#: templates/core/workshop_box.html:68
+msgid "You will also need to add shipping costs. 📮"
+msgstr ""
+
+#: templates/core/workshop_box.html:71
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
+msgstr ""
+
+#: templates/core/workshop_box.html:78
+#, fuzzy
+#| msgid "How old are you?"
+msgid "How to get one?"
+msgstr "¿Cuantos años tienes?"
+
+#: templates/core/workshop_box.html:80
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
+msgstr ""
+
+#: templates/core/workshop_box.html:86
+msgid "Requirements to apply for a free box:"
+msgstr ""
+
+#: templates/core/workshop_box.html:88
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
+msgstr ""
+
+#: templates/core/workshop_box.html:89
+msgid "You need to have a venue for your workshop"
+msgstr ""
+
+#: templates/core/workshop_box.html:90
+#, fuzzy
+#| msgid "Application process is open until"
+msgid "Application process for your event needs to be open"
+msgstr "El proceso de solicitud está abierto hasta"
+
+#: templates/core/workshop_box.html:91
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
+msgstr ""
+
+#: templates/core/workshop_box.html:94
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
+msgstr ""
+
+#: templates/default/about.html:4
+msgid "Free programming workshop for women"
+msgstr ""
+
+#: templates/default/about.html:5
+msgid "Build your first website at EuroPython 2014 in Berlin!"
+msgstr ""
+
+#: templates/default/about.html:6
+msgid "Learn more"
+msgstr ""
+
+#: templates/default/apply.html:5
+#, fuzzy
+#| msgid "Applications have been updated"
+msgid "Applications are now open!"
+msgstr "Se han actualizado las aplicaciones"
+
+#: templates/default/apply.html:7
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
+msgstr ""
+
+#: templates/default/apply.html:10
+msgid "Register"
+msgstr ""
+
+#: templates/default/coach.html:5
+msgid "Be a Mentor!"
+msgstr ""
+
+#: templates/default/coach.html:8
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+msgstr ""
+
+#: templates/default/coach.html:16 templates/default/values.html:5
+#, fuzzy
+#| msgid "Django Girls Store"
+msgid "Django Girls"
+msgstr "Tienda Django Girls"
+
+#: templates/default/coach.html:18
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
+msgstr ""
+
+#: templates/default/coach.html:24
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgstr ""
+
+#: templates/default/coach.html:30
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
+msgstr ""
+
+#: templates/default/faq.html:6
+msgid "Do I need to know anything about websites or programming?"
+msgstr ""
+
+#: templates/default/faq.html:9
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
+msgstr ""
+
+#: templates/default/faq.html:18
+msgid "I am not living in Germany, can I attend?"
+msgstr ""
+
+#: templates/default/faq.html:21
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
+msgstr ""
+
+#: templates/default/faq.html:31
+msgid "Should I bring my own laptop?"
+msgstr ""
+
+#: templates/default/faq.html:34
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
+msgstr ""
+
+#: templates/default/faq.html:45
+msgid "Do I need to have something installed on my laptop?"
+msgstr ""
+
+#: templates/default/faq.html:48
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
+msgstr ""
+
+#: templates/default/faq.html:58
+msgid "Is EuroPython conference good for a total beginner?"
+msgstr ""
+
+#: templates/default/faq.html:61
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
+msgstr ""
+
+#: templates/default/faq.html:70
+msgid "Is food provided?"
+msgstr ""
+
+#: templates/default/faq.html:71
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgstr ""
+
+#: templates/default/footer.html:39
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
+msgstr ""
+
+#: templates/default/partners.html:3
+#, fuzzy
+#| msgid "Sponsors 📢️"
+msgid "Sponsors"
+msgstr "Patrocinadores 📢️"
+
+#: templates/default/partners.html:7
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
+msgstr ""
+
+#: templates/default/values.html:7
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
+msgstr ""
+
+#: templates/default/values.html:11
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
+msgstr ""
+
+#: templates/default/values.html:15
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
+msgstr ""
+
+#: templates/default/values.html:22
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
+msgstr ""
+
+#: templates/default/values.html:33
+#, fuzzy
+#| msgid "Apply for a pass!"
+msgid "Apply for the workshop!"
+msgstr "¡Solicite un pase!"
+
+#: templates/default/values.html:35
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
+msgstr ""
+
+#: templates/default/values.html:43
+msgid "As a workshop attendee you will:"
+msgstr ""
+
+#: templates/default/values.html:46
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
+msgstr ""
+
+#: templates/default/values.html:48
+msgid "be fed by us: during our event, food is provided"
+msgstr ""
+
+#: templates/default/values.html:53
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
+msgstr ""
+
+#: templates/donations/donate.html:13
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Why give to the Django Girls Foundation?"
+msgstr "Fundación Django Girls"
+
+#: templates/donations/donate.html:19
+#, fuzzy
+#| msgid "Permissions"
+msgid "Our mission:"
+msgstr "Permisos"
+
+#: templates/donations/donate.html:22
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
+msgstr ""
+
+#: templates/donations/donate.html:30
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
+msgstr ""
+
+#: templates/donations/donate.html:38
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
+msgstr ""
+
+#: templates/donations/donate.html:47
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
+msgstr ""
+
+#: templates/donations/donate.html:54
+msgid "A woman looking at her laptop during Django Girls Lagos 2016."
+msgstr ""
+
+#: templates/donations/donate.html:62
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Start supporting Django Girls Foundation today 💕"
+msgstr "Fundación Django Girls"
+
+#: templates/donations/donate.html:68
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "Monthly donations"
+msgstr "Donaciones de Patreon"
+
+#: templates/donations/donate.html:75
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgstr ""
+
+#: templates/donations/donate.html:83
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/donate.html:105
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "One-time donations"
+msgstr "Donaciones de Patreon"
+
+#: templates/donations/donate.html:107
+#, fuzzy
+#| msgid ""
+#| "If you want to contact the organizers of this event, you can email them "
+#| "at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|"
+#| "lower)s@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgstr ""
+"Si deseas ponerte en contacto con los organizadores de este evento, puede "
+"enviarles un correo electrónico a <a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
+
+#: templates/donations/donate.html:114
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+msgstr ""
+
+#: templates/donations/donate.html:121
+msgid "Donate now"
+msgstr ""
+
+#: templates/donations/donate.html:130
+msgid "Credit or debit card"
+msgstr ""
+
+#: templates/donations/donate.html:146
+msgid "Other ways of supporting us"
+msgstr ""
+
+#: templates/donations/donate.html:147
+msgid "Humble Bundle Store"
+msgstr ""
+
+#: templates/donations/donate.html:149
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
+msgstr ""
+
+#: templates/donations/donate.html:161
+#, fuzzy
+#| msgid "They already sponsor us! 💕"
+msgid "They already support us:"
+msgstr "¡Ya nos patrocinan! 💕"
+
+#: templates/donations/donate.html:170
+msgid "Our current projects that will benefit from your help"
+msgstr ""
+
+#: templates/donations/donate.html:171
+#, fuzzy
+#| msgid "Django Girls events"
+msgid "Django Girls Awesomeness Ambassador:"
+msgstr "Eventos de Django Girls"
+
+#: templates/donations/donate.html:174
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
+msgstr ""
+
+#: templates/donations/donate.html:182
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
+msgstr ""
+
+#: templates/donations/donate.html:191 templates/donations/donate.html:211
+msgid "Your donations will help us make her position secure."
+msgstr ""
+
+#: templates/donations/donate.html:193
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Django Girls Fundraising Coordinator:"
+msgstr "Fundación Django Girls"
+
+#: templates/donations/donate.html:196
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
+msgstr ""
+
+#: templates/donations/donate.html:205
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
+msgstr ""
+
+#: templates/donations/donate.html:213
+#, fuzzy
+#| msgid "Django Girls Store"
+msgid "Django Girls Summit:"
+msgstr "Tienda Django Girls"
+
+#: templates/donations/donate.html:216
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
+msgstr ""
+
+#: templates/donations/donate.html:223
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
+msgstr ""
+
+#: templates/donations/error.html:7
+msgid "Error"
+msgstr ""
+
+#: templates/donations/error.html:9
+msgid "Sorry, an error has occurred"
+msgstr ""
+
+#: templates/donations/error.html:15 templates/donations/success.html:13
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "Back to donation page"
+msgstr "Donaciones de Patreon"
+
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
+#: templates/donations/success.html:8
+#, python-format
+msgid "Thank you for your contribution of %(currency)s%(amount)s!"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:3
+#, python-format
+msgid "Hello team %(city)s!"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:5
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:8
+#, fuzzy
+#| msgid "Numbers 📈🗺"
+msgid "Numbers"
+msgstr "Números 📈🗺"
+
+#: templates/emails/event_thank_you.html:10
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:17
+msgid "Tell us how it went!"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:18
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:22
+msgid "Share your experiences"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:23
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:27
+msgid "Upload your photos"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:28
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
+msgstr ""
+
+#: templates/emails/event_thank_you.html:32
+#, fuzzy
+#| msgid "PGOpen Donation"
+msgid "Donation"
+msgstr "Donación PGOpen"
+
+#: templates/emails/event_thank_you.html:34
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
+msgstr ""
+
+#: templates/emails/event_thank_you.html:41
+msgid "Discount in our store"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:42
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
+msgstr ""
+
+#: templates/emails/event_thank_you.html:49
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+msgstr ""
+
+#: templates/emails/event_thank_you.html:55
+msgid "Thanks and congrats yet again, you're awesome!"
+msgstr ""
+
+#: templates/emails/event_thank_you.html:58
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
+#: templates/emails/organize/application_confirmation.html:36
+#: templates/emails/organize/event_deployed.html:94
+#: templates/emails/submit_information_email.html:16
+msgid "Hugs, rainbows and sunshines!"
+msgstr ""
+
+#: templates/emails/existing_user.html:3 templates/emails/new_user.html:3
+#: templates/emails/organize/event_deployed.html:3
+msgid "Hi there!"
+msgstr ""
+
+#: templates/emails/existing_user.html:5
+#, python-format
+msgid "Congrats! You can now manage %(event)s event!"
+msgstr ""
+
+#: templates/emails/existing_user.html:7
+#, python-format
+msgid "The website address is https://djangogirls.org/%(page_url)s"
+msgstr ""
+
+#: templates/emails/existing_user.html:10
+msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
+msgstr ""
+
+#: templates/emails/existing_user.html:17
+#, python-format
+msgid "Email: %(email)s<br /> Use your existing password."
+msgstr ""
+
+#: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
+msgstr ""
+
+#: templates/emails/existing_user.html:26
+#, python-format
+msgid ""
+"\n"
+"    Your event's email is %(email)s. Ask the main organizer of you event\n"
+"    for password and instructions to access it.\n"
+msgstr ""
+
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
+msgstr ""
+
+#: templates/emails/new_user.html:5
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
+msgstr ""
+
+#: templates/emails/new_user.html:7
+#, python-format
+msgid "Your website address is https://djangogirls.org/%(page_url)s"
+msgstr ""
+
+#: templates/emails/new_user.html:10
+msgid "Login here:<br /> https://djangogirls.org/admin/"
+msgstr ""
+
+#: templates/emails/new_user.html:17
+#, python-format
+msgid ""
+"\n"
+"  Email: %(email)s<br />\n"
+"  Password: %(password)s\n"
+msgstr ""
+
+#: templates/emails/new_user.html:26
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
+msgstr ""
+
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
+msgstr ""
+
+#: templates/emails/offer_help_email.html:3
+#, python-format
+msgid "Hi team %(event)s!"
+msgstr ""
+
+#: templates/emails/offer_help_email.html:5
+msgid "How are you? We hope you are doing fantastic! :)"
+msgstr ""
+
+#: templates/emails/offer_help_email.html:8
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
+msgstr ""
+
+#: templates/emails/offer_help_email.html:14
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
+msgstr ""
+
+#: templates/emails/offer_help_email.html:17
+msgid "Hugs, cupcakes and sparkles"
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:3
+msgid "Hello,"
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:10
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:16
+msgid "There are three requirements for becoming an organizer of Django Girls:"
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:18
+msgid "Being an awesome person - already done! :)"
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:20
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:25
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:3
+#: templates/emails/organize/application_notification.html:64
+#, fuzzy
+#| msgid "Action"
+msgid "Actions"
+msgstr "Acción"
+
+#: templates/emails/organize/application_notification.html:4
+#: templates/emails/organize/application_notification.html:65
+#, fuzzy
+#| msgid "Reject application"
+msgid "See application"
+msgstr "Rechazar solicitud"
+
+#: templates/emails/organize/application_notification.html:6
+#, fuzzy
+msgid "Event information"
+msgstr "Confirmación de contraseña"
+
+#: templates/emails/organize/application_notification.html:8
+msgid "Previously organized event:"
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:12
+msgid "Date:"
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:16
+#, fuzzy
+#| msgid "Action"
+msgid "Location:"
+msgstr "Acción"
+
+#: templates/emails/organize/application_notification.html:20
+#, fuzzy
+#| msgid "Organize"
+msgid "Organizers"
+msgstr "Organizar"
+
+#: templates/emails/organize/application_notification.html:22
+#, fuzzy
+#| msgid "Add organizer"
+msgid "Lead organizer:"
+msgstr "Agregar organizador"
+
+#: templates/emails/organize/application_notification.html:26
+#, fuzzy
+#| msgid "Team"
+msgid "Team:"
+msgstr "Equipo"
+
+#: templates/emails/organize/application_notification.html:36
+#: templates/organize/form/step2_application.html:38
+#, fuzzy
+#| msgid "How old are you?"
+msgid "Who are you?"
+msgstr "¿Cuantos años tienes?"
+
+#: templates/emails/organize/application_notification.html:40
+#: templates/organize/form/step2_application.html:55
+#, fuzzy
+#| msgid "Why do you want to attend the workshop?"
+msgid "Why do you want to organize a Django Girls workshop?"
+msgstr "¿Por qué quieres asistir al taller?"
+
+#: templates/emails/organize/application_notification.html:44
+#: templates/organize/form/step2_application.html:72
+#, fuzzy
+#| msgid "I've never been to a Django Girls event"
+msgid "Have you been involved in Django Girls before?"
+msgstr "Nunca he estado en un evento de Django Girls"
+
+#: templates/emails/organize/application_notification.html:48
+#: templates/organize/form/step2_application.html:94
+msgid "Have you organized any other event before?"
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:52
+#: templates/organize/form/step5_workshop.html:103
+msgid "Do you have a venue in mind?"
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:56
+msgid "Do you have a plan which companies will you approach for sponsorship?"
+msgstr ""
+
+#: templates/emails/organize/application_notification.html:60
+#: templates/organize/form/step5_workshop.html:139
+#: templates/organize/form/step5_workshop_remote.html:121
+msgid "Do you have potential coaches in mind?"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:6
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:9
+msgid "Below you can find all details and access to your chapter."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:11
+#, fuzzy
+#| msgid "E-mail address"
+msgid "1) Email address"
+msgstr "Correo electrónico"
+
+#: templates/emails/organize/event_deployed.html:13
+#, fuzzy, python-format
+#| msgid "Your e-mail address:"
+msgid "Your e-mail is %(email)s."
+msgstr "Tu dirección de correo electrónico:"
+
+#: templates/emails/organize/event_deployed.html:16
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
+"    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:22
+#, fuzzy
+#| msgid "Password"
+msgid "Password:"
+msgstr "Contraseña"
+
+#: templates/emails/organize/event_deployed.html:24
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:30
+msgid "You can also add this inbox to your email client:"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:36
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:39
+#, fuzzy
+#| msgid "Event website"
+msgid "2) Website"
+msgstr "Sitio web del evento"
+
+#: templates/emails/organize/event_deployed.html:42
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:48
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:52
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:59
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:65
+msgid "3) Organizers community"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:67
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:73
+msgid "4) Postponing or canceling"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:82
+msgid "5) Need more help?"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:91
+msgid "Good luck!"
+msgstr ""
+
+#: templates/emails/organize/event_deployed.html:95
+#, fuzzy
+#| msgid "Django Girls Store"
+msgid "Django Girls team"
+msgstr "Tienda Django Girls"
+
+#: templates/emails/organize/rejection.html:3
+msgid "Hello there,"
+msgstr ""
+
+#: templates/emails/organize/rejection.html:6
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
+msgstr ""
+
+#: templates/emails/organize/rejection.html:12
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
+msgstr ""
+
+#: templates/emails/organize/rejection.html:25
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
+msgstr ""
+
+#: templates/emails/organize/rejection.html:29
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
+msgstr ""
+
+#: templates/emails/submit_information_email.html:3
+#, python-format
+msgid "Hello team %(event)s!"
+msgstr ""
+
+#: templates/emails/submit_information_email.html:5
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
+msgstr ""
+
+#: templates/emails/submit_information_email.html:9
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
+msgstr ""
+
+#: templates/event/base.html:15 templates/global/base.html:15
+msgid "Django Girls - start your journey with programming"
+msgstr ""
+
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
+msgstr ""
+
+#: templates/event/menu.html:7 templates/global/menu.html:7
+msgid "Toggle navigation"
+msgstr ""
+
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
+msgstr ""
+
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
+msgstr ""
+
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
+msgstr ""
+
+#: templates/global/footer.html:10
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Foundation"
+msgstr "Fundación Django Girls"
+
 #: templates/global/footer.html:11 templates/global/menu.html:23
 msgid "Newsletter"
 msgstr "Boletín informativo"
+
+#: templates/global/footer.html:12
+msgid "Chat with us!"
+msgstr ""
+
+#: templates/global/footer.html:14
+msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
+msgstr ""
+
+#: templates/global/footer.html:20
+#, fuzzy
+#| msgid "Support us!"
+msgid "Support us"
+msgstr "Apoyanos!"
+
+#: templates/global/footer.html:22
+#, fuzzy
+#| msgid "Patreon donations"
+msgid "Make a donation"
+msgstr "Donaciones de Patreon"
+
+#: templates/global/footer.html:23
+msgid "Donate on Patreon"
+msgstr ""
+
+#: templates/global/footer.html:25
+#, fuzzy
+#| msgid "Sponsors 📢️"
+msgid "Sponsor us"
+msgstr "Patrocinadores 📢️"
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
+msgstr ""
+
+#: templates/global/footer.html:30
+#, fuzzy
+#| msgid "Comment"
+msgid "Community"
+msgstr "Comentario"
+
+#: templates/global/footer.html:41
+#, fuzzy
+#| msgid "Django Tutorial"
+msgid "Tutorial"
+msgstr "Tutorial de Django"
+
+#: templates/global/footer.html:43
+msgid "Coaching Guide"
+msgstr ""
+
+#: templates/global/footer.html:45
+msgid "Graphics"
+msgstr ""
+
+#: templates/global/footer.html:52
+msgid "Terms & Conditions"
+msgstr ""
+
+#: templates/global/footer.html:53
+msgid "Privacy & Cookies"
+msgstr ""
+
+#: templates/global/footer.html:60
+#, python-format
+msgid "<b>%(future_events_count)s</b> upcoming events"
+msgstr ""
+
+#: templates/global/footer.html:61
+#, python-format
+msgid "<b>%(past_events_count)s</b> past events"
+msgstr ""
+
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
+msgstr ""
+
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
+msgstr ""
+
+#: templates/global/footer.html:64
+#, python-format
+msgid "<b>%(countries_count)s</b> countries"
+msgstr ""
 
 #: templates/global/menu.html:22
 msgid "Organize"
 msgstr "Organizar"
 
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr "El evento que estás organizando será remoto"
+#: templates/global/menu.html:24
+msgid "Blog"
+msgstr ""
 
-#: templates/organize/prerequisites.html:51
-msgid "Introduction to Organizer’s Manual"
-msgstr "Introducción al manual del organizador"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
 
-#: templates/organize/prerequisites.html:69
-msgid "Frequently Asked Questions"
-msgstr "Preguntas frecuentes"
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
+msgstr ""
 
-#: templates/organize/prerequisites.html:81
-msgid "You’re at least 18 years old"
-msgstr "Tienes al menos 18 años."
+#: templates/global/menu.html:31
+msgid "Donate"
+msgstr ""
 
-#: templates/organize/prerequisites.html:93
-msgid "The event you’re organizing will be non-profit"
-msgstr "El evento que estás organizando será sin fines de lucro."
+#: templates/global/menu.html:32
+msgid "Our Patreon page"
+msgstr ""
 
-#: templates/organize/prerequisites.html:111
-msgid "Get started!"
-msgstr "¡Empezar!"
+#: templates/includes/_event.html:8
+msgid "Photo credit:"
+msgstr ""
 
-#: templates/registration/password_reset_complete.html:4
-msgid "Password Reset Complete"
-msgstr "Restablecimiento de contraseña completo"
+#: templates/includes/_faq.html:6
+msgid "Q: How can I register?"
+msgstr ""
 
-#: templates/registration/password_reset_confirm.html:4
-msgid "Password Reset"
-msgstr "Restablecer contraseña"
+#: templates/includes/_faq.html:11
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
+msgstr ""
 
-#: templates/registration/password_reset_confirm.html:11
-msgid "Set my new password!"
-msgstr "¡Establecer mi nueva contraseña!"
+#: templates/includes/_faq.html:23
+msgid "Q: I missed the deadline! Can I still apply to a workshop?"
+msgstr ""
 
-#: templates/registration/password_reset_form.html:4
-msgid "Forget your password?"
-msgstr "¿Olvidaste tu contraseña?"
+#: templates/includes/_faq.html:29
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
+msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
-msgstr "Portugués brasileño"
+#: templates/includes/_faq.html:41
+msgid "Q: I want to coach or sponsor an event!"
+msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
-msgstr "Coreano"
+#: templates/includes/_faq.html:45
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
+msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
-msgstr "Persa"
+#: templates/includes/_faq.html:52
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
+msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
-msgstr "Ruso"
+#: templates/includes/_faq.html:57
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
+msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
-msgstr "Español"
+#: templates/includes/_no_event.html:5
+msgid "Don't see an event in your city?"
+msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
-msgstr "Código de conducta de Django Girls"
+#: templates/includes/_no_event.html:11
+msgid "Sign up for our newsletter"
+msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
-msgstr "Este documento también está disponible en:"
+#: templates/includes/_no_event.html:13
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
+msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
-msgstr "Django Girls tiene como objetivo ser un evento acogedor, donde las personas se reúnan en un ambiente amigable. En consecuencia, esperamos que todos los participantes muestren respeto y cortesía hacia los demás participantes durante todo el taller."
-
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
-msgstr "Para aclarar lo que se espera, todos los delegados / asistentes, oradores, expositores, organizadores y voluntarios en cualquier evento de Django Girls deben cumplir con el siguiente Código de Conducta. Los organizadores harán cumplir este código antes y durante todo el evento."
-
-#: templates/core/coc.html:57
-msgid "In short"
-msgstr "En breve"
-
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
-msgstr "Django Girls se dedica a brindar una experiencia de taller libre de acoso para todos, independientemente de su género, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza o religión."
-
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
-msgstr "No toleramos el acoso a los participantes del taller de ninguna forma."
-
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
-msgstr "El lenguaje y las imágenes sexuales no son apropiados para ningún lugar de taller, incluidas las charlas."
-
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
-msgstr "Se amable con otros. No insultes ni menosprecies a otros asistentes. Compórtate profesionalmente. No publique fotografías de personas sin su consentimiento. Recuerda que el acoso y las bromas sexistas, racistas o excluyentes no son apropiadas para Django Girls."
-
-#: templates/core/coc.html:83
-msgid "Longer version"
-msgstr "Versión más larga"
-
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
-msgstr "El acoso incluye comentarios verbales ofensivos relacionados con género, orientación sexual, discapacidad, apariencia física, tamaño corporal, raza, religión, imágenes sexuales en espacios públicos, intimidación deliberada, acecho, seguimiento, fotografía o grabación de acoso, interrupción sostenida de conversaciones u otros acontecimientos, contacto físico inapropiado y atención sexual no deseada."
-
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
-msgstr "Se espera que los participantes a los que se les solicite detener cualquier comportamiento de acoso cumplan de inmediato."
-
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
-msgstr "Denuncia de acoso"
-
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
-msgstr "Parámetros faltantes"
-
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
-msgstr "Se han actualizado las aplicaciones"
-
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
-msgstr "El organizador %(user_name)s ha sido eliminado"
-
-#: core/admin/event.py:280
-msgid "Add organizers"
-msgstr "Agregar organizadores"
-
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
-msgstr "No hay traducción para el idioma %(lang)s"
-
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
-msgstr "Administración de Django Girls"
-
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
-msgstr "¡Ya nos patrocinan! 💕"
-
-#: applications/decorators.py:21
+#: templates/includes/_no_event.html:16
 #, fuzzy
-msgid "\"page_url\" slug must be present to user this decorator."
-msgstr "El slug \"City\" debe estar presente para utilizar este decorador."
+#| msgid "Your e-mail address:"
+msgid "Your e-mail"
+msgstr "Tu dirección de correo electrónico:"
 
-#: applications/questions.py:147
-#, fuzzy
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
-msgstr "Los datos recopilados a través de este formulario se utilizan solo para los eventos de Django Girls. Usamos Sitios y Servicios de Terceros para que esto suceda: por ejemplo, usamos Mandrill para enviarte correos electrónicos. No te preocupes: ¡No compartimos tus datos con spammers y no los vendemos! Más información sobre nuestra política de privacidad <a href='/privacy-cookies/'>aquí</a>."
+#: templates/includes/_no_event.html:17
+msgid "Your city"
+msgstr ""
 
-#: organize/models.py:94
-#, fuzzy
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
-msgstr "Información sobre cómo garantizará la seguridad de los participantes' y entrenadores' durante la pandemia de Covid-19"
+#: templates/includes/_no_event.html:27
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
+msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-#, fuzzy
-msgid "Send Renewal email"
-msgstr "Crear nuevo correo electrónico"
+#: templates/includes/_no_event.html:29
+msgid "Find out more"
+msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-#, fuzzy
-msgid "Application deployed."
-msgstr "Solicitud cerrada."
-
-#: templates/core/2016-2017.html:88
-#, fuzzy
-msgid "Map of Django Girls events from January 2016 to July 2017"
-msgstr "Mapa del evento de Django Girls de julio de 2014 a julio de 2017"
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
 
 #: templates/jobboard/index.html:39 templates/jobboard/job.html:23
 #, fuzzy
@@ -1966,8 +6106,2434 @@ msgstr "Aplicar"
 msgid "More information"
 msgstr "Confirmación de contraseña"
 
-#: templates/organize/form/step5_workshop.html:157
-#, fuzzy
-msgid "What are your current local restrictions?"
-msgstr "¿Cuál es tu ocupación actual?"
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
 
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
+msgstr ""
+
+#: templates/organize/commitment.html:20
+#, fuzzy
+#| msgid "Django Girls Local Organizers"
+msgid "Django Girls Organizer Commitement"
+msgstr "Organizadores locales de Django Girls"
+
+#: templates/organize/commitment.html:23
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgstr ""
+
+#: templates/organize/commitment.html:31
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
+msgstr ""
+
+#: templates/organize/commitment.html:35
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
+msgstr ""
+
+#: templates/organize/commitment.html:39
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+msgstr ""
+
+#: templates/organize/commitment.html:44
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgstr ""
+
+#: templates/organize/commitment.html:49
+msgid "Sign the commitement"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:10
+#, fuzzy
+#| msgid "Contact Django Girls"
+msgid "Welcome to Django Girls!"
+msgstr "Póngase en contacto con Django Girls"
+
+#: templates/organize/confirmation-of-acceptance.html:12
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:14
+msgid "In the information pack, you will receive access to the following:"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:18
+msgid "Your brand new shiny Django Girls Kraków event website"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:21
+msgid "The e-mail account for your event: kraków@djangogirls.org"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:24
+msgid "Our private community of organizers on Slack (a group chat application)"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:27
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:31
+msgid "We hope you’re as excited as we are about starting this adventure!"
+msgstr ""
+
+#: templates/organize/confirmation-of-acceptance.html:33
+msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
+msgstr ""
+
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+#, fuzzy
+#| msgid "Motivations to organize"
+msgid "Application to organize a workshop"
+msgstr "Motivaciones para organizar"
+
+#: templates/organize/form/step1_previous_event.html:45
+#, fuzzy
+#| msgid "Yes, I organized Django Girls"
+msgid "Have you organized a Django Girls workshop before?"
+msgstr "Sí, organicé Django Girls"
+
+#: templates/organize/form/step1_previous_event.html:48
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:80
+#: templates/organize/form/step2_application.html:111
+#: templates/organize/form/step3_organizers.html:185
+msgid "Go to next step"
+msgstr ""
+
+#: templates/organize/form/step2_application.html:39
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
+msgstr ""
+
+#: templates/organize/form/step2_application.html:56
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
+msgstr ""
+
+#: templates/organize/form/step2_application.html:73
+msgid "Check boxes next to all the things that describe you"
+msgstr ""
+
+#: templates/organize/form/step2_application.html:95
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
+msgstr ""
+
+#: templates/organize/form/step3_organizers.html:25
+#, fuzzy
+#| msgid "Why do you want to attend the workshop?"
+msgid "Who is going to organize this workshop?"
+msgstr "¿Por qué quieres asistir al taller?"
+
+#: templates/organize/form/step3_organizers.html:43
+#, fuzzy
+#| msgid "Add organizer"
+msgid "Lead organizer"
+msgstr "Agregar organizador"
+
+#: templates/organize/form/step3_organizers.html:44
+msgid "This is probably you! :)"
+msgstr ""
+
+#: templates/organize/form/step3_organizers.html:49
+#: templates/organize/form/step3_organizers.html:92
+#: templates/organize/form/step3_organizers.html:132
+msgid "First name"
+msgstr ""
+
+#: templates/organize/form/step3_organizers.html:60
+#: templates/organize/form/step3_organizers.html:103
+#: templates/organize/form/step3_organizers.html:143
+#, fuzzy
+#| msgid "name"
+msgid "Last name"
+msgstr "nombre"
+
+#: templates/organize/form/step3_organizers.html:71
+#: templates/organize/form/step3_organizers.html:114
+#: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
+#, fuzzy
+#| msgid "E-mail address"
+msgid "Email address"
+msgstr "Correo electrónico"
+
+#: templates/organize/form/step3_organizers.html:85
+#, fuzzy
+#| msgid "About organizer"
+msgid "Your organizing team"
+msgstr "Acerca del organizador"
+
+#: templates/organize/form/step3_organizers.html:86
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
+msgstr ""
+
+#: templates/organize/form/step4_workshop_type.html:25
+msgid "Remote or In-Person Workshop?"
+msgstr ""
+
+#: templates/organize/form/step4_workshop_type.html:31
+#, fuzzy
+#| msgid "Remove organizers"
+msgid "Remote or In-Person?"
+msgstr "Eliminar organizadores"
+
+#: templates/organize/form/step4_workshop_type.html:32
+msgid "Will your workshop be Remote or In-Person?"
+msgstr ""
+
+#: templates/organize/form/step4_workshop_type.html:36
+msgid "Workshop Type"
+msgstr ""
+
+#: templates/organize/form/step4_workshop_type.html:49
+#, fuzzy
+#| msgid "processed"
+msgid "Proceed!"
+msgstr "procesado"
+
+#: templates/organize/form/step5_workshop.html:32
+#: templates/organize/form/step5_workshop_remote.html:32
+#, fuzzy
+#| msgid "I've never been to a Django Girls event"
+msgid "Tell us all about your Django Girls event!"
+msgstr "Nunca he estado en un evento de Django Girls"
+
+#: templates/organize/form/step5_workshop.html:46
+#: templates/organize/form/step5_workshop_remote.html:46
+msgid "Where?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:47
+#: templates/organize/form/step5_workshop_remote.html:47
+#, fuzzy
+#| msgid "Why do you want to attend the workshop?"
+msgid "In which city do you want to organize a workshop?"
+msgstr "¿Por qué quieres asistir al taller?"
+
+#: templates/organize/form/step5_workshop.html:52
+#: templates/organize/form/step5_workshop_remote.html:52
+msgid "City"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:64
+#: templates/organize/form/step5_workshop_remote.html:64
+#, fuzzy
+#| msgid "City, Country"
+msgid "Country"
+msgstr "Ciudad, País"
+
+#: templates/organize/form/step5_workshop.html:84
+#: templates/organize/form/step5_workshop_remote.html:84
+msgid "When?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:85
+#: templates/organize/form/step5_workshop_remote.html:85
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:89
+#: templates/organize/form/step5_workshop_remote.html:89
+msgid "Date of your event"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:104
+msgid "Tell us about your ideas on where to host the event in your city."
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:121
+#: templates/organize/form/step5_workshop_remote.html:103
+msgid "Do you already know which companies you will approach for sponsorship?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:122
+#: templates/organize/form/step5_workshop_remote.html:104
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:140
+#: templates/organize/form/step5_workshop_remote.html:122
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:157
+#: templates/organize/form/step5_workshop_remote.html:157
+#, fuzzy
+#| msgid ""
+#| "Information about how you intend to ensure your workshop is inclusive and "
+#| "promotes diversity"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
+msgstr ""
+"Información sobre cómo piensa asegurarse de que su taller sea inclusivo y "
+"promueva la diversidad"
+
+#: templates/organize/form/step5_workshop.html:158
+#: templates/organize/form/step5_workshop_remote.html:158
+#, fuzzy
+#| msgid ""
+#| "Information about how you intend to ensure your workshop is inclusive and "
+#| "promotes diversity"
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
+msgstr ""
+"Información sobre cómo piensa asegurarse de que su taller sea inclusivo y "
+"promueva la diversidad"
+
+#: templates/organize/form/step5_workshop.html:175
+#: templates/organize/form/step5_workshop_remote.html:175
+msgid "Any additional you may want to share with us?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop.html:176
+#: templates/organize/form/step5_workshop_remote.html:176
+#, fuzzy
+#| msgid "Any additional information you think may help your application"
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
+msgstr "Alguna información adicional que crees que pueda ayudar a tu solicitud"
+
+#: templates/organize/form/step5_workshop.html:200
+#: templates/organize/form/step5_workshop_remote.html:200
+msgid "Finish!"
+msgstr ""
+
+#: templates/organize/form/step5_workshop_remote.html:139
+msgid "How will you host your workshop remotely?"
+msgstr ""
+
+#: templates/organize/form/step5_workshop_remote.html:140
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
+msgstr ""
+
+#: templates/organize/form/thank_you.html:15
+msgid "You rock!"
+msgstr ""
+
+#: templates/organize/form/thank_you.html:17
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
+msgstr ""
+
+#: templates/organize/form/thank_you.html:19
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
+msgstr ""
+
+#: templates/organize/form/thank_you.html:23
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgstr ""
+
+#: templates/organize/form/thank_you.html:26
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
+msgstr ""
+
+#: templates/organize/form/thank_you.html:34
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgstr ""
+
+#: templates/organize/index.html:9
+#, fuzzy
+#| msgid "Django Girls workshops"
+msgid "Organize Django Girls workshop"
+msgstr "Talleres de Django Girls"
+
+#: templates/organize/index.html:16
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
+msgstr ""
+
+#: templates/organize/index.html:24
+#, fuzzy
+#| msgid "In-Person"
+msgid "In-Person Workshops"
+msgstr "En Persona"
+
+#: templates/organize/index.html:27
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
+msgstr ""
+
+#: templates/organize/index.html:34
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
+msgstr ""
+
+#: templates/organize/index.html:42
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
+msgstr ""
+
+#: templates/organize/index.html:47
+msgid "Remote Workshops"
+msgstr ""
+
+#: templates/organize/index.html:50
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
+msgstr ""
+
+#: templates/organize/index.html:57
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
+msgstr ""
+
+#: templates/organize/index.html:67
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+msgstr ""
+
+#: templates/organize/index.html:73
+#, fuzzy
+#| msgid "Yes, I organized Django Girls"
+msgid "The Value of Organizing Django Girls"
+msgstr "Sí, organicé Django Girls"
+
+#: templates/organize/index.html:77
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
+msgstr ""
+
+#: templates/organize/index.html:80
+msgid "Make a real impact to advance the diversity in the tech industry"
+msgstr ""
+
+#: templates/organize/index.html:83
+msgid "Play a huge role in fostering tech community in your local area"
+msgstr ""
+
+#: templates/organize/index.html:92
+#, fuzzy
+#| msgid "Remove organizers"
+msgid "Resources for organizers"
+msgstr "Eliminar organizadores"
+
+#: templates/organize/index.html:96
+#, fuzzy
+#| msgid "Django Girls Local Organizers"
+msgid "Django Girls Organizer’s Manual"
+msgstr "Organizadores locales de Django Girls"
+
+#: templates/organize/index.html:99
+#, fuzzy
+#| msgid "Django Girls Contact"
+msgid "Django Girls Coaching Guide"
+msgstr "Contacto de Django Girls"
+
+#: templates/organize/index.html:102
+#, fuzzy
+#| msgid "Resources"
+msgid "Media resources"
+msgstr "Recursos"
+
+#: templates/organize/index.html:105
+#, fuzzy
+#| msgid "Django Girls workshop in..."
+msgid "Django Girls Workshop Tutorial"
+msgstr "Taller de Django Girls en ..."
+
+#: templates/organize/index.html:108
+#, fuzzy
+#| msgid "Apply for a pass!"
+msgid "Apply for Event Sponsorship"
+msgstr "¡Solicite un pase!"
+
+#: templates/organize/index.html:111
+msgid "Private mailing list &amp; Slack"
+msgstr ""
+
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
+msgstr ""
+
+#: templates/organize/index.html:130
+#, fuzzy
+#| msgid "Yes, I organized Django Girls"
+msgid "Agata Grdal, organizer of Django Girls Wrocław"
+msgstr "Sí, organicé Django Girls"
+
+#: templates/organize/index.html:137
+#, fuzzy
+#| msgid "Django Girls Local Organizers"
+msgid "Experiences of Django Girls organizers"
+msgstr "Organizadores locales de Django Girls"
+
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
+msgstr ""
+
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
+msgstr ""
+
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+msgstr ""
+
+#: templates/organize/prerequisites.html:29
+#, fuzzy
+#| msgid "Number of Django Girls workshops"
+msgid "Prerequisities to organize a Django Girls workshop"
+msgstr "Número de talleres de Django Girls"
+
+#: templates/organize/prerequisites.html:32
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
+msgstr ""
+
+#: templates/organize/prerequisites.html:42
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgstr ""
+
+#: templates/organize/prerequisites.html:51
+msgid "Introduction to Organizer’s Manual"
+msgstr "Introducción al manual del organizador"
+
+#: templates/organize/prerequisites.html:57
+#, fuzzy
+#| msgid "Django Girls workshops"
+msgid "Organizing Django Girls workshop step by step"
+msgstr "Talleres de Django Girls"
+
+#: templates/organize/prerequisites.html:63
+#, fuzzy
+#| msgid "Number of Django Girls workshops"
+msgid "Environment at Django Girls workshop"
+msgstr "Número de talleres de Django Girls"
+
+#: templates/organize/prerequisites.html:69
+msgid "Frequently Asked Questions"
+msgstr "Preguntas frecuentes"
+
+#: templates/organize/prerequisites.html:76
+msgid "Confirm that you meet following requirements to organize a workshop:"
+msgstr ""
+
+#: templates/organize/prerequisites.html:81
+msgid "You’re at least 18 years old"
+msgstr "Tienes al menos 18 años."
+
+#: templates/organize/prerequisites.html:87
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
+msgstr ""
+
+#: templates/organize/prerequisites.html:93
+msgid "The event you’re organizing will be non-profit"
+msgstr "El evento que estás organizando será sin fines de lucro."
+
+#: templates/organize/prerequisites.html:100
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
+msgstr ""
+
+#: templates/organize/prerequisites.html:111
+msgid "Get started!"
+msgstr "¡Empezar!"
+
+#: templates/organize/suspend.html:9
+msgid "Suspension of In-Person Workshop Applications"
+msgstr ""
+
+#: templates/organize/suspend.html:11
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
+msgstr ""
+
+#: templates/organize/suspend.html:18
+msgid "Any inconveniences caused are sincerely regretted."
+msgstr ""
+
+#: templates/registration/password_reset_complete.html:4
+msgid "Password Reset Complete"
+msgstr "Restablecimiento de contraseña completo"
+
+#: templates/registration/password_reset_complete.html:8
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
+msgstr ""
+
+#: templates/registration/password_reset_confirm.html:4
+msgid "Password Reset"
+msgstr "Restablecer contraseña"
+
+#: templates/registration/password_reset_confirm.html:7
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
+msgstr ""
+
+#: templates/registration/password_reset_confirm.html:11
+msgid "Set my new password!"
+msgstr "¡Establecer mi nueva contraseña!"
+
+#: templates/registration/password_reset_done.html:5
+msgctxt "Followed by mailbox icon, check your inbox or email"
+msgid "Check Your"
+msgstr ""
+
+#: templates/registration/password_reset_done.html:12
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
+msgstr ""
+
+#: templates/registration/password_reset_form.html:4
+msgid "Forget your password?"
+msgstr "¿Olvidaste tu contraseña?"
+
+#: templates/registration/password_reset_form.html:7
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
+msgstr ""
+
+#: templates/registration/password_reset_form.html:11
+msgid "Reset password link time!"
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:4
+#: templates/sponsor/sponsor-request.html:11
+msgid "Request for GitHub sponsoring"
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:5
+msgid "Fill the form available on this page to apply for a GitHub grant."
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:14
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:22
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:30
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:36
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
+msgstr ""
+
+#: templates/sponsor/sponsor-request.html:42
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
+msgstr ""
+
+#: templates/story/stories.html:9
+#, fuzzy
+#| msgid "Django Girls Store"
+msgid "Django Girls Story"
+msgstr "Tienda Django Girls"
+
+#: templates/story/stories.html:11
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
+msgstr ""
+
+#: templates/story/stories.html:18
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
+msgstr ""
+
+#: templates/story/stories.html:26
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
+msgstr ""
+
+#: templates/story/stories.html:33
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+#, fuzzy
+#| msgid "Applications"
+msgid "Options"
+msgstr "Solicitudes"
+
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+#, fuzzy
+#| msgid "Comment"
+msgid "Commands"
+msgstr "Comentario"
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing argument"
+msgstr "Parámetros faltantes"
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing option"
+msgstr "Parámetros faltantes"
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+#, fuzzy
+#| msgid "Missing parameters"
+msgid "Missing parameter"
+msgstr "Parámetros faltantes"
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, fuzzy, python-brace-format
+#| msgid "Missing parameters"
+msgid "Missing {param_type}"
+msgstr "Parámetros faltantes"
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, fuzzy, python-brace-format
+#| msgid "Missing parameters"
+msgid "Missing parameter: {param_name}"
+msgstr "Parámetros faltantes"
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+#, fuzzy
+#| msgid "Password confirmation"
+msgid "Repeat for confirmation"
+msgstr "Confirmación de contraseña"
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+#, fuzzy
+#| msgid "The two password fields didn't match."
+msgid "Error: The two entered values do not match."
+msgstr "Los dos campos de contraseña no coinciden."
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+#, fuzzy
+#| msgid "Messaging"
+msgid "Messages"
+msgstr "Mensajería"
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+#, fuzzy
+#| msgid "Statistics"
+msgid "Static Files"
+msgstr "Estadísticas"
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+#, fuzzy
+#| msgid "Application"
+msgid "Syndication"
+msgstr "Solicitud"
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+#, fuzzy
+#| msgid "email address"
+msgid "Enter a valid email address."
+msgstr "correo electrónico"
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+#, fuzzy
+#| msgid "This field is required."
+msgid "This field cannot be null."
+msgstr "Este campo es obligatorio."
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+#, fuzzy
+#| msgid "Question"
+msgid "Duration"
+msgstr "Pregunta"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Floating point number"
+msgstr "Tu número de teléfono:"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+#, fuzzy
+#| msgid "address"
+msgid "IPv4 address"
+msgstr "dirección"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+#, fuzzy
+#| msgid "address"
+msgid "IP address"
+msgstr "dirección"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+#, fuzzy
+#| msgid "Subject"
+msgid "A JSON object"
+msgstr "Asunto"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
+msgstr ""
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Enter a whole number."
+msgstr "Tu número de teléfono:"
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+#, fuzzy
+#| msgid "Status"
+msgid "Sat"
+msgstr "Estado"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+#, fuzzy
+#| msgid "Summary"
+msgid "mar"
+msgstr "Resumen"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+#, fuzzy
+#| msgid "Summary"
+msgid "may"
+msgstr "Resumen"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
+msgstr ""
+
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, fuzzy, python-format
+#| msgid "month"
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "mes"
+msgstr[1] "mes"
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+#, fuzzy
+#| msgid "Django Girls Foundation"
+msgid "Django Documentation"
+msgstr "Fundación Django Girls"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+#, fuzzy
+#| msgid "Get started!"
+msgid "Get started with Django"
+msgstr "¡Empezar!"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+#, fuzzy
+#| msgid "Django Girls Contact"
+msgid "Django Community"
+msgstr "Contacto de Django Girls"
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""
+
+#~ msgid "\"City\" slug must be present to user this decorator."
+#~ msgstr "El slug \"City\" debe estar presente para utilizar este decorador."
+
+#~ msgid ""
+#~ "Data collected through this form is used only for the purpose of Django "
+#~ "Girls events. We're using Third Party Sites and Services to make it "
+#~ "happen: for example, we're using Mandrill to send you emails. Don't "
+#~ "worry: We don't share your data with spammers, and we don't sell it! More "
+#~ "info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#~ msgstr ""
+#~ "Los datos recopilados a través de este formulario se utilizan solo para "
+#~ "los eventos de Django Girls. Usamos Sitios y Servicios de Terceros para "
+#~ "que esto suceda: por ejemplo, usamos Mandrill para enviarte correos "
+#~ "electrónicos. No te preocupes: ¡No compartimos tus datos con spammers y "
+#~ "no los vendemos! Más información sobre nuestra política de privacidad <a "
+#~ "href='/privacy-cookies/'>aquí</a>."
+
+#~ msgid "Map of Django Girls event from July 2014 to July 2017"
+#~ msgstr "Mapa del evento de Django Girls de julio de 2014 a julio de 2017"
+
+#~ msgid "The event you're organizing will be remote"
+#~ msgstr "El evento que estás organizando será remoto"
+
+#, fuzzy
+#~ msgid "What are your current local restrictions?"
+#~ msgstr "¿Cuál es tu ocupación actual?"

--- a/locale/fa/LC_MESSAGES/django.po
+++ b/locale/fa/LC_MESSAGES/django.po
@@ -1,37 +1,57 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: fa\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: fa\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
 msgstr "درخواستی برای این آدرس ایمیل قبلا ثبت شده."
 
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
+msgstr ""
+
 #: applications/models.py:19
 msgid "Apply for a spot at Django Girls [City]!"
 msgstr ""
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
 msgstr ""
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
@@ -64,10 +84,11 @@ msgstr ""
 
 #: applications/models.py:93
 msgid "List all available options, separated with semicolon (;)"
-msgstr "یک لیست از تمام گزینه‌ها بنویسید، با نقطه ویرگول (;) گزینه‌ها را جدا کنید"
+msgstr ""
+"یک لیست از تمام گزینه‌ها بنویسید، با نقطه ویرگول (;) گزینه‌ها را جدا کنید"
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr ""
 
 #: applications/models.py:98
@@ -127,27 +148,27 @@ msgstr ""
 msgid "RSVP status"
 msgstr ""
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr ""
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr ""
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr ""
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr ""
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr ""
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr ""
 
@@ -164,7 +185,9 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr ""
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
 msgstr ""
 
 #: applications/questions.py:59
@@ -212,11 +235,16 @@ msgid "What is your current level of experience with programming?"
 msgstr ""
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
 msgstr ""
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
 msgstr ""
 
 #: applications/questions.py:115
@@ -240,7 +268,12 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr ""
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
 msgstr ""
 
 #: applications/questions.py:138
@@ -248,19 +281,29 @@ msgid "How did you hear about Django Girls?"
 msgstr ""
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
 msgstr ""
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
 msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr ""
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
 msgstr ""
 
 #: applications/questions.py:164
@@ -271,32 +314,64 @@ msgstr ""
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr ""
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr ""
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr ""
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr ""
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr ""
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
+msgstr ""
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
 msgstr ""
 
 #: contact/forms.py:15
@@ -343,7 +418,7 @@ msgstr ""
 msgid "page URL"
 msgstr ""
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr ""
 
@@ -367,8 +442,55 @@ msgstr ""
 msgid "You cannot remove yourself from a team."
 msgstr ""
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr ""
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
+msgstr ""
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr ""
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr ""
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr ""
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr ""
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr ""
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr ""
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
 msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
@@ -381,10 +503,6 @@ msgstr ""
 
 #: core/admin/user.py:19
 msgid "Important dates"
-msgstr ""
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
 msgstr ""
 
 #: core/default_eventpage_content.py:60
@@ -423,56 +541,93 @@ msgstr ""
 msgid "E-mail address"
 msgstr ""
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr ""
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr ""
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr ""
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr ""
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr ""
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
 msgstr ""
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
 msgstr ""
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr ""
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr ""
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr ""
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr ""
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr ""
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr ""
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr ""
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr ""
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr ""
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr ""
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
 msgstr ""
 
 #: organize/admin.py:16
@@ -483,21 +638,30 @@ msgstr ""
 msgid "Move selected application to in review"
 msgstr ""
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr ""
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr ""
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr ""
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr ""
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
+msgstr ""
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
 
 #: organize/constants.py:4
@@ -544,135 +708,164 @@ msgstr ""
 msgid "Deployed"
 msgstr ""
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr ""
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+msgid "No, it's my first time organizing Django Girls"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr ""
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr ""
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr ""
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr ""
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
+#: organize/forms.py:109
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
 msgstr ""
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
 msgstr ""
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr ""
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr ""
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr ""
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr ""
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr ""
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr ""
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr ""
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr ""
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr ""
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr ""
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr ""
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr ""
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] ""
 msgstr[1] ""
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr ""
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -759,10 +952,13 @@ msgid "payments"
 msgstr ""
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
 msgstr[0] ""
@@ -777,7 +973,9 @@ msgid "Section background"
 msgstr ""
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
 msgstr ""
 
 #: pictures/models.py:39
@@ -792,11 +990,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -809,11 +1007,15 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr ""
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:5
@@ -821,11 +1023,20 @@ msgid "Submitted applications"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
 msgstr ""
 
 #: templates/admin/core/event/view_add_organizers.html:6
@@ -845,7 +1056,7 @@ msgid "Remove event organizers"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -853,6 +1064,7 @@ msgid "To get started, choose an event:"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, python-format
 msgid "Organizers of %(event_name)s"
 msgstr ""
 
@@ -869,16 +1081,44 @@ msgid "Action"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr ""
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+msgid "Blacklist Organizer"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/change_form.html:15
@@ -897,19 +1137,28 @@ msgstr ""
 msgid "Reject application"
 msgstr ""
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr ""
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -919,14 +1168,20 @@ msgid "Yes, I'm sure"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -935,10 +1190,12 @@ msgid "Scores"
 msgstr ""
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr ""
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr ""
 
@@ -964,6 +1221,7 @@ msgid "Save & draw next"
 msgstr ""
 
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr ""
 
@@ -1044,17 +1302,27 @@ msgid "Nothing to see here..."
 msgstr ""
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
 msgstr ""
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
 msgstr ""
 
@@ -1063,6 +1331,7 @@ msgid "Submit your application"
 msgstr ""
 
 #: templates/applications/communication.html:14
+#, python-format
 msgid "Send email to applicants of %(title)s"
 msgstr ""
 
@@ -1096,6 +1365,7 @@ msgid "Create one!"
 msgstr ""
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr ""
 
@@ -1124,8 +1394,11 @@ msgid "Email preview"
 msgstr ""
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
 msgstr ""
 
@@ -1138,20 +1411,31 @@ msgid "Emails that failed to sent:"
 msgstr ""
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
 msgstr ""
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
 msgstr ""
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 msgstr ""
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
@@ -1176,8 +1460,11 @@ msgid "To be sure your email reach the right person, check this FAQ first!"
 msgstr ""
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
 msgstr ""
@@ -1191,7 +1478,10 @@ msgid "Django Girls Annual Report 2015"
 msgstr ""
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
 msgstr ""
 
 #: templates/core/2015.html:25
@@ -1207,7 +1497,14 @@ msgid "Financial Transparency 💰🔍"
 msgstr ""
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
 msgstr ""
 
 #: templates/core/2015.html:58
@@ -1215,11 +1512,23 @@ msgid "Expenses 💸"
 msgstr ""
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
 msgstr ""
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
 msgstr ""
 
 #: templates/core/2015.html:77
@@ -1232,6 +1541,7 @@ msgid "Amount"
 msgstr ""
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr ""
 
@@ -1264,11 +1574,23 @@ msgid "Income 🌟👀"
 msgstr ""
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
 msgstr ""
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
 msgstr ""
 
 #: templates/core/2015.html:122
@@ -1276,6 +1598,7 @@ msgid "Income"
 msgstr ""
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr ""
 
@@ -1288,6 +1611,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr ""
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr ""
 
@@ -1312,7 +1636,11 @@ msgid "Total income"
 msgstr ""
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
 msgstr ""
 
 #: templates/core/2015.html:151
@@ -1324,19 +1652,37 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr ""
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
 msgstr ""
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
 msgstr ""
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
 msgstr ""
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
 msgstr ""
 
 #: templates/core/2015.html:187
@@ -1344,75 +1690,173 @@ msgid "Achievements & Events in 2015 🏆🏅"
 msgstr ""
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
 msgstr ""
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
 msgstr ""
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
 msgstr ""
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
 msgstr ""
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
 msgstr ""
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
 msgstr ""
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
 msgstr ""
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
 msgstr ""
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
 msgstr ""
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
 msgstr ""
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
 msgstr ""
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
 msgstr ""
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
 msgstr ""
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
 msgstr ""
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
 msgstr ""
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
 msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
 msgstr ""
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
 msgstr ""
 
 #: templates/core/2015.html:351
@@ -1420,39 +1864,95 @@ msgid "Success stories 💖"
 msgstr ""
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
 msgstr ""
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
 msgstr ""
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
 msgstr ""
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
 msgstr ""
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
 msgstr ""
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
 msgstr ""
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
 msgstr ""
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
 msgstr ""
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
 msgstr ""
 
 #: templates/core/2015.html:461
@@ -1464,15 +1964,31 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr ""
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
 msgstr ""
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
 msgstr ""
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
 msgstr ""
 
 #: templates/core/2015.html:479
@@ -1484,43 +2000,77 @@ msgid "Sponsors 📢️"
 msgstr ""
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
 msgstr ""
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
 msgstr ""
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
@@ -1528,7 +2078,10 @@ msgid "Django Girls Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
 msgstr ""
 
 #: templates/core/2016-2017.html:26
@@ -1536,11 +2089,25 @@ msgid "Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
 msgstr ""
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
 msgstr ""
 
 #: templates/core/2016-2017.html:50
@@ -1548,35 +2115,55 @@ msgid "✨ Highlights ✨"
 msgstr ""
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
 msgstr ""
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
 msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr ""
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:94
@@ -1632,11 +2219,23 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr ""
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
 msgstr ""
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
 msgstr ""
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
@@ -1648,11 +2247,22 @@ msgid "🎁 Organiser Starter Kits"
 msgstr ""
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
 msgstr ""
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
 msgstr ""
 
 #: templates/core/2016-2017.html:169
@@ -1660,7 +2270,12 @@ msgid "💰 Fundraising"
 msgstr ""
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
 msgstr ""
 
 #: templates/core/2016-2017.html:183
@@ -1692,11 +2307,31 @@ msgid "Participants Survey"
 msgstr ""
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
 msgstr ""
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
 msgstr ""
 
 #: templates/core/2016-2017.html:227
@@ -1704,15 +2339,29 @@ msgid "Participants’ Involvement in Tech Activities"
 msgstr ""
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
 msgstr ""
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
 msgstr ""
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
 msgstr ""
 
 #: templates/core/2016-2017.html:258
@@ -1720,19 +2369,33 @@ msgid "Participants’ learning to code after the workshop"
 msgstr ""
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
 msgstr ""
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
 msgstr ""
 
 #: templates/core/2016-2017.html:291
@@ -1740,19 +2403,35 @@ msgid "Participants’ Employment in Tech after attending workshops"
 msgstr ""
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
+#, python-format
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
 msgstr ""
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
 msgstr ""
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
 msgstr ""
 
 #: templates/core/2016-2017.html:326
@@ -1760,19 +2439,39 @@ msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr ""
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
 msgstr ""
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
 msgstr ""
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:362
@@ -1780,15 +2479,152 @@ msgid "Summary"
 msgstr ""
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
 msgstr ""
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
 msgstr ""
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
+msgstr ""
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr ""
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr ""
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr ""
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr ""
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
 msgstr ""
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
@@ -1797,7 +2633,12 @@ msgid "Contribute"
 msgstr ""
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
 msgstr ""
 
 #: templates/core/contribute.html:22
@@ -1805,11 +2646,22 @@ msgid "Support us!"
 msgstr ""
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
 msgstr ""
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
 msgstr ""
 
 #: templates/core/contribute.html:46
@@ -1817,11 +2669,17 @@ msgid "Organize!"
 msgstr ""
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
 msgstr ""
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:72
@@ -1829,15 +2687,23 @@ msgid "Coach!"
 msgstr ""
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
 msgstr ""
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
 msgstr ""
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
 msgstr ""
 
 #: templates/core/contribute.html:99
@@ -1849,11 +2715,15 @@ msgid "Computer screen with a console and a webpage."
 msgstr ""
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
 msgstr ""
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:123
@@ -1865,11 +2735,16 @@ msgid "A note book and a pen."
 msgstr ""
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
 msgstr ""
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
 msgstr ""
 
 #: templates/core/contribute.html:140
@@ -1881,11 +2756,18 @@ msgid "A computer screen saying hello and golden balloons saying yay!."
 msgstr ""
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
 msgstr ""
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
 msgstr ""
 
 #: templates/core/contribute.html:166
@@ -1897,11 +2779,17 @@ msgid "A web page opened on a computer."
 msgstr ""
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
 msgstr ""
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
 msgstr ""
 
 #: templates/core/contribute.html:188
@@ -1913,11 +2801,16 @@ msgid "A pile a tattoo."
 msgstr ""
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
 msgstr ""
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:11
@@ -1925,7 +2818,13 @@ msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
@@ -1933,14 +2832,22 @@ msgid "Our awesome supporters ✨"
 msgstr ""
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
 msgstr ""
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
 msgstr ""
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
@@ -1969,7 +2876,11 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr ""
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
 msgstr ""
 
 #: templates/core/faq.html:20
@@ -1985,27 +2896,67 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr ""
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
 msgstr ""
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
 msgstr ""
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
 msgstr ""
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
 msgstr ""
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
 msgstr ""
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
 msgstr ""
 
 #: templates/core/faq.html:109
@@ -2013,7 +2964,9 @@ msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr ""
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
 msgstr ""
 
 #: templates/core/faq.html:117
@@ -2021,11 +2974,29 @@ msgid "We are trans-inclusive and welcome applications from all women."
 msgstr ""
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
 msgstr ""
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
 msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
@@ -2042,7 +3013,9 @@ msgid "We inspire women to fall in love with programming."
 msgstr ""
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
 msgstr ""
 
 #: templates/core/index.html:29
@@ -2050,11 +3023,20 @@ msgid "What is Django Girls?"
 msgstr ""
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
 msgstr ""
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
 msgstr ""
 
 #: templates/core/index.html:53
@@ -2062,11 +3044,22 @@ msgid "Django Girls impact"
 msgstr ""
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
 msgstr ""
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
 msgstr ""
 
 #: templates/core/index.html:69
@@ -2078,11 +3071,18 @@ msgid "Bring Django Girls to your city!"
 msgstr ""
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
 msgstr ""
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
 msgstr ""
 
 #: templates/core/index.html:82 templates/organize/index.html:89
@@ -2090,6 +3090,7 @@ msgid "Apply to organize a workshop"
 msgstr ""
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr ""
 
@@ -2098,7 +3099,9 @@ msgid "Badass Django Ladies"
 msgstr ""
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
 msgstr ""
 
 #: templates/core/index.html:125
@@ -2118,7 +3121,15 @@ msgid "Support our work"
 msgstr ""
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
@@ -2126,7 +3137,11 @@ msgid "Make a recurring donation on Patreon"
 msgstr ""
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
 msgstr ""
 
 #: templates/core/index.html:162
@@ -2134,7 +3149,9 @@ msgid "Stay up to date!"
 msgstr ""
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
 msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
@@ -2150,12 +3167,51 @@ msgstr ""
 msgid "See the Django Girls Dispatch archives"
 msgstr ""
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr ""
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr ""
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
 msgstr ""
 
 #: templates/core/newsletter.html:4
@@ -2167,11 +3223,16 @@ msgid "Django Girls Dispatch"
 msgstr ""
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
 msgstr ""
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
 msgstr ""
 
 #: templates/core/newsletter.html:49
@@ -2183,11 +3244,15 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:20
@@ -2207,19 +3272,31 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:53
@@ -2231,15 +3308,25 @@ msgid "Scope of this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:74
@@ -2247,7 +3334,9 @@ msgid "Data Collected"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:79
@@ -2283,7 +3372,9 @@ msgid "operating system (automatically collected); and"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:90
@@ -2295,15 +3386,22 @@ msgid "We will keep any personal Data you submit for 60 months."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:108
@@ -2319,15 +3417,21 @@ msgid "improvement of our products / services;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:115
@@ -2339,15 +3443,25 @@ msgid "Third Party Sites and Services"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:142
@@ -2355,7 +3469,11 @@ msgid "Links to Other Websites"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:151
@@ -2363,7 +3481,12 @@ msgid "Changes of Business Ownership and Control"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:161
@@ -2375,7 +3498,9 @@ msgid "Controlling Use of Your Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:167
@@ -2395,11 +3520,17 @@ msgid "Your Right to Withhold Information"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:178
@@ -2407,7 +3538,9 @@ msgid "Accessing Your Own Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:182
@@ -2415,7 +3548,10 @@ msgid "Security"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:186
@@ -2423,27 +3559,49 @@ msgid "Cookies"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:201
@@ -2451,19 +3609,29 @@ msgid "You can choose to enable or disable Cookies in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:214
@@ -2471,7 +3639,11 @@ msgid "Changes to this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
 msgstr ""
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
@@ -2480,7 +3652,11 @@ msgid "Resources"
 msgstr ""
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
 msgstr ""
 
 #: templates/core/resources.html:22
@@ -2492,7 +3668,10 @@ msgid "Tutorial Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
 msgstr ""
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
@@ -2509,7 +3688,10 @@ msgid "Organize Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
 msgstr ""
 
 #: templates/core/resources.html:67
@@ -2517,7 +3699,10 @@ msgid "Coaching Guide Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
 msgstr ""
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
@@ -2529,7 +3714,10 @@ msgid "Tutorial Extensions Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
 msgstr ""
 
 #: templates/core/terms_conditions.html:4
@@ -2539,11 +3727,17 @@ msgstr ""
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
 msgstr ""
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/terms_conditions.html:18
@@ -2559,7 +3753,10 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr ""
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:39
@@ -2567,7 +3764,9 @@ msgid "Agreement"
 msgstr ""
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
 msgstr ""
 
 #: templates/core/terms_conditions.html:44
@@ -2583,19 +3782,26 @@ msgid "You promise us:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
 msgstr ""
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
 msgstr ""
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:53
@@ -2603,15 +3809,25 @@ msgid "That you won’t do anything that might cause our systems to crash."
 msgstr ""
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
 msgstr ""
 
 #: templates/core/terms_conditions.html:59
@@ -2619,11 +3835,20 @@ msgid "Intellectual property"
 msgstr ""
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:71
@@ -2631,11 +3856,17 @@ msgid "Price and payment"
 msgstr ""
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
 msgstr ""
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:86
@@ -2643,7 +3874,11 @@ msgid "Use of communications facilities"
 msgstr ""
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:90
@@ -2651,51 +3886,79 @@ msgid "you must not use language that may be offensive to other Users;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
 msgstr ""
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
 msgstr ""
 
 #: templates/core/terms_conditions.html:114
@@ -2703,7 +3966,10 @@ msgid "Privacy and cookies"
 msgstr ""
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:123
@@ -2719,7 +3985,9 @@ msgid "that the Site will meet your needs;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:130
@@ -2743,19 +4011,35 @@ msgid "that the Site is secure,"
 msgstr ""
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
 msgstr ""
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
 msgstr ""
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
 msgstr ""
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
 msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
@@ -2763,11 +4047,20 @@ msgid "Events"
 msgstr ""
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
 msgstr ""
 
 #: templates/core/terms_conditions.html:164
@@ -2775,11 +4068,15 @@ msgid "Problems"
 msgstr ""
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
 msgstr ""
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
 msgstr ""
 
 #: templates/core/terms_conditions.html:170
@@ -2787,11 +4084,16 @@ msgid "Availability of the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
 msgstr ""
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:176
@@ -2799,7 +4101,11 @@ msgid "Limitation of liability"
 msgstr ""
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:180
@@ -2807,7 +4113,9 @@ msgid "You use the Site and its Content at your own risk."
 msgstr ""
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
 msgstr ""
 
 #: templates/core/terms_conditions.html:184
@@ -2815,11 +4123,16 @@ msgid "Linking"
 msgstr ""
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
 msgstr ""
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:190
@@ -2827,15 +4140,23 @@ msgid "We can never guarantee that a link will work."
 msgstr ""
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
 msgstr ""
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:199
@@ -2851,7 +4172,9 @@ msgid "you can only link from a site that you own;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:203
@@ -2859,7 +4182,9 @@ msgid "you mustn’t frame our Site on any other site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
 msgstr ""
 
 #: templates/core/terms_conditions.html:208
@@ -2867,11 +4192,18 @@ msgid "Modifications to these T&Cs & the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
 msgstr ""
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
 msgstr ""
 
 #: templates/core/terms_conditions.html:221
@@ -2879,39 +4211,66 @@ msgid "General stuff"
 msgstr ""
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
 msgstr ""
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
 msgstr ""
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
 msgstr ""
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
 msgstr ""
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:235
@@ -2923,15 +4282,22 @@ msgid "Definitions"
 msgstr ""
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
 msgstr ""
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:244
@@ -2939,7 +4305,10 @@ msgid "<b>Organiser</b> means the organiser or promoter of an Event."
 msgstr ""
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:253
@@ -2947,7 +4316,8 @@ msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr ""
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
 msgstr ""
 
 #: templates/core/workshop_box.html:9
@@ -2955,7 +4325,10 @@ msgid "Order Django Girls Workshop Box for your event!"
 msgstr ""
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
 msgstr ""
 
 #: templates/core/workshop_box.html:27
@@ -2963,11 +4336,19 @@ msgid "How it works?"
 msgstr ""
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
 msgstr ""
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
 msgstr ""
 
 #: templates/core/workshop_box.html:44
@@ -3031,7 +4412,11 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr ""
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
 msgstr ""
 
 #: templates/core/workshop_box.html:78
@@ -3039,7 +4424,12 @@ msgid "How to get one?"
 msgstr ""
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
 msgstr ""
 
 #: templates/core/workshop_box.html:86
@@ -3047,7 +4437,9 @@ msgid "Requirements to apply for a free box:"
 msgstr ""
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
 msgstr ""
 
 #: templates/core/workshop_box.html:89
@@ -3059,11 +4451,16 @@ msgid "Application process for your event needs to be open"
 msgstr ""
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
 msgstr ""
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
 msgstr ""
 
 #: templates/default/about.html:4
@@ -3083,7 +4480,9 @@ msgid "Applications are now open!"
 msgstr ""
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
 msgstr ""
 
 #: templates/default/apply.html:10
@@ -3095,7 +4494,10 @@ msgid "Be a Mentor!"
 msgstr ""
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
 msgstr ""
 
 #: templates/default/coach.html:16 templates/default/values.html:5
@@ -3103,15 +4505,23 @@ msgid "Django Girls"
 msgstr ""
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
 msgstr ""
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 msgstr ""
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
 msgstr ""
 
 #: templates/default/faq.html:6
@@ -3119,7 +4529,10 @@ msgid "Do I need to know anything about websites or programming?"
 msgstr ""
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
 msgstr ""
 
 #: templates/default/faq.html:18
@@ -3127,7 +4540,11 @@ msgid "I am not living in Germany, can I attend?"
 msgstr ""
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
 msgstr ""
 
 #: templates/default/faq.html:31
@@ -3135,7 +4552,10 @@ msgid "Should I bring my own laptop?"
 msgstr ""
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
 msgstr ""
 
 #: templates/default/faq.html:45
@@ -3143,7 +4563,10 @@ msgid "Do I need to have something installed on my laptop?"
 msgstr ""
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
 msgstr ""
 
 #: templates/default/faq.html:58
@@ -3151,7 +4574,11 @@ msgid "Is EuroPython conference good for a total beginner?"
 msgstr ""
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
 msgstr ""
 
 #: templates/default/faq.html:70
@@ -3159,11 +4586,17 @@ msgid "Is food provided?"
 msgstr ""
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
 msgstr ""
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
 msgstr ""
 
 #: templates/default/partners.html:3
@@ -3171,23 +4604,40 @@ msgid "Sponsors"
 msgstr ""
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
 msgstr ""
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
 msgstr ""
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
 msgstr ""
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
 msgstr ""
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
 msgstr ""
 
 #: templates/default/values.html:33
@@ -3195,7 +4645,10 @@ msgid "Apply for the workshop!"
 msgstr ""
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
 msgstr ""
 
 #: templates/default/values.html:43
@@ -3203,7 +4656,9 @@ msgid "As a workshop attendee you will:"
 msgstr ""
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
 msgstr ""
 
 #: templates/default/values.html:48
@@ -3211,7 +4666,9 @@ msgid "be fed by us: during our event, food is provided"
 msgstr ""
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
 msgstr ""
 
 #: templates/donations/donate.html:13
@@ -3223,19 +4680,37 @@ msgid "Our mission:"
 msgstr ""
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
 msgstr ""
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
 msgstr ""
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
 msgstr ""
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
 msgstr ""
 
 #: templates/donations/donate.html:54
@@ -3251,11 +4726,19 @@ msgid "Monthly donations"
 msgstr ""
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
 msgstr ""
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
 
 #: templates/donations/donate.html:105
@@ -3263,11 +4746,16 @@ msgid "One-time donations"
 msgstr ""
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
 msgstr ""
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
 msgstr ""
 
 #: templates/donations/donate.html:121
@@ -3287,15 +4775,10 @@ msgid "Humble Bundle Store"
 msgstr ""
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr ""
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr ""
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
 msgstr ""
 
 #: templates/donations/donate.html:161
@@ -3311,11 +4794,26 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr ""
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
 msgstr ""
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
 msgstr ""
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
@@ -3327,11 +4825,20 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr ""
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
 msgstr ""
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
 msgstr ""
 
 #: templates/donations/donate.html:213
@@ -3339,11 +4846,15 @@ msgid "Django Girls Summit:"
 msgstr ""
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
 msgstr ""
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
 msgstr ""
 
 #: templates/donations/error.html:7
@@ -3358,16 +4869,52 @@ msgstr ""
 msgid "Back to donation page"
 msgstr ""
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
 #: templates/donations/success.html:8
+#, python-format
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:3
+#, python-format
 msgid "Hello team %(city)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:8
@@ -3375,7 +4922,12 @@ msgid "Numbers"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:17
@@ -3383,7 +4935,10 @@ msgid "Tell us how it went!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:22
@@ -3391,7 +4946,12 @@ msgid "Share your experiences"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:27
@@ -3399,7 +4959,10 @@ msgid "Upload your photos"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:32
@@ -3407,7 +4970,11 @@ msgid "Donation"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:41
@@ -3415,11 +4982,19 @@ msgid "Discount in our store"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:55
@@ -3427,9 +5002,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -3440,10 +5015,12 @@ msgid "Hi there!"
 msgstr ""
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
 msgstr ""
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3452,29 +5029,39 @@ msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr ""
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
 msgstr ""
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
 msgstr ""
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3483,21 +5070,37 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
 msgstr ""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr ""
 
@@ -3506,11 +5109,17 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:17
@@ -3521,8 +5130,19 @@ msgstr ""
 msgid "Hello,"
 msgstr ""
 
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:16
@@ -3534,11 +5154,36 @@ msgid "Being an awesome person - already done! :)"
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
 msgstr ""
 
 #: templates/emails/organize/application_notification.html:3
@@ -3615,7 +5260,9 @@ msgid "Do you have potential coaches in mind?"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:9
@@ -3627,14 +5274,17 @@ msgid "1) Email address"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:22
@@ -3642,7 +5292,9 @@ msgid "Password:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:30
@@ -3650,7 +5302,9 @@ msgid "You can also add this inbox to your email client:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:39
@@ -3658,19 +5312,29 @@ msgid "2) Website"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:65
@@ -3678,30 +5342,40 @@ msgid "3) Organizers community"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -3710,55 +5384,91 @@ msgid "Hello there,"
 msgstr ""
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
 msgstr ""
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
 msgstr ""
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
 msgstr ""
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
 msgstr ""
 
 #: templates/global/footer.html:10
@@ -3773,12 +5483,12 @@ msgstr ""
 msgid "Chat with us!"
 msgstr ""
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr ""
-
 #: templates/global/footer.html:14
 msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
 msgstr ""
 
 #: templates/global/footer.html:20
@@ -3795,6 +5505,10 @@ msgstr ""
 
 #: templates/global/footer.html:25
 msgid "Sponsor us"
+msgstr ""
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
 msgstr ""
 
 #: templates/global/footer.html:30
@@ -3822,22 +5536,27 @@ msgid "Privacy & Cookies"
 msgstr ""
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr ""
 
 #: templates/global/footer.html:61
+#, python-format
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr ""
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
 msgstr ""
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
 msgstr ""
 
 #: templates/global/footer.html:64
+#, python-format
 msgid "<b>%(countries_count)s</b> countries"
 msgstr ""
 
@@ -3849,8 +5568,12 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
 msgstr ""
 
 #: templates/global/menu.html:31
@@ -3870,7 +5593,11 @@ msgid "Q: How can I register?"
 msgstr ""
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
 msgstr ""
 
 #: templates/includes/_faq.html:23
@@ -3878,7 +5605,12 @@ msgid "Q: I missed the deadline! Can I still apply to a workshop?"
 msgstr ""
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
 msgstr ""
 
 #: templates/includes/_faq.html:41
@@ -3886,15 +5618,23 @@ msgid "Q: I want to coach or sponsor an event!"
 msgstr ""
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
 msgstr ""
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
 msgstr ""
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
 msgstr ""
 
 #: templates/includes/_no_event.html:5
@@ -3906,7 +5646,8 @@ msgid "Sign up for our newsletter"
 msgstr ""
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
 msgstr ""
 
 #: templates/includes/_no_event.html:16
@@ -3918,11 +5659,38 @@ msgid "Your city"
 msgstr ""
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
 msgstr ""
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
+msgstr ""
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr ""
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr ""
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
 msgstr ""
 
 #: templates/organize/commitment.html:20
@@ -3930,23 +5698,36 @@ msgid "Django Girls Organizer Commitement"
 msgstr ""
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
 msgstr ""
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
 msgstr ""
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
 msgstr ""
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
 msgstr ""
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
 msgstr ""
 
 #: templates/organize/commitment.html:49
@@ -3958,7 +5739,10 @@ msgid "Welcome to Django Girls!"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:14
@@ -3978,7 +5762,8 @@ msgid "Our private community of organizers on Slack (a group chat application)"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:31
@@ -3989,12 +5774,96 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:80
@@ -4003,17 +5872,16 @@ msgstr ""
 msgid "Go to next step"
 msgstr ""
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr ""
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:73
@@ -4021,7 +5889,9 @@ msgid "Check boxes next to all the things that describe you"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:25
@@ -4051,6 +5921,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -4059,7 +5930,10 @@ msgid "Your organizing team"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
 msgstr ""
 
 #: templates/organize/form/step4_workshop_type.html:25
@@ -4085,10 +5959,6 @@ msgstr ""
 #: templates/organize/form/step5_workshop.html:32
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:46
@@ -4118,7 +5988,10 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:89
@@ -4137,43 +6010,42 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -4183,7 +6055,9 @@ msgid "How will you host your workshop remotely?"
 msgstr ""
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:15
@@ -4191,23 +6065,39 @@ msgid "You rock!"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
 msgstr ""
 
 #: templates/organize/index.html:9
@@ -4215,11 +6105,13 @@ msgid "Organize Django Girls workshop"
 msgstr ""
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr ""
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
 msgstr ""
 
 #: templates/organize/index.html:24
@@ -4227,15 +6119,24 @@ msgid "In-Person Workshops"
 msgstr ""
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
 msgstr ""
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
 msgstr ""
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
 msgstr ""
 
 #: templates/organize/index.html:47
@@ -4243,15 +6144,26 @@ msgid "Remote Workshops"
 msgstr ""
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
 msgstr ""
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
 msgstr ""
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/organize/index.html:73
@@ -4259,7 +6171,9 @@ msgid "The Value of Organizing Django Girls"
 msgstr ""
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
 msgstr ""
 
 #: templates/organize/index.html:80
@@ -4291,31 +6205,50 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+msgid "Apply for Event Sponsorship"
+msgstr ""
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
 msgstr ""
 
 #: templates/organize/prerequisites.html:29
@@ -4323,19 +6256,17 @@ msgid "Prerequisities to organize a Django Girls workshop"
 msgstr ""
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr ""
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr ""
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:51
@@ -4363,7 +6294,9 @@ msgid "You’re at least 18 years old"
 msgstr ""
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
 msgstr ""
 
 #: templates/organize/prerequisites.html:93
@@ -4371,7 +6304,9 @@ msgid "The event you’re organizing will be non-profit"
 msgstr ""
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
 msgstr ""
 
 #: templates/organize/prerequisites.html:111
@@ -4383,7 +6318,11 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr ""
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
 msgstr ""
 
 #: templates/organize/suspend.html:18
@@ -4395,7 +6334,10 @@ msgid "Password Reset Complete"
 msgstr ""
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:4
@@ -4403,7 +6345,9 @@ msgid "Password Reset"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:11
@@ -4416,7 +6360,11 @@ msgid "Check Your"
 msgstr ""
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:4
@@ -4424,7 +6372,10 @@ msgid "Forget your password?"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
 msgstr ""
 
 #: templates/registration/password_reset_form.html:11
@@ -4441,23 +6392,38 @@ msgid "Fill the form available on this page to apply for a GitHub grant."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
 msgstr ""
 
 #: templates/story/stories.html:9
@@ -4465,372 +6431,1540 @@ msgid "Django Girls Story"
 msgstr ""
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
 msgstr ""
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
 msgstr ""
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
 msgstr ""
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
 msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
 msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
 msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
 msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
 msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
 msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
 msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+msgid "Options"
 msgstr ""
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+msgid "Repeat for confirmation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+msgid "Error: The two entered values do not match."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+msgid "Syndication"
+msgstr ""
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+msgid "Enter a valid email address."
+msgstr ""
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+#, fuzzy
+#| msgid "Question"
+msgid "Duration"
+msgstr "سوال"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+msgid "Floating point number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+msgid "IPv4 address"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+msgid "IP address"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+msgid "A JSON object"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
+msgstr ""
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+msgid "Enter a whole number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
 msgstr ""
 
-#: templates/core/coc.html:57
-msgid "In short"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
 msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
 msgstr ""
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
 msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
 msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
 msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
 msgstr ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
 msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
 msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
 msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sat"
 msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
 msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
 msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
 msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
 msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
 msgstr ""
 
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
 msgstr ""
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
 msgstr ""
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
 msgstr ""
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
 msgstr ""
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
 msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
 msgstr ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
 msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
 msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
 msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
 msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
 msgstr ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
 msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
 msgstr ""
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
 msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
 msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
 msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
 msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
 msgstr ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
 msgstr ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
 msgstr ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
 msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
 msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
 msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
 msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
 msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
 msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
 msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
 msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
 msgstr ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
 msgstr ""
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
 msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
 msgstr ""
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
 msgstr ""
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
 msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
 msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
 msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
 msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
 msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
 msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
 msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
-#: templates/global/menu.html:25
-msgid "Jobs"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
 msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""

--- a/locale/fr/LC_MESSAGES/django.po
+++ b/locale/fr/LC_MESSAGES/django.po
@@ -1,48 +1,82 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: fr\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: fr\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
 msgstr "Une demande existe déjà avec cet email."
 
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
+msgstr ""
+
 #: applications/models.py:19
 msgid "Apply for a spot at Django Girls [City]!"
 msgstr "Effectuer une demande pour Django Girls [Ville]!"
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
-msgstr "Bravo ! Nous sommes ravis que vous souhaitiez participer à notre atelier. Veuillez noter que le fait de remplir le formulaire ci-dessous ne vous donne pas une place pour l'atelier, mais une chance d'en obtenir une. Le processus d'inscription est ouvert du {INSERT DATE} until {INSERT DATE}. Si vous êtes curieux à propos des critères pour la sélection des demandes, vous pouvez en apprendre davantage sur le <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Bonne chance !"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
+msgstr ""
+"Bravo ! Nous sommes ravis que vous souhaitiez participer à notre atelier. "
+"Veuillez noter que le fait de remplir le formulaire ci-dessous ne vous donne "
+"pas une place pour l'atelier, mais une chance d'en obtenir une. Le processus "
+"d'inscription est ouvert du {INSERT DATE} until {INSERT DATE}. Si vous êtes "
+"curieux à propos des critères pour la sélection des demandes, vous pouvez en "
+"apprendre davantage sur le <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Bonne chance !"
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
 "Django Girls"
-msgstr "Bonjour !\n"
+msgstr ""
+"Bonjour !\n"
 "\n"
-"Voici la confirmation de votre demande pour  <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Bravo ! C'est déjà un grand pas, nous sommes fiers de vous !\n"
+"Voici la confirmation de votre demande pour  <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Bravo ! C'est déjà un grand pas, nous "
+"sommes fiers de vous !\n"
 "\n"
-"Notez qu'il ne s'agit pas d'une confirmation de participation à l'événement, mais d'une confirmation que nous avons reçu votre candidature.\n"
+"Notez qu'il ne s'agit pas d'une confirmation de participation à l'événement, "
+"mais d'une confirmation que nous avons reçu votre candidature.\n"
 "\n"
-"Vous recevrez bientôt un email de l'équipe qui organise les Django Girls {CITY}. Vous pouvez toujours les joindre en répondant à cet email ou en écrivant à {le mail de l'événement}.\n"
+"Vous recevrez bientôt un email de l'équipe qui organise les Django Girls "
+"{CITY}. Vous pouvez toujours les joindre en répondant à cet email ou en "
+"écrivant à {le mail de l'événement}.\n"
 "Pour votre référence, nous joignons vos réponses ci-dessous.\n"
 "\n"
 "Câlins, cupcakes et high-five !\n"
@@ -76,9 +110,10 @@ msgstr "La réponse à la question est-elle obligatoire ?"
 msgid "List all available options, separated with semicolon (;)"
 msgstr "Liste des options disponibles, séparées par des points virgules (;)"
 
-#. Simple quote in french a replaced by double quote, there is no way to remove the error for the french language?
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+#, fuzzy
+#| msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr "Utilisé uniquement avec le type de question \"Choix\""
 
 #: applications/models.py:98
@@ -91,7 +126,9 @@ msgstr "Position de la question"
 
 #: applications/models.py:111
 msgid "You can only get choices for fields that have question_type == choices."
-msgstr "Vous ne pouvez avoir des choix multiples uniquement pour les champs qui ont le type question_type == choices."
+msgstr ""
+"Vous ne pouvez avoir des choix multiples uniquement pour les champs qui ont "
+"le type question_type == choices."
 
 #: applications/models.py:118 templates/applications/applications.html:37
 #: templates/applications/applications.html:86
@@ -138,27 +175,29 @@ msgstr "État de la demande"
 msgid "RSVP status"
 msgstr "RSVP statut"
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr "5 étant le plus positif, 1 étant le plus négatif."
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr "Des commentaires supplémentaires ?"
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr "Contenu du courriel"
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
-msgstr "Vous pouvez utiliser la syntaxe HTML dans ce message. La prévisualisation du message est sur la droite."
+msgstr ""
+"Vous pouvez utiliser la syntaxe HTML dans ce message. La prévisualisation du "
+"message est sur la droite."
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr "Destinataires"
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr "Seules les personnes assignées au groupe choisi recevront cet e-mail."
 
@@ -175,8 +214,13 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr "Souhaitez-vous recevoir des nouvelles de l'équipe Django Girls ?"
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
-msgstr "Pas de spam, promis ! Seulement des conseils de programmation utiles et les dernières nouvelles du monde des Django Girls. Nous l'envoyons une fois toutes les deux semaines."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
+msgstr ""
+"Pas de spam, promis ! Seulement des conseils de programmation utiles et les "
+"dernières nouvelles du monde des Django Girls. Nous l'envoyons une fois "
+"toutes les deux semaines."
 
 #: applications/questions.py:59
 msgid "Yes, please!"
@@ -223,14 +267,24 @@ msgid "What is your current level of experience with programming?"
 msgstr "Quel est votre niveau actuel en programmation ?"
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
-msgstr "Je suis une personne débutante totale, je n'y connais rien ; j'ai déjà essayé le HTML ou le CSS ; j'ai déjà essayé le JavaScript ; j'ai suivi quelques leçons de Python ; j'ai déjà construit un site web ; je travaille en tant que développeuse/développeur"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
+msgstr ""
+"Je suis une personne débutante totale, je n'y connais rien ; j'ai déjà "
+"essayé le HTML ou le CSS ; j'ai déjà essayé le JavaScript ; j'ai suivi "
+"quelques leçons de Python ; j'ai déjà construit un site web ; je travaille "
+"en tant que développeuse/développeur"
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
-msgstr "Si vous avez coché autre chose que débutant, pourriez-vous nous en dire un peu plus sur vos connaissances en programmation ?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
+msgstr ""
+"Si vous avez coché autre chose que débutant, pourriez-vous nous en dire un "
+"peu plus sur vos connaissances en programmation ?"
 
-#. Is occupation in the meaning of job here ?
 #: applications/questions.py:115
 msgid "What is your current occupation?"
 msgstr "Quelle est votre profession actuelle ?"
@@ -249,31 +303,58 @@ msgstr "Parlez-nous de vos motivations et de vos aspirations."
 
 #: applications/questions.py:125
 msgid "How are you planning to share what you've learnt with others?"
-msgstr "Comment comptez-vous partager ce que vous avez appris avec les autres ?"
+msgstr ""
+"Comment comptez-vous partager ce que vous avez appris avec les autres ?"
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
-msgstr "Django Girls est une organisation gérée par des bénévoles et nous recherchons des personnes qui sont actives et qui peuvent nous aider à aider plus de femmes à entrer dans le domaine. Nous souhaitons que vous partagiez ce que vous avez appris lors de l'atelier avec d'autres personnes de différentes manières : en organisant un événement Django Girls dans votre ville, en parlant de Django Girls lors de vos rencontres locales, en écrivant un blog ou simplement en enseignant à vos amis."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
+msgstr ""
+"Django Girls est une organisation gérée par des bénévoles et nous "
+"recherchons des personnes qui sont actives et qui peuvent nous aider à aider "
+"plus de femmes à entrer dans le domaine. Nous souhaitons que vous partagiez "
+"ce que vous avez appris lors de l'atelier avec d'autres personnes de "
+"différentes manières : en organisant un événement Django Girls dans votre "
+"ville, en parlant de Django Girls lors de vos rencontres locales, en "
+"écrivant un blog ou simplement en enseignant à vos amis."
 
 #: applications/questions.py:138
 msgid "How did you hear about Django Girls?"
 msgstr "Comment avez-vous entendu parler de Django Girls ?"
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
-msgstr "Je reconnais que certaines de mes données seront utilisées sur des sites et services tiers."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
+msgstr ""
+"Je reconnais que certaines de mes données seront utilisées sur des sites et "
+"services tiers."
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
-msgstr "Les données collectées par le biais de ce formulaire ne sont utilisées que dans le cadre des événements Django Girls. Nous utilisons des sites et services tiers pour y parvenir : par exemple, nous utilisons Mandrill pour vous envoyer des emails. Ne vous inquiétez pas : nous ne partageons pas vos données avec des spammeurs, et nous ne les vendons pas ! Plus d'informations sur notre politique de confidentialité <a href='/privacy-cookies/'>here</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
+msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr "Oui"
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
-msgstr "Il est important que tous les participants se conforment au <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
+msgstr ""
+"Il est important que tous les participants se conforment au <a href='/"
+"coc/'>Django Girls Code of Conduct</a>"
 
 #: applications/questions.py:164
 msgid "I've read and understood the Django Girls Code of Conduct"
@@ -281,35 +362,69 @@ msgstr "J'ai lu et compris le code de conduite de Django Girls"
 
 #: applications/views.py:42
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
-msgstr "C'est parti ! Votre demande a été enregistrée. Nous vous contacterons bientôt !"
+msgstr ""
+"C'est parti ! Votre demande a été enregistrée. Nous vous contacterons "
+"bientôt !"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr "Numéro de demande"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr "État de la demande"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr "RSVP Statut"
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr "Score Moyen"
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr ""
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr ""
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr "Pas de @, Pas de http://, juste le pseudonyme"
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr "Pour un meilleur affichage, garder au format carré"
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
 msgstr "Coachs"
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
+msgstr ""
 
 #: contact/forms.py:15
 msgid "Django Girls workshop in..."
@@ -337,11 +452,14 @@ msgstr "Qui voulez-vous contacter ?"
 
 #: contact/views.py:17
 msgid "Thank you for your email. We will be in touch shortly."
-msgstr "Merci pour votre émail. Nous reviendrons vers vous dans les plus brefs délais."
+msgstr ""
+"Merci pour votre émail. Nous reviendrons vers vous dans les plus brefs "
+"délais."
 
 #: contact/views.py:19
 msgid "Ooops. We couldn't send your email :( Please try again later"
-msgstr "Oups. Nous n'avons pas pu envoyer votre email :( Veuillez réessayer plus tard"
+msgstr ""
+"Oups. Nous n'avons pas pu envoyer votre email :( Veuillez réessayer plus tard"
 
 #: core/admin/event.py:82
 msgid "past event?"
@@ -355,7 +473,7 @@ msgstr "Qui a des stats?"
 msgid "page URL"
 msgstr "URL de la page"
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr "Infos de l'événement"
 
@@ -379,9 +497,56 @@ msgstr "Statistiques"
 msgid "You cannot remove yourself from a team."
 msgstr "Vous ne pouvez pas vous retirer vous même de l'équipe."
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr ""
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
 msgstr "Supprimer les organisateurs"
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr ""
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr "Changer cela uniquement si vous savez ce que vous faites"
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr "Les deux mots de passe ne correspondent pas."
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr "Mot de passe"
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr "Confirmation du mot de passe"
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr "Entrez le même mot de passe, pour la vérification."
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
+msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
 msgid "Personal info"
@@ -394,10 +559,6 @@ msgstr "Permissions"
 #: core/admin/user.py:19
 msgid "Important dates"
 msgstr "Dates importantes"
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
-msgstr "Changer cela uniquement si vous savez ce que vous faites"
 
 #: core/default_eventpage_content.py:60
 msgid "About"
@@ -435,57 +596,99 @@ msgstr "Prénom et nom des organisateurs"
 msgid "E-mail address"
 msgstr "Adresses email"
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr "Les deux mots de passe ne correspondent pas."
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr "Mot de passe"
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr "Confirmation du mot de passe"
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr "Entrez le même mot de passe, pour la vérification."
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
-msgstr "Parlons de votre équipe. Qui est la personne qui organise principalement:"
+msgstr ""
+"Parlons de votre équipe. Qui est la personne qui organise principalement:"
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
-msgstr "La date de l'événement ne peut pas être une année seulement. S'il vous plaît, donnez au moins le mois et l'année."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
+msgstr ""
+"La date de l'événement ne peut pas être une année seulement. S'il vous "
+"plaît, donnez au moins le mois et l'année."
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
-msgstr "La date de l'événement est trop proche. La date de l'atelier doit être au moins 3 mois (90 jours) à partir d'aujourd'hui."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
+msgstr ""
+"La date de l'événement est trop proche. La date de l'atelier doit être au "
+"moins 3 mois (90 jours) à partir d'aujourd'hui."
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr "La date de l'événement doit être dans le futur"
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr "Liste des évènements Django Girls a travers le monde"
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr ""
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr "Anglais"
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr "Français"
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr "Allemand"
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr ""
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr ""
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
 msgstr "Portugais"
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr ""
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr ""
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
 
 #: organize/admin.py:16
 msgid "Move selected application to on hold"
@@ -495,21 +698,30 @@ msgstr "Déplacer la demande sélectionnée à mettre en attente"
 msgid "Move selected application to in review"
 msgstr "Déplacer la demande sélectionnée à mettre en révision"
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr "Informations de la demande"
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr "Demande"
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr "Organisateur principal"
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr ""
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
+msgstr ""
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
 
 #: organize/constants.py:4
@@ -556,135 +768,178 @@ msgstr "Rejeté"
 msgid "Deployed"
 msgstr "Déployé"
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr "Oui, j'ai organisé Django Girls"
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+#, fuzzy
+#| msgid "No, it’s my first time organizing Django Girls"
+msgid "No, it's my first time organizing Django Girls"
 msgstr "Non, c'est la première fois que j'organises Django Girls"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr "À distance"
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr "En personne"
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr "Choisir un événement"
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr "Vous devez choisir un événement."
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr "Choisir un pays"
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
-msgstr "Vous ne pouvez pas appliquer pour l'organisation d'un autre événement lorsque vous avez déjà fait une demande pour un autre événement."
+#: organize/forms.py:109
+#, fuzzy
+#| msgid ""
+#| "Your event date is too close. Workshop date should be at least 3 months "
+#| "(90 days) from now."
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
+msgstr ""
+"La date de l'événement est trop proche. La date de l'atelier doit être au "
+"moins 3 mois (90 jours) à partir d'aujourd'hui."
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
-msgstr "Vos ateliers devraient êtres à interval de 6 mois. Veuillez lire notre Manuel de l'Organisateur."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
+msgstr ""
+"Vous ne pouvez pas appliquer pour l'organisation d'un autre événement "
+"lorsque vous avez déjà fait une demande pour un autre événement."
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+"Vos ateliers devraient êtres à interval de 6 mois. Veuillez lire notre "
+"Manuel de l'Organisateur."
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr "À propos de l'organisateur"
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr "Motivations à organiser"
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr "Implication dans la communauté Django Girls"
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr "Expérience dans l'organisation d'événements"
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr "Informations sur le potentiel lieu"
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr "Informations sur les potentiels sponsors"
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr "Informations sur les potentiels coachs"
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr "Informations sur la procédure pour héberger l'événement en remote"
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
-msgstr "Informations sur l'assurance de la sécurité des participants et des coachs pendant la pandémie Covid-19"
-
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
+msgstr ""
+"Informations sur l'assurance de la sécurité des participants et des coachs "
+"pendant la pandémie Covid-19"
+
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr ""
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr ""
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr "Paiements incomplets"
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr "Marquer le paiement sélectionné comme complété"
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] ""
 msgstr[1] ""
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr "Marquer le paiement sélectionné comme complété"
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -714,7 +969,6 @@ msgstr "contributeur depuis"
 msgid "last update"
 msgstr "dernière mise à jour"
 
-#. A patron, and in this case for Patreon, is usually called a "contributeur". I don't know of any better word to express it, if someone has a better idea.
 #: patreonmanager/models.py:15 patreonmanager/models.py:54
 msgid "patron"
 msgstr "contributeur"
@@ -772,10 +1026,13 @@ msgid "payments"
 msgstr ""
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
 msgstr[0] ""
@@ -790,7 +1047,9 @@ msgid "Section background"
 msgstr ""
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
 msgstr ""
 
 #: pictures/models.py:39
@@ -805,11 +1064,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -822,11 +1081,15 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr ""
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:5
@@ -834,11 +1097,20 @@ msgid "Submitted applications"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
 msgstr ""
 
 #: templates/admin/core/event/view_add_organizers.html:6
@@ -858,7 +1130,9 @@ msgid "Remove event organizers"
 msgstr "Retirer les organisateurs d'événement"
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+#, fuzzy
+#| msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr "Ici vous pouvez retirer les organisateurs d'événement existants"
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -866,6 +1140,8 @@ msgid "To get started, choose an event:"
 msgstr "Pour débuter, choisissez un événement:"
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, fuzzy, python-format
+#| msgid "Organizers of %(event_name)s"
 msgid "Organizers of %(event_name)s"
 msgstr "Organisateurs de %(event_name)"
 
@@ -882,17 +1158,52 @@ msgid "Action"
 msgstr "Action"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
-msgstr "'Êtes-vous certain de vouloir retirer l'organisateur %(org_email) de l'événement %(event_name)?'"
+#, fuzzy, python-format
+#| msgid ""
+#| "'Are you sure that you want to remove organizer %(org_email)s from event "
+#| "%(event_name)s?'"
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
+msgstr ""
+"'Êtes-vous certain de vouloir retirer l'organisateur %(org_email) de "
+"l'événement %(event_name)?'"
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr "Retirer"
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
 msgstr "Triage"
+
+#: templates/admin/core/organizerissue/change_form.html:15
+#, fuzzy
+#| msgid "Main organizer"
+msgid "Blacklist Organizer"
+msgstr "Organisateur principal"
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
+msgstr ""
 
 #: templates/admin/organize/eventapplication/change_form.html:15
 msgid "Accept application"
@@ -910,19 +1221,28 @@ msgstr "Déplacer à En Attente"
 msgid "Reject application"
 msgstr "Rejeter la demande"
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr ""
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr "Demande fermée."
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -932,14 +1252,20 @@ msgid "Yes, I'm sure"
 msgstr "Oui, je suis certain"
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -948,10 +1274,12 @@ msgid "Scores"
 msgstr ""
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr ""
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr ""
 
@@ -977,6 +1305,7 @@ msgid "Save & draw next"
 msgstr ""
 
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr ""
 
@@ -1057,17 +1386,30 @@ msgid "Nothing to see here..."
 msgstr "Rien à voir..."
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
-msgstr "Attention! Ce formulaire n'a pas de question de type \"email\"! Il est important de correctement collecter le courriel des candidats, autrement vous ne pourrez pas les contacter à travers notre système. :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
+msgstr ""
+"Attention! Ce formulaire n'a pas de question de type \"email\"! Il est "
+"important de correctement collecter le courriel des candidats, autrement "
+"vous ne pourrez pas les contacter à travers notre système. :sadpanda:"
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
 msgstr ""
 
@@ -1076,6 +1418,8 @@ msgid "Submit your application"
 msgstr "Soumettre votre demande"
 
 #: templates/applications/communication.html:14
+#, fuzzy, python-format
+#| msgid "Send email to applicants of %(title)s"
 msgid "Send email to applicants of %(title)s"
 msgstr "Envoyer un courriel au demandeur de %(title)"
 
@@ -1109,6 +1453,7 @@ msgid "Create one!"
 msgstr ""
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr ""
 
@@ -1137,8 +1482,11 @@ msgid "Email preview"
 msgstr ""
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
 msgstr ""
 
@@ -1151,20 +1499,31 @@ msgid "Emails that failed to sent:"
 msgstr ""
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
 msgstr ""
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
 msgstr ""
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 msgstr ""
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
@@ -1186,11 +1545,15 @@ msgstr "Bonjour! Je voudrais recevoir de vos nouvelles!"
 
 #: templates/contact/contact.html:16
 msgid "To be sure your email reach the right person, check this FAQ first!"
-msgstr "Pour être certain que ce courriel soit bien acheminé, consultez notre FAQ!"
+msgstr ""
+"Pour être certain que ce courriel soit bien acheminé, consultez notre FAQ!"
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
 msgstr ""
@@ -1204,8 +1567,14 @@ msgid "Django Girls Annual Report 2015"
 msgstr "Rapport Annuel 2015 de Django Girls"
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
-msgstr "Merci aux organisateurs, coaches et autres bénévoles de tous les pays du monde, 2015 a été une année incroyable pour Django Girls. Lire tout sur nos défis et accomplissements de 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
+msgstr ""
+"Merci aux organisateurs, coaches et autres bénévoles de tous les pays du "
+"monde, 2015 a été une année incroyable pour Django Girls. Lire tout sur nos "
+"défis et accomplissements de 2015."
 
 #: templates/core/2015.html:25
 msgid "Annual Report 2015"
@@ -1220,7 +1589,14 @@ msgid "Financial Transparency 💰🔍"
 msgstr "Transparence Financière 💰🔍"
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
 msgstr ""
 
 #: templates/core/2015.html:58
@@ -1228,12 +1604,28 @@ msgid "Expenses 💸"
 msgstr "Dépenses 💸"
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
 msgstr ""
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
-msgstr "Un autre coût significatif a été d'envoyer quelques membres d'équipes de Django Girls au EuroPython, mais ce coût a été recoupé par une généreuse subvention de Divio. Leur parrainage a complètement couvert les frais reliés à l'envoie de 3 membres de l'équipe Django Girls à l'EuroPython en Espagne."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
+msgstr ""
+"Un autre coût significatif a été d'envoyer quelques membres d'équipes de "
+"Django Girls au EuroPython, mais ce coût a été recoupé par une généreuse "
+"subvention de Divio. Leur parrainage a complètement couvert les frais reliés "
+"à l'envoie de 3 membres de l'équipe Django Girls à l'EuroPython en Espagne."
 
 #: templates/core/2015.html:77
 msgid "Expense"
@@ -1245,6 +1637,7 @@ msgid "Amount"
 msgstr "Montant"
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr "%% des dépenses"
 
@@ -1277,11 +1670,23 @@ msgid "Income 🌟👀"
 msgstr ""
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
 msgstr ""
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
 msgstr ""
 
 #: templates/core/2015.html:122
@@ -1289,6 +1694,7 @@ msgid "Income"
 msgstr ""
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr ""
 
@@ -1301,6 +1707,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr ""
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr ""
 
@@ -1325,7 +1732,11 @@ msgid "Total income"
 msgstr ""
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
 msgstr ""
 
 #: templates/core/2015.html:151
@@ -1337,19 +1748,37 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr "En 2016, nous allons nous concentrer sur les initiatives suivantes:"
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
 msgstr ""
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
 msgstr ""
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
 msgstr ""
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
 msgstr ""
 
 #: templates/core/2015.html:187
@@ -1357,75 +1786,175 @@ msgid "Achievements & Events in 2015 🏆🏅"
 msgstr "Réalisations & Événements en 2015 🏆🏅"
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
-msgstr "2015 était pour nous une année palpitante. Voici un compte-rendu des événements, saison par saison."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
+msgstr ""
+"2015 était pour nous une année palpitante. Voici un compte-rendu des "
+"événements, saison par saison."
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
 msgstr ""
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
 msgstr ""
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
 msgstr ""
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
 msgstr ""
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
 msgstr ""
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
 msgstr ""
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
 msgstr ""
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
 msgstr ""
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
 msgstr ""
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
 msgstr ""
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
 msgstr ""
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
 msgstr ""
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
 msgstr ""
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
 msgstr ""
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
 msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
 msgstr ""
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
 msgstr ""
 
 #: templates/core/2015.html:351
@@ -1433,39 +1962,95 @@ msgid "Success stories 💖"
 msgstr ""
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
 msgstr ""
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
 msgstr ""
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
 msgstr ""
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
 msgstr ""
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
 msgstr ""
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
 msgstr ""
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
 msgstr ""
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
 msgstr ""
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
 msgstr ""
 
 #: templates/core/2015.html:461
@@ -1477,15 +2062,31 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr ""
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
 msgstr ""
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
 msgstr ""
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
 msgstr ""
 
 #: templates/core/2015.html:479
@@ -1497,43 +2098,77 @@ msgid "Sponsors 📢️"
 msgstr ""
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
 msgstr ""
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
 msgstr ""
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
@@ -1541,7 +2176,10 @@ msgid "Django Girls Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
 msgstr ""
 
 #: templates/core/2016-2017.html:26
@@ -1549,11 +2187,25 @@ msgid "Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
 msgstr ""
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
 msgstr ""
 
 #: templates/core/2016-2017.html:50
@@ -1561,35 +2213,55 @@ msgid "✨ Highlights ✨"
 msgstr ""
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
 msgstr ""
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
 msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr ""
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:94
@@ -1645,11 +2317,23 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr ""
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
 msgstr ""
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
 msgstr ""
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
@@ -1661,11 +2345,22 @@ msgid "🎁 Organiser Starter Kits"
 msgstr ""
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
 msgstr ""
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
 msgstr ""
 
 #: templates/core/2016-2017.html:169
@@ -1673,7 +2368,12 @@ msgid "💰 Fundraising"
 msgstr ""
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
 msgstr ""
 
 #: templates/core/2016-2017.html:183
@@ -1705,11 +2405,31 @@ msgid "Participants Survey"
 msgstr ""
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
 msgstr ""
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
 msgstr ""
 
 #: templates/core/2016-2017.html:227
@@ -1717,15 +2437,29 @@ msgid "Participants’ Involvement in Tech Activities"
 msgstr ""
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
 msgstr ""
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
 msgstr ""
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
 msgstr ""
 
 #: templates/core/2016-2017.html:258
@@ -1733,19 +2467,33 @@ msgid "Participants’ learning to code after the workshop"
 msgstr ""
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
 msgstr ""
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
 msgstr ""
 
 #: templates/core/2016-2017.html:291
@@ -1753,19 +2501,35 @@ msgid "Participants’ Employment in Tech after attending workshops"
 msgstr ""
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
+#, python-format
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
 msgstr ""
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
 msgstr ""
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
 msgstr ""
 
 #: templates/core/2016-2017.html:326
@@ -1773,19 +2537,39 @@ msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr ""
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
 msgstr ""
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
 msgstr ""
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:362
@@ -1793,16 +2577,187 @@ msgid "Summary"
 msgstr ""
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
 msgstr ""
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
 msgstr ""
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
 msgstr ""
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr "Django Girls Code de Conduite"
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr "Code de Conduite"
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr ""
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+"Django Girls est un évènement accueillant, pendant lequel des personnes se "
+"rencontrent dans un environnement convivial. Dès lors, nous attendons de "
+"chaque participant·e qu'iel fasse preuve de respect et de courtoisie envers "
+"les autres personnes durant les ateliers."
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+"Afin d'expliciter le comportement que nous attendons, tous·tes les "
+"participant·e·s, organisateurs·rices, exposant·e·s, et volontaires de "
+"n'importe quel évènement Django Girls doivent se conformer au Code de "
+"Conduite suivant. Les organisateurs·rices devront faire appliquer ce "
+"règlement durant toute la tenue de l'évènement."
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr "Version courte"
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+"Django Girls est dédié à l'organisation d'ateliers sans harcèlement, qu’il "
+"soit lié au genre, à l'orientation sexuelle, au handicap, à l'apparence "
+"physique, au poids, à la race, ou à la religion."
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+"Nous ne tolèrerons aucune forme d’harcèlement envers les participant·e·s."
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+"Les comportements ou l'utilisation d'images à connotation sexuelle ne sont "
+"en aucun cas appropriés, que ce soit pendant l’atelier ou dans le cadre de "
+"présentations."
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+"Faites attention aux autres. N'insultez pas ou ne rabaissez pas les autres "
+"participant·e·s. Soyez professionnels·elles. Ne prenez ni ne publiez de "
+"photographie sans avoir obtenu le consentement des personnes concernées. "
+"Rappelez-vous que les blagues racistes, sexistes, discriminantes ou "
+"excluantes ne seront en aucun cas tolérées pendant un évènement Django Girls."
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+"Les participant·e·s qui violeraient ces règles pourraient se voir "
+"sanctionner ou exclu·e·s de l'évènement et ce, sans aucun dédommagement "
+"possible de la part des organisateurs·rices."
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr "Version longue"
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr "Que faire en cas de harcèlement ?"
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+"Si vous vous sentez harcelé, si vous pensez qu’une personne se fait "
+"harceler, ou plus généralement en cas de soucis, merci de contacter "
+"immédiatement votre coach ou un⋅e organisateurs⋅rices."
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
+msgstr ""
+"Les organisateurs⋅rices sont particulièrement renseigné⋅e⋅s sur comment "
+"gérer ce genre d’incident et sur quelles suites donner en fonction de chaque "
+"situation. Les organisateurs⋅rices seront heureux⋅ses d'aider les "
+"participant⋅e⋅s à contacter l’équipe, la sécurité en charge des lieux ou les "
+"forces de l’ordre, ainsi que de fournir une escorte ou d’aider toute "
+"personne qui aura été harcelée à se sentir en sécurité pendant le reste de "
+"l’atelier. Nous accordons beaucoup d’importance à votre présence."
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
 #: templates/global/menu.html:26
@@ -1810,7 +2765,12 @@ msgid "Contribute"
 msgstr ""
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
 msgstr ""
 
 #: templates/core/contribute.html:22
@@ -1818,11 +2778,22 @@ msgid "Support us!"
 msgstr ""
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
 msgstr ""
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
 msgstr ""
 
 #: templates/core/contribute.html:46
@@ -1830,11 +2801,17 @@ msgid "Organize!"
 msgstr ""
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
 msgstr ""
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:72
@@ -1842,15 +2819,23 @@ msgid "Coach!"
 msgstr ""
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
 msgstr ""
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
 msgstr ""
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
 msgstr ""
 
 #: templates/core/contribute.html:99
@@ -1862,11 +2847,15 @@ msgid "Computer screen with a console and a webpage."
 msgstr ""
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
 msgstr ""
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:123
@@ -1878,11 +2867,16 @@ msgid "A note book and a pen."
 msgstr ""
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
 msgstr ""
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
 msgstr ""
 
 #: templates/core/contribute.html:140
@@ -1894,11 +2888,18 @@ msgid "A computer screen saying hello and golden balloons saying yay!."
 msgstr ""
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
 msgstr ""
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
 msgstr ""
 
 #: templates/core/contribute.html:166
@@ -1910,11 +2911,17 @@ msgid "A web page opened on a computer."
 msgstr ""
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
 msgstr ""
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
 msgstr ""
 
 #: templates/core/contribute.html:188
@@ -1926,11 +2933,16 @@ msgid "A pile a tattoo."
 msgstr ""
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
 msgstr ""
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:11
@@ -1938,7 +2950,13 @@ msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
@@ -1946,14 +2964,22 @@ msgid "Our awesome supporters ✨"
 msgstr ""
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
 msgstr ""
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
 msgstr ""
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
@@ -1982,7 +3008,11 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr ""
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
 msgstr ""
 
 #: templates/core/faq.html:20
@@ -1998,27 +3028,67 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr ""
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
 msgstr ""
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
 msgstr ""
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
 msgstr ""
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
 msgstr ""
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
 msgstr ""
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
 msgstr ""
 
 #: templates/core/faq.html:109
@@ -2026,7 +3096,9 @@ msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr ""
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
 msgstr ""
 
 #: templates/core/faq.html:117
@@ -2034,11 +3106,29 @@ msgid "We are trans-inclusive and welcome applications from all women."
 msgstr ""
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
 msgstr ""
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
 msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
@@ -2055,7 +3145,9 @@ msgid "We inspire women to fall in love with programming."
 msgstr "Nous incitons les femmes à tomber amoureuses de la programmation."
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
 msgstr ""
 
 #: templates/core/index.html:29
@@ -2063,11 +3155,20 @@ msgid "What is Django Girls?"
 msgstr "Qu'est-ce que Django Girls?"
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
 msgstr ""
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
 msgstr ""
 
 #: templates/core/index.html:53
@@ -2075,11 +3176,22 @@ msgid "Django Girls impact"
 msgstr ""
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
 msgstr ""
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
 msgstr ""
 
 #: templates/core/index.html:69
@@ -2091,11 +3203,18 @@ msgid "Bring Django Girls to your city!"
 msgstr ""
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
 msgstr ""
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
 msgstr ""
 
 #: templates/core/index.html:82 templates/organize/index.html:89
@@ -2103,6 +3222,7 @@ msgid "Apply to organize a workshop"
 msgstr ""
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr ""
 
@@ -2111,7 +3231,9 @@ msgid "Badass Django Ladies"
 msgstr ""
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
 msgstr ""
 
 #: templates/core/index.html:125
@@ -2131,7 +3253,15 @@ msgid "Support our work"
 msgstr ""
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
@@ -2139,7 +3269,11 @@ msgid "Make a recurring donation on Patreon"
 msgstr ""
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
 msgstr ""
 
 #: templates/core/index.html:162
@@ -2147,7 +3281,9 @@ msgid "Stay up to date!"
 msgstr ""
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
 msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
@@ -2163,12 +3299,51 @@ msgstr ""
 msgid "See the Django Girls Dispatch archives"
 msgstr ""
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr ""
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr ""
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
 msgstr ""
 
 #: templates/core/newsletter.html:4
@@ -2180,11 +3355,16 @@ msgid "Django Girls Dispatch"
 msgstr ""
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
 msgstr ""
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
 msgstr ""
 
 #: templates/core/newsletter.html:49
@@ -2196,11 +3376,15 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:20
@@ -2220,19 +3404,31 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:53
@@ -2244,15 +3440,25 @@ msgid "Scope of this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:74
@@ -2260,7 +3466,9 @@ msgid "Data Collected"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:79
@@ -2296,7 +3504,9 @@ msgid "operating system (automatically collected); and"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:90
@@ -2308,15 +3518,22 @@ msgid "We will keep any personal Data you submit for 60 months."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:108
@@ -2332,15 +3549,21 @@ msgid "improvement of our products / services;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:115
@@ -2352,15 +3575,25 @@ msgid "Third Party Sites and Services"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:142
@@ -2368,7 +3601,11 @@ msgid "Links to Other Websites"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:151
@@ -2376,7 +3613,12 @@ msgid "Changes of Business Ownership and Control"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:161
@@ -2388,7 +3630,9 @@ msgid "Controlling Use of Your Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:167
@@ -2408,11 +3652,17 @@ msgid "Your Right to Withhold Information"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:178
@@ -2420,7 +3670,9 @@ msgid "Accessing Your Own Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:182
@@ -2428,7 +3680,10 @@ msgid "Security"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:186
@@ -2436,27 +3691,49 @@ msgid "Cookies"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:201
@@ -2464,19 +3741,29 @@ msgid "You can choose to enable or disable Cookies in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:214
@@ -2484,7 +3771,11 @@ msgid "Changes to this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
 msgstr ""
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
@@ -2493,7 +3784,11 @@ msgid "Resources"
 msgstr ""
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
 msgstr ""
 
 #: templates/core/resources.html:22
@@ -2505,7 +3800,10 @@ msgid "Tutorial Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
 msgstr ""
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
@@ -2522,7 +3820,10 @@ msgid "Organize Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
 msgstr ""
 
 #: templates/core/resources.html:67
@@ -2530,7 +3831,10 @@ msgid "Coaching Guide Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
 msgstr ""
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
@@ -2542,7 +3846,10 @@ msgid "Tutorial Extensions Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
 msgstr ""
 
 #: templates/core/terms_conditions.html:4
@@ -2552,11 +3859,17 @@ msgstr ""
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
 msgstr ""
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/terms_conditions.html:18
@@ -2572,7 +3885,10 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr ""
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:39
@@ -2580,7 +3896,9 @@ msgid "Agreement"
 msgstr ""
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
 msgstr ""
 
 #: templates/core/terms_conditions.html:44
@@ -2596,19 +3914,26 @@ msgid "You promise us:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
 msgstr ""
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
 msgstr ""
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:53
@@ -2616,15 +3941,25 @@ msgid "That you won’t do anything that might cause our systems to crash."
 msgstr ""
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
 msgstr ""
 
 #: templates/core/terms_conditions.html:59
@@ -2632,11 +3967,20 @@ msgid "Intellectual property"
 msgstr ""
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:71
@@ -2644,11 +3988,17 @@ msgid "Price and payment"
 msgstr ""
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
 msgstr ""
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:86
@@ -2656,7 +4006,11 @@ msgid "Use of communications facilities"
 msgstr ""
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:90
@@ -2664,51 +4018,79 @@ msgid "you must not use language that may be offensive to other Users;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
 msgstr ""
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
 msgstr ""
 
 #: templates/core/terms_conditions.html:114
@@ -2716,7 +4098,10 @@ msgid "Privacy and cookies"
 msgstr ""
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:123
@@ -2732,7 +4117,9 @@ msgid "that the Site will meet your needs;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:130
@@ -2756,19 +4143,35 @@ msgid "that the Site is secure,"
 msgstr ""
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
 msgstr ""
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
 msgstr ""
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
 msgstr ""
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
 msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
@@ -2776,11 +4179,20 @@ msgid "Events"
 msgstr ""
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
 msgstr ""
 
 #: templates/core/terms_conditions.html:164
@@ -2788,11 +4200,15 @@ msgid "Problems"
 msgstr ""
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
 msgstr ""
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
 msgstr ""
 
 #: templates/core/terms_conditions.html:170
@@ -2800,11 +4216,16 @@ msgid "Availability of the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
 msgstr ""
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:176
@@ -2812,7 +4233,11 @@ msgid "Limitation of liability"
 msgstr ""
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:180
@@ -2820,7 +4245,9 @@ msgid "You use the Site and its Content at your own risk."
 msgstr ""
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
 msgstr ""
 
 #: templates/core/terms_conditions.html:184
@@ -2828,11 +4255,16 @@ msgid "Linking"
 msgstr ""
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
 msgstr ""
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:190
@@ -2840,15 +4272,23 @@ msgid "We can never guarantee that a link will work."
 msgstr ""
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
 msgstr ""
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:199
@@ -2864,7 +4304,9 @@ msgid "you can only link from a site that you own;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:203
@@ -2872,7 +4314,9 @@ msgid "you mustn’t frame our Site on any other site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
 msgstr ""
 
 #: templates/core/terms_conditions.html:208
@@ -2880,11 +4324,18 @@ msgid "Modifications to these T&Cs & the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
 msgstr ""
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
 msgstr ""
 
 #: templates/core/terms_conditions.html:221
@@ -2892,39 +4343,66 @@ msgid "General stuff"
 msgstr ""
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
 msgstr ""
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
 msgstr ""
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
 msgstr ""
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
 msgstr ""
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:235
@@ -2936,15 +4414,22 @@ msgid "Definitions"
 msgstr ""
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
 msgstr ""
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:244
@@ -2952,7 +4437,10 @@ msgid "<b>Organiser</b> means the organiser or promoter of an Event."
 msgstr ""
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:253
@@ -2960,7 +4448,8 @@ msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr ""
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
 msgstr ""
 
 #: templates/core/workshop_box.html:9
@@ -2968,7 +4457,10 @@ msgid "Order Django Girls Workshop Box for your event!"
 msgstr ""
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
 msgstr ""
 
 #: templates/core/workshop_box.html:27
@@ -2976,11 +4468,19 @@ msgid "How it works?"
 msgstr ""
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
 msgstr ""
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
 msgstr ""
 
 #: templates/core/workshop_box.html:44
@@ -3044,7 +4544,11 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr ""
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
 msgstr ""
 
 #: templates/core/workshop_box.html:78
@@ -3052,7 +4556,12 @@ msgid "How to get one?"
 msgstr ""
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
 msgstr ""
 
 #: templates/core/workshop_box.html:86
@@ -3060,7 +4569,9 @@ msgid "Requirements to apply for a free box:"
 msgstr ""
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
 msgstr ""
 
 #: templates/core/workshop_box.html:89
@@ -3072,11 +4583,16 @@ msgid "Application process for your event needs to be open"
 msgstr ""
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
 msgstr ""
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
 msgstr ""
 
 #: templates/default/about.html:4
@@ -3096,7 +4612,9 @@ msgid "Applications are now open!"
 msgstr ""
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
 msgstr ""
 
 #: templates/default/apply.html:10
@@ -3108,7 +4626,10 @@ msgid "Be a Mentor!"
 msgstr ""
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
 msgstr ""
 
 #: templates/default/coach.html:16 templates/default/values.html:5
@@ -3116,15 +4637,23 @@ msgid "Django Girls"
 msgstr ""
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
 msgstr ""
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 msgstr ""
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
 msgstr ""
 
 #: templates/default/faq.html:6
@@ -3132,7 +4661,10 @@ msgid "Do I need to know anything about websites or programming?"
 msgstr ""
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
 msgstr ""
 
 #: templates/default/faq.html:18
@@ -3140,7 +4672,11 @@ msgid "I am not living in Germany, can I attend?"
 msgstr ""
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
 msgstr ""
 
 #: templates/default/faq.html:31
@@ -3148,7 +4684,10 @@ msgid "Should I bring my own laptop?"
 msgstr ""
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
 msgstr ""
 
 #: templates/default/faq.html:45
@@ -3156,7 +4695,10 @@ msgid "Do I need to have something installed on my laptop?"
 msgstr ""
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
 msgstr ""
 
 #: templates/default/faq.html:58
@@ -3164,7 +4706,11 @@ msgid "Is EuroPython conference good for a total beginner?"
 msgstr ""
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
 msgstr ""
 
 #: templates/default/faq.html:70
@@ -3172,11 +4718,17 @@ msgid "Is food provided?"
 msgstr ""
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
 msgstr ""
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
 msgstr ""
 
 #: templates/default/partners.html:3
@@ -3184,23 +4736,40 @@ msgid "Sponsors"
 msgstr ""
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
 msgstr ""
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
 msgstr ""
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
 msgstr ""
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
 msgstr ""
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
 msgstr ""
 
 #: templates/default/values.html:33
@@ -3208,7 +4777,10 @@ msgid "Apply for the workshop!"
 msgstr ""
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
 msgstr ""
 
 #: templates/default/values.html:43
@@ -3216,7 +4788,9 @@ msgid "As a workshop attendee you will:"
 msgstr ""
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
 msgstr ""
 
 #: templates/default/values.html:48
@@ -3224,7 +4798,9 @@ msgid "be fed by us: during our event, food is provided"
 msgstr ""
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
 msgstr ""
 
 #: templates/donations/donate.html:13
@@ -3236,19 +4812,37 @@ msgid "Our mission:"
 msgstr ""
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
 msgstr ""
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
 msgstr ""
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
 msgstr ""
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
 msgstr ""
 
 #: templates/donations/donate.html:54
@@ -3264,11 +4858,19 @@ msgid "Monthly donations"
 msgstr ""
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
 msgstr ""
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
 
 #: templates/donations/donate.html:105
@@ -3276,11 +4878,16 @@ msgid "One-time donations"
 msgstr ""
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
 msgstr ""
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
 msgstr ""
 
 #: templates/donations/donate.html:121
@@ -3300,15 +4907,10 @@ msgid "Humble Bundle Store"
 msgstr ""
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr ""
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr ""
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
 msgstr ""
 
 #: templates/donations/donate.html:161
@@ -3324,11 +4926,26 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr ""
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
 msgstr ""
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
 msgstr ""
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
@@ -3340,11 +4957,20 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr ""
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
 msgstr ""
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
 msgstr ""
 
 #: templates/donations/donate.html:213
@@ -3352,11 +4978,15 @@ msgid "Django Girls Summit:"
 msgstr ""
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
 msgstr ""
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
 msgstr ""
 
 #: templates/donations/error.html:7
@@ -3371,16 +5001,52 @@ msgstr ""
 msgid "Back to donation page"
 msgstr ""
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
 #: templates/donations/success.html:8
+#, python-format
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:3
+#, python-format
 msgid "Hello team %(city)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:8
@@ -3388,7 +5054,12 @@ msgid "Numbers"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:17
@@ -3396,7 +5067,10 @@ msgid "Tell us how it went!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:22
@@ -3404,7 +5078,12 @@ msgid "Share your experiences"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:27
@@ -3412,7 +5091,10 @@ msgid "Upload your photos"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:32
@@ -3420,7 +5102,11 @@ msgid "Donation"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:41
@@ -3428,11 +5114,19 @@ msgid "Discount in our store"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:55
@@ -3440,9 +5134,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -3453,10 +5147,12 @@ msgid "Hi there!"
 msgstr ""
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
 msgstr ""
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3465,29 +5161,39 @@ msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr ""
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
 msgstr ""
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
 msgstr ""
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3496,21 +5202,37 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
 msgstr ""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr ""
 
@@ -3519,11 +5241,17 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:17
@@ -3534,8 +5262,19 @@ msgstr ""
 msgid "Hello,"
 msgstr ""
 
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:16
@@ -3547,11 +5286,36 @@ msgid "Being an awesome person - already done! :)"
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
 msgstr ""
 
 #: templates/emails/organize/application_notification.html:3
@@ -3628,7 +5392,9 @@ msgid "Do you have potential coaches in mind?"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:9
@@ -3640,14 +5406,17 @@ msgid "1) Email address"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:22
@@ -3655,7 +5424,9 @@ msgid "Password:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:30
@@ -3663,7 +5434,9 @@ msgid "You can also add this inbox to your email client:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:39
@@ -3671,19 +5444,29 @@ msgid "2) Website"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:65
@@ -3691,30 +5474,40 @@ msgid "3) Organizers community"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -3723,55 +5516,91 @@ msgid "Hello there,"
 msgstr ""
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
 msgstr ""
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
 msgstr ""
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
 msgstr ""
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
 msgstr ""
 
 #: templates/global/footer.html:10
@@ -3786,12 +5615,12 @@ msgstr ""
 msgid "Chat with us!"
 msgstr ""
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr "Code de Conduite"
-
 #: templates/global/footer.html:14
 msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
 msgstr ""
 
 #: templates/global/footer.html:20
@@ -3808,6 +5637,10 @@ msgstr ""
 
 #: templates/global/footer.html:25
 msgid "Sponsor us"
+msgstr ""
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
 msgstr ""
 
 #: templates/global/footer.html:30
@@ -3835,22 +5668,27 @@ msgid "Privacy & Cookies"
 msgstr ""
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr ""
 
 #: templates/global/footer.html:61
+#, python-format
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr ""
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
 msgstr ""
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
 msgstr ""
 
 #: templates/global/footer.html:64
+#, python-format
 msgid "<b>%(countries_count)s</b> countries"
 msgstr ""
 
@@ -3862,8 +5700,12 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
 msgstr ""
 
 #: templates/global/menu.html:31
@@ -3883,7 +5725,11 @@ msgid "Q: How can I register?"
 msgstr ""
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
 msgstr ""
 
 #: templates/includes/_faq.html:23
@@ -3891,7 +5737,12 @@ msgid "Q: I missed the deadline! Can I still apply to a workshop?"
 msgstr ""
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
 msgstr ""
 
 #: templates/includes/_faq.html:41
@@ -3899,15 +5750,23 @@ msgid "Q: I want to coach or sponsor an event!"
 msgstr ""
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
 msgstr ""
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
 msgstr ""
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
 msgstr ""
 
 #: templates/includes/_no_event.html:5
@@ -3919,7 +5778,8 @@ msgid "Sign up for our newsletter"
 msgstr ""
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
 msgstr ""
 
 #: templates/includes/_no_event.html:16
@@ -3931,11 +5791,38 @@ msgid "Your city"
 msgstr ""
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
 msgstr ""
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
+msgstr ""
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr ""
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr ""
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
 msgstr ""
 
 #: templates/organize/commitment.html:20
@@ -3943,23 +5830,36 @@ msgid "Django Girls Organizer Commitement"
 msgstr ""
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
 msgstr ""
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
 msgstr ""
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
 msgstr ""
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
 msgstr ""
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
 msgstr ""
 
 #: templates/organize/commitment.html:49
@@ -3971,7 +5871,10 @@ msgid "Welcome to Django Girls!"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:14
@@ -3991,7 +5894,8 @@ msgid "Our private community of organizers on Slack (a group chat application)"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:31
@@ -4002,12 +5906,96 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:80
@@ -4016,17 +6004,16 @@ msgstr ""
 msgid "Go to next step"
 msgstr ""
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr ""
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:73
@@ -4034,7 +6021,9 @@ msgid "Check boxes next to all the things that describe you"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:25
@@ -4064,6 +6053,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -4072,7 +6062,10 @@ msgid "Your organizing team"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
 msgstr ""
 
 #: templates/organize/form/step4_workshop_type.html:25
@@ -4098,10 +6091,6 @@ msgstr ""
 #: templates/organize/form/step5_workshop.html:32
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:46
@@ -4131,7 +6120,10 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:89
@@ -4150,43 +6142,42 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -4196,7 +6187,9 @@ msgid "How will you host your workshop remotely?"
 msgstr ""
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:15
@@ -4204,23 +6197,39 @@ msgid "You rock!"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
 msgstr ""
 
 #: templates/organize/index.html:9
@@ -4228,11 +6237,13 @@ msgid "Organize Django Girls workshop"
 msgstr ""
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr ""
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
 msgstr ""
 
 #: templates/organize/index.html:24
@@ -4240,15 +6251,24 @@ msgid "In-Person Workshops"
 msgstr ""
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
 msgstr ""
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
 msgstr ""
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
 msgstr ""
 
 #: templates/organize/index.html:47
@@ -4256,15 +6276,26 @@ msgid "Remote Workshops"
 msgstr ""
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
 msgstr ""
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
 msgstr ""
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/organize/index.html:73
@@ -4272,7 +6303,9 @@ msgid "The Value of Organizing Django Girls"
 msgstr ""
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
 msgstr ""
 
 #: templates/organize/index.html:80
@@ -4304,31 +6337,52 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+#, fuzzy
+#| msgid "Apply for a pass!"
+msgid "Apply for Event Sponsorship"
+msgstr "Demander un pass!"
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
 msgstr ""
 
 #: templates/organize/prerequisites.html:29
@@ -4336,19 +6390,17 @@ msgid "Prerequisities to organize a Django Girls workshop"
 msgstr ""
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr ""
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr ""
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:51
@@ -4376,7 +6428,9 @@ msgid "You’re at least 18 years old"
 msgstr ""
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
 msgstr ""
 
 #: templates/organize/prerequisites.html:93
@@ -4384,7 +6438,9 @@ msgid "The event you’re organizing will be non-profit"
 msgstr ""
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
 msgstr ""
 
 #: templates/organize/prerequisites.html:111
@@ -4396,7 +6452,11 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr ""
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
 msgstr ""
 
 #: templates/organize/suspend.html:18
@@ -4408,7 +6468,10 @@ msgid "Password Reset Complete"
 msgstr ""
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:4
@@ -4416,7 +6479,9 @@ msgid "Password Reset"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:11
@@ -4429,7 +6494,11 @@ msgid "Check Your"
 msgstr ""
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:4
@@ -4437,7 +6506,10 @@ msgid "Forget your password?"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
 msgstr ""
 
 #: templates/registration/password_reset_form.html:11
@@ -4454,23 +6526,38 @@ msgid "Fill the form available on this page to apply for a GitHub grant."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
 msgstr ""
 
 #: templates/story/stories.html:9
@@ -4478,372 +6565,1582 @@ msgid "Django Girls Story"
 msgstr ""
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
 msgstr ""
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
 msgstr ""
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
 msgstr ""
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
 msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
 msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
 msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
 msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
 msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
-msgstr "Django Girls Code de Conduite"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+#, fuzzy
+#| msgid "Applications"
+msgid "Options"
+msgstr "Demandes"
+
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+#, fuzzy
+#| msgid "Password confirmation"
+msgid "Repeat for confirmation"
+msgstr "Confirmation du mot de passe"
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+#, fuzzy
+#| msgid "The two password fields didn't match."
+msgid "Error: The two entered values do not match."
+msgstr "Les deux mots de passe ne correspondent pas."
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+#, fuzzy
+#| msgid "Messaging"
+msgid "Messages"
+msgstr "Messages"
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+#, fuzzy
+#| msgid "Statistics"
+msgid "Static Files"
+msgstr "Statistiques"
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+#, fuzzy
+#| msgid "Application"
+msgid "Syndication"
+msgstr "Demande"
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+#, fuzzy
+#| msgid "Your e-mail address:"
+msgid "Enter a valid email address."
+msgstr "Votre adresse email:"
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+#, fuzzy
+#| msgid "Question"
+msgid "Duration"
+msgstr "Question"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Floating point number"
+msgstr "Votre téléphone:"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
+msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+#, fuzzy
+#| msgid "address"
+msgid "IPv4 address"
+msgstr "adresse"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+#, fuzzy
+#| msgid "address"
+msgid "IP address"
+msgstr "adresse"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+#, fuzzy
+#| msgid "Subject"
+msgid "A JSON object"
+msgstr "Sujet"
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
+msgstr ""
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+#, fuzzy
+#| msgid "Your phone number:"
+msgid "Enter a whole number."
+msgstr "Votre téléphone:"
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
 msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
-msgstr "Django Girls est un évènement accueillant, pendant lequel des personnes se rencontrent dans un environnement convivial. Dès lors, nous attendons de chaque participant·e qu'iel fasse preuve de respect et de courtoisie envers les autres personnes durant les ateliers."
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+#, fuzzy
+#| msgid "Status"
+msgid "Sat"
+msgstr "Statut"
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
-msgstr "Afin d'expliciter le comportement que nous attendons, tous·tes les participant·e·s, organisateurs·rices, exposant·e·s, et volontaires de n'importe quel évènement Django Girls doivent se conformer au Code de Conduite suivant. Les organisateurs·rices devront faire appliquer ce règlement durant toute la tenue de l'évènement."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
 
-#: templates/core/coc.html:57
-msgid "In short"
-msgstr "Version courte"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
-msgstr "Django Girls est dédié à l'organisation d'ateliers sans harcèlement, qu’il soit lié au genre, à l'orientation sexuelle, au handicap, à l'apparence physique, au poids, à la race, ou à la religion."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
+msgstr ""
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
-msgstr "Nous ne tolèrerons aucune forme d’harcèlement envers les participant·e·s."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
-msgstr "Les comportements ou l'utilisation d'images à connotation sexuelle ne sont en aucun cas appropriés, que ce soit pendant l’atelier ou dans le cadre de présentations."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
+msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
-msgstr "Faites attention aux autres. N'insultez pas ou ne rabaissez pas les autres participant·e·s. Soyez professionnels·elles. Ne prenez ni ne publiez de photographie sans avoir obtenu le consentement des personnes concernées. Rappelez-vous que les blagues racistes, sexistes, discriminantes ou excluantes ne seront en aucun cas tolérées pendant un évènement Django Girls."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
-msgstr "Les participant·e·s qui violeraient ces règles pourraient se voir sanctionner ou exclu·e·s de l'évènement et ce, sans aucun dédommagement possible de la part des organisateurs·rices."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
-msgstr "Version longue"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
 msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
 msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
 msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
 msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
 msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
-msgstr "Que faire en cas de harcèlement ?"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
-msgstr "Si vous vous sentez harcelé, si vous pensez qu’une personne se fait harceler, ou plus généralement en cas de soucis, merci de contacter immédiatement votre coach ou un⋅e organisateurs⋅rices."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
+msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
-msgstr "Les organisateurs⋅rices sont particulièrement renseigné⋅e⋅s sur comment gérer ce genre d’incident et sur quelles suites donner en fonction de chaque situation. Les organisateurs⋅rices seront heureux⋅ses d'aider les participant⋅e⋅s à contacter l’équipe, la sécurité en charge des lieux ou les forces de l’ordre, ainsi que de fournir une escorte ou d’aider toute personne qui aura été harcelée à se sentir en sécurité pendant le reste de l’atelier. Nous accordons beaucoup d’importance à votre présence."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
+msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
 msgstr ""
 
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
 msgstr ""
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
 msgstr ""
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
 msgstr ""
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
 msgstr ""
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
 msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
 msgstr ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
 msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
 msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
 msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
 msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
 msgstr ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
 msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
 msgstr ""
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
 msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
 msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
 msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
 msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
 msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, fuzzy, python-format
+#| msgid "month"
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] "mois"
+msgstr[1] "mois"
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
 msgstr ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
 msgstr ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
 msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
 msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
 msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
 msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
 msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
 msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
 msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
 msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
 msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
 msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
 msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
 msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
 msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
 msgstr ""
 
-#: templates/global/menu.html:25
-msgid "Jobs"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
 msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
 msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
 msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
 msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
 msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
 msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
 msgstr ""
 
+#~ msgid ""
+#~ "Data collected through this form is used only for the purpose of Django "
+#~ "Girls events. We're using Third Party Sites and Services to make it "
+#~ "happen: for example, we're using Mandrill to send you emails. Don't "
+#~ "worry: We don't share your data with spammers, and we don't sell it! More "
+#~ "info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#~ msgstr ""
+#~ "Les données collectées par le biais de ce formulaire ne sont utilisées "
+#~ "que dans le cadre des événements Django Girls. Nous utilisons des sites "
+#~ "et services tiers pour y parvenir : par exemple, nous utilisons Mandrill "
+#~ "pour vous envoyer des emails. Ne vous inquiétez pas : nous ne partageons "
+#~ "pas vos données avec des spammeurs, et nous ne les vendons pas ! Plus "
+#~ "d'informations sur notre politique de confidentialité <a href='/privacy-"
+#~ "cookies/'>here</a>."

--- a/locale/ko/LC_MESSAGES/django.po
+++ b/locale/ko/LC_MESSAGES/django.po
@@ -1,19 +1,26 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: ko\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: ko\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
+msgstr ""
+
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
 msgstr ""
 
 #: applications/models.py:19
@@ -21,17 +28,30 @@ msgid "Apply for a spot at Django Girls [City]!"
 msgstr ""
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
 msgstr ""
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
@@ -67,7 +87,7 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr ""
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr ""
 
 #: applications/models.py:98
@@ -127,27 +147,27 @@ msgstr ""
 msgid "RSVP status"
 msgstr ""
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr ""
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr ""
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr ""
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr ""
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr ""
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr ""
 
@@ -164,7 +184,9 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr ""
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
 msgstr ""
 
 #: applications/questions.py:59
@@ -212,11 +234,16 @@ msgid "What is your current level of experience with programming?"
 msgstr ""
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
 msgstr ""
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
 msgstr ""
 
 #: applications/questions.py:115
@@ -240,7 +267,12 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr ""
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
 msgstr ""
 
 #: applications/questions.py:138
@@ -248,19 +280,29 @@ msgid "How did you hear about Django Girls?"
 msgstr ""
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
 msgstr ""
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
 msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr ""
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
 msgstr ""
 
 #: applications/questions.py:164
@@ -271,32 +313,64 @@ msgstr ""
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr ""
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr ""
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr ""
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr ""
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr ""
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
+msgstr ""
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
 msgstr ""
 
 #: contact/forms.py:15
@@ -343,7 +417,7 @@ msgstr ""
 msgid "page URL"
 msgstr ""
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr ""
 
@@ -367,8 +441,55 @@ msgstr ""
 msgid "You cannot remove yourself from a team."
 msgstr ""
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr ""
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
+msgstr ""
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr ""
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr ""
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr ""
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr ""
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr ""
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr ""
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
 msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
@@ -381,10 +502,6 @@ msgstr ""
 
 #: core/admin/user.py:19
 msgid "Important dates"
-msgstr ""
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
 msgstr ""
 
 #: core/default_eventpage_content.py:60
@@ -423,56 +540,93 @@ msgstr ""
 msgid "E-mail address"
 msgstr ""
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr ""
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr ""
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr ""
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr ""
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr ""
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
 msgstr ""
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
 msgstr ""
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr ""
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr ""
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr ""
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr ""
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr ""
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr ""
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr ""
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr ""
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr ""
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr ""
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
 msgstr ""
 
 #: organize/admin.py:16
@@ -483,21 +637,30 @@ msgstr ""
 msgid "Move selected application to in review"
 msgstr ""
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr ""
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr ""
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr ""
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr ""
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
+msgstr ""
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
 
 #: organize/constants.py:4
@@ -544,133 +707,162 @@ msgstr ""
 msgid "Deployed"
 msgstr ""
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr ""
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+msgid "No, it's my first time organizing Django Girls"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr ""
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr ""
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr ""
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr ""
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
+#: organize/forms.py:109
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
 msgstr ""
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
 msgstr ""
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr ""
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr ""
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr ""
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr ""
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr ""
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr ""
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr ""
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr ""
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr ""
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr ""
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr ""
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr ""
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] ""
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr ""
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -757,10 +949,13 @@ msgid "payments"
 msgstr ""
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
 msgstr[0] ""
@@ -774,7 +969,9 @@ msgid "Section background"
 msgstr ""
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
 msgstr ""
 
 #: pictures/models.py:39
@@ -789,11 +986,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -806,11 +1003,15 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr ""
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:5
@@ -818,11 +1019,20 @@ msgid "Submitted applications"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
 msgstr ""
 
 #: templates/admin/core/event/view_add_organizers.html:6
@@ -842,7 +1052,7 @@ msgid "Remove event organizers"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -850,6 +1060,7 @@ msgid "To get started, choose an event:"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, python-format
 msgid "Organizers of %(event_name)s"
 msgstr ""
 
@@ -866,16 +1077,44 @@ msgid "Action"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr ""
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+msgid "Blacklist Organizer"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/change_form.html:15
@@ -894,19 +1133,28 @@ msgstr ""
 msgid "Reject application"
 msgstr ""
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr ""
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -916,14 +1164,20 @@ msgid "Yes, I'm sure"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -932,10 +1186,12 @@ msgid "Scores"
 msgstr ""
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr ""
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr ""
 
@@ -961,6 +1217,7 @@ msgid "Save & draw next"
 msgstr ""
 
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr ""
 
@@ -1041,17 +1298,27 @@ msgid "Nothing to see here..."
 msgstr ""
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
 msgstr ""
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
 msgstr ""
 
@@ -1060,6 +1327,7 @@ msgid "Submit your application"
 msgstr ""
 
 #: templates/applications/communication.html:14
+#, python-format
 msgid "Send email to applicants of %(title)s"
 msgstr ""
 
@@ -1093,6 +1361,7 @@ msgid "Create one!"
 msgstr ""
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr ""
 
@@ -1121,8 +1390,11 @@ msgid "Email preview"
 msgstr ""
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
 msgstr ""
 
@@ -1135,20 +1407,31 @@ msgid "Emails that failed to sent:"
 msgstr ""
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
 msgstr ""
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
 msgstr ""
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 msgstr ""
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
@@ -1173,8 +1456,11 @@ msgid "To be sure your email reach the right person, check this FAQ first!"
 msgstr ""
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
 msgstr ""
@@ -1188,7 +1474,10 @@ msgid "Django Girls Annual Report 2015"
 msgstr ""
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
 msgstr ""
 
 #: templates/core/2015.html:25
@@ -1204,7 +1493,14 @@ msgid "Financial Transparency 💰🔍"
 msgstr ""
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
 msgstr ""
 
 #: templates/core/2015.html:58
@@ -1212,11 +1508,23 @@ msgid "Expenses 💸"
 msgstr ""
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
 msgstr ""
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
 msgstr ""
 
 #: templates/core/2015.html:77
@@ -1229,6 +1537,7 @@ msgid "Amount"
 msgstr ""
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr ""
 
@@ -1261,11 +1570,23 @@ msgid "Income 🌟👀"
 msgstr ""
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
 msgstr ""
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
 msgstr ""
 
 #: templates/core/2015.html:122
@@ -1273,6 +1594,7 @@ msgid "Income"
 msgstr ""
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr ""
 
@@ -1285,6 +1607,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr ""
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr ""
 
@@ -1309,7 +1632,11 @@ msgid "Total income"
 msgstr ""
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
 msgstr ""
 
 #: templates/core/2015.html:151
@@ -1321,19 +1648,37 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr ""
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
 msgstr ""
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
 msgstr ""
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
 msgstr ""
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
 msgstr ""
 
 #: templates/core/2015.html:187
@@ -1341,75 +1686,173 @@ msgid "Achievements & Events in 2015 🏆🏅"
 msgstr ""
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
 msgstr ""
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
 msgstr ""
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
 msgstr ""
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
 msgstr ""
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
 msgstr ""
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
 msgstr ""
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
 msgstr ""
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
 msgstr ""
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
 msgstr ""
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
 msgstr ""
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
 msgstr ""
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
 msgstr ""
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
 msgstr ""
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
 msgstr ""
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
 msgstr ""
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
 msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
 msgstr ""
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
 msgstr ""
 
 #: templates/core/2015.html:351
@@ -1417,39 +1860,95 @@ msgid "Success stories 💖"
 msgstr ""
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
 msgstr ""
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
 msgstr ""
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
 msgstr ""
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
 msgstr ""
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
 msgstr ""
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
 msgstr ""
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
 msgstr ""
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
 msgstr ""
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
 msgstr ""
 
 #: templates/core/2015.html:461
@@ -1461,15 +1960,31 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr ""
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
 msgstr ""
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
 msgstr ""
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
 msgstr ""
 
 #: templates/core/2015.html:479
@@ -1481,43 +1996,77 @@ msgid "Sponsors 📢️"
 msgstr ""
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
 msgstr ""
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
 msgstr ""
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
@@ -1525,7 +2074,10 @@ msgid "Django Girls Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
 msgstr ""
 
 #: templates/core/2016-2017.html:26
@@ -1533,11 +2085,25 @@ msgid "Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
 msgstr ""
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
 msgstr ""
 
 #: templates/core/2016-2017.html:50
@@ -1545,35 +2111,55 @@ msgid "✨ Highlights ✨"
 msgstr ""
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
 msgstr ""
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
 msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr ""
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:94
@@ -1629,11 +2215,23 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr ""
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
 msgstr ""
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
 msgstr ""
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
@@ -1645,11 +2243,22 @@ msgid "🎁 Organiser Starter Kits"
 msgstr ""
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
 msgstr ""
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
 msgstr ""
 
 #: templates/core/2016-2017.html:169
@@ -1657,7 +2266,12 @@ msgid "💰 Fundraising"
 msgstr ""
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
 msgstr ""
 
 #: templates/core/2016-2017.html:183
@@ -1689,11 +2303,31 @@ msgid "Participants Survey"
 msgstr ""
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
 msgstr ""
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
 msgstr ""
 
 #: templates/core/2016-2017.html:227
@@ -1701,15 +2335,29 @@ msgid "Participants’ Involvement in Tech Activities"
 msgstr ""
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
 msgstr ""
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
 msgstr ""
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
 msgstr ""
 
 #: templates/core/2016-2017.html:258
@@ -1717,19 +2365,33 @@ msgid "Participants’ learning to code after the workshop"
 msgstr ""
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
 msgstr ""
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
 msgstr ""
 
 #: templates/core/2016-2017.html:291
@@ -1737,19 +2399,35 @@ msgid "Participants’ Employment in Tech after attending workshops"
 msgstr ""
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
+#, python-format
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
 msgstr ""
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
 msgstr ""
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
 msgstr ""
 
 #: templates/core/2016-2017.html:326
@@ -1757,19 +2435,39 @@ msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr ""
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
 msgstr ""
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
 msgstr ""
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:362
@@ -1777,15 +2475,152 @@ msgid "Summary"
 msgstr ""
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
 msgstr ""
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
 msgstr ""
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
+msgstr ""
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr ""
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr ""
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr ""
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr ""
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
 msgstr ""
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
@@ -1794,7 +2629,12 @@ msgid "Contribute"
 msgstr ""
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
 msgstr ""
 
 #: templates/core/contribute.html:22
@@ -1802,11 +2642,22 @@ msgid "Support us!"
 msgstr ""
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
 msgstr ""
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
 msgstr ""
 
 #: templates/core/contribute.html:46
@@ -1814,11 +2665,17 @@ msgid "Organize!"
 msgstr ""
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
 msgstr ""
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:72
@@ -1826,15 +2683,23 @@ msgid "Coach!"
 msgstr ""
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
 msgstr ""
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
 msgstr ""
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
 msgstr ""
 
 #: templates/core/contribute.html:99
@@ -1846,11 +2711,15 @@ msgid "Computer screen with a console and a webpage."
 msgstr ""
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
 msgstr ""
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:123
@@ -1862,11 +2731,16 @@ msgid "A note book and a pen."
 msgstr ""
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
 msgstr ""
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
 msgstr ""
 
 #: templates/core/contribute.html:140
@@ -1878,11 +2752,18 @@ msgid "A computer screen saying hello and golden balloons saying yay!."
 msgstr ""
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
 msgstr ""
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
 msgstr ""
 
 #: templates/core/contribute.html:166
@@ -1894,11 +2775,17 @@ msgid "A web page opened on a computer."
 msgstr ""
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
 msgstr ""
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
 msgstr ""
 
 #: templates/core/contribute.html:188
@@ -1910,11 +2797,16 @@ msgid "A pile a tattoo."
 msgstr ""
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
 msgstr ""
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:11
@@ -1922,7 +2814,13 @@ msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
@@ -1930,14 +2828,22 @@ msgid "Our awesome supporters ✨"
 msgstr ""
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
 msgstr ""
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
 msgstr ""
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
@@ -1966,7 +2872,11 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr ""
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
 msgstr ""
 
 #: templates/core/faq.html:20
@@ -1982,27 +2892,67 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr ""
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
 msgstr ""
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
 msgstr ""
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
 msgstr ""
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
 msgstr ""
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
 msgstr ""
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
 msgstr ""
 
 #: templates/core/faq.html:109
@@ -2010,7 +2960,9 @@ msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr ""
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
 msgstr ""
 
 #: templates/core/faq.html:117
@@ -2018,11 +2970,29 @@ msgid "We are trans-inclusive and welcome applications from all women."
 msgstr ""
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
 msgstr ""
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
 msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
@@ -2039,7 +3009,9 @@ msgid "We inspire women to fall in love with programming."
 msgstr ""
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
 msgstr ""
 
 #: templates/core/index.html:29
@@ -2047,11 +3019,20 @@ msgid "What is Django Girls?"
 msgstr ""
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
 msgstr ""
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
 msgstr ""
 
 #: templates/core/index.html:53
@@ -2059,11 +3040,22 @@ msgid "Django Girls impact"
 msgstr ""
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
 msgstr ""
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
 msgstr ""
 
 #: templates/core/index.html:69
@@ -2075,11 +3067,18 @@ msgid "Bring Django Girls to your city!"
 msgstr ""
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
 msgstr ""
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
 msgstr ""
 
 #: templates/core/index.html:82 templates/organize/index.html:89
@@ -2087,6 +3086,7 @@ msgid "Apply to organize a workshop"
 msgstr ""
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr ""
 
@@ -2095,7 +3095,9 @@ msgid "Badass Django Ladies"
 msgstr ""
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
 msgstr ""
 
 #: templates/core/index.html:125
@@ -2115,7 +3117,15 @@ msgid "Support our work"
 msgstr ""
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
@@ -2123,7 +3133,11 @@ msgid "Make a recurring donation on Patreon"
 msgstr ""
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
 msgstr ""
 
 #: templates/core/index.html:162
@@ -2131,7 +3145,9 @@ msgid "Stay up to date!"
 msgstr ""
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
 msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
@@ -2147,12 +3163,51 @@ msgstr ""
 msgid "See the Django Girls Dispatch archives"
 msgstr ""
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr ""
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr ""
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
 msgstr ""
 
 #: templates/core/newsletter.html:4
@@ -2164,11 +3219,16 @@ msgid "Django Girls Dispatch"
 msgstr ""
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
 msgstr ""
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
 msgstr ""
 
 #: templates/core/newsletter.html:49
@@ -2180,11 +3240,15 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:20
@@ -2204,19 +3268,31 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:53
@@ -2228,15 +3304,25 @@ msgid "Scope of this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:74
@@ -2244,7 +3330,9 @@ msgid "Data Collected"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:79
@@ -2280,7 +3368,9 @@ msgid "operating system (automatically collected); and"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:90
@@ -2292,15 +3382,22 @@ msgid "We will keep any personal Data you submit for 60 months."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:108
@@ -2316,15 +3413,21 @@ msgid "improvement of our products / services;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:115
@@ -2336,15 +3439,25 @@ msgid "Third Party Sites and Services"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:142
@@ -2352,7 +3465,11 @@ msgid "Links to Other Websites"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:151
@@ -2360,7 +3477,12 @@ msgid "Changes of Business Ownership and Control"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:161
@@ -2372,7 +3494,9 @@ msgid "Controlling Use of Your Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:167
@@ -2392,11 +3516,17 @@ msgid "Your Right to Withhold Information"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:178
@@ -2404,7 +3534,9 @@ msgid "Accessing Your Own Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:182
@@ -2412,7 +3544,10 @@ msgid "Security"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:186
@@ -2420,27 +3555,49 @@ msgid "Cookies"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:201
@@ -2448,19 +3605,29 @@ msgid "You can choose to enable or disable Cookies in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:214
@@ -2468,7 +3635,11 @@ msgid "Changes to this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
 msgstr ""
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
@@ -2477,7 +3648,11 @@ msgid "Resources"
 msgstr ""
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
 msgstr ""
 
 #: templates/core/resources.html:22
@@ -2489,7 +3664,10 @@ msgid "Tutorial Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
 msgstr ""
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
@@ -2506,7 +3684,10 @@ msgid "Organize Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
 msgstr ""
 
 #: templates/core/resources.html:67
@@ -2514,7 +3695,10 @@ msgid "Coaching Guide Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
 msgstr ""
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
@@ -2526,7 +3710,10 @@ msgid "Tutorial Extensions Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
 msgstr ""
 
 #: templates/core/terms_conditions.html:4
@@ -2536,11 +3723,17 @@ msgstr ""
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
 msgstr ""
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/terms_conditions.html:18
@@ -2556,7 +3749,10 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr ""
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:39
@@ -2564,7 +3760,9 @@ msgid "Agreement"
 msgstr ""
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
 msgstr ""
 
 #: templates/core/terms_conditions.html:44
@@ -2580,19 +3778,26 @@ msgid "You promise us:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
 msgstr ""
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
 msgstr ""
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:53
@@ -2600,15 +3805,25 @@ msgid "That you won’t do anything that might cause our systems to crash."
 msgstr ""
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
 msgstr ""
 
 #: templates/core/terms_conditions.html:59
@@ -2616,11 +3831,20 @@ msgid "Intellectual property"
 msgstr ""
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:71
@@ -2628,11 +3852,17 @@ msgid "Price and payment"
 msgstr ""
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
 msgstr ""
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:86
@@ -2640,7 +3870,11 @@ msgid "Use of communications facilities"
 msgstr ""
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:90
@@ -2648,51 +3882,79 @@ msgid "you must not use language that may be offensive to other Users;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
 msgstr ""
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
 msgstr ""
 
 #: templates/core/terms_conditions.html:114
@@ -2700,7 +3962,10 @@ msgid "Privacy and cookies"
 msgstr ""
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:123
@@ -2716,7 +3981,9 @@ msgid "that the Site will meet your needs;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:130
@@ -2740,19 +4007,35 @@ msgid "that the Site is secure,"
 msgstr ""
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
 msgstr ""
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
 msgstr ""
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
 msgstr ""
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
 msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
@@ -2760,11 +4043,20 @@ msgid "Events"
 msgstr ""
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
 msgstr ""
 
 #: templates/core/terms_conditions.html:164
@@ -2772,11 +4064,15 @@ msgid "Problems"
 msgstr ""
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
 msgstr ""
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
 msgstr ""
 
 #: templates/core/terms_conditions.html:170
@@ -2784,11 +4080,16 @@ msgid "Availability of the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
 msgstr ""
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:176
@@ -2796,7 +4097,11 @@ msgid "Limitation of liability"
 msgstr ""
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:180
@@ -2804,7 +4109,9 @@ msgid "You use the Site and its Content at your own risk."
 msgstr ""
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
 msgstr ""
 
 #: templates/core/terms_conditions.html:184
@@ -2812,11 +4119,16 @@ msgid "Linking"
 msgstr ""
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
 msgstr ""
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:190
@@ -2824,15 +4136,23 @@ msgid "We can never guarantee that a link will work."
 msgstr ""
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
 msgstr ""
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:199
@@ -2848,7 +4168,9 @@ msgid "you can only link from a site that you own;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:203
@@ -2856,7 +4178,9 @@ msgid "you mustn’t frame our Site on any other site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
 msgstr ""
 
 #: templates/core/terms_conditions.html:208
@@ -2864,11 +4188,18 @@ msgid "Modifications to these T&Cs & the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
 msgstr ""
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
 msgstr ""
 
 #: templates/core/terms_conditions.html:221
@@ -2876,39 +4207,66 @@ msgid "General stuff"
 msgstr ""
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
 msgstr ""
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
 msgstr ""
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
 msgstr ""
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
 msgstr ""
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:235
@@ -2920,15 +4278,22 @@ msgid "Definitions"
 msgstr ""
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
 msgstr ""
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:244
@@ -2936,7 +4301,10 @@ msgid "<b>Organiser</b> means the organiser or promoter of an Event."
 msgstr ""
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:253
@@ -2944,7 +4312,8 @@ msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr ""
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
 msgstr ""
 
 #: templates/core/workshop_box.html:9
@@ -2952,7 +4321,10 @@ msgid "Order Django Girls Workshop Box for your event!"
 msgstr ""
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
 msgstr ""
 
 #: templates/core/workshop_box.html:27
@@ -2960,11 +4332,19 @@ msgid "How it works?"
 msgstr ""
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
 msgstr ""
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
 msgstr ""
 
 #: templates/core/workshop_box.html:44
@@ -3028,7 +4408,11 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr ""
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
 msgstr ""
 
 #: templates/core/workshop_box.html:78
@@ -3036,7 +4420,12 @@ msgid "How to get one?"
 msgstr ""
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
 msgstr ""
 
 #: templates/core/workshop_box.html:86
@@ -3044,7 +4433,9 @@ msgid "Requirements to apply for a free box:"
 msgstr ""
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
 msgstr ""
 
 #: templates/core/workshop_box.html:89
@@ -3056,11 +4447,16 @@ msgid "Application process for your event needs to be open"
 msgstr ""
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
 msgstr ""
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
 msgstr ""
 
 #: templates/default/about.html:4
@@ -3080,7 +4476,9 @@ msgid "Applications are now open!"
 msgstr ""
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
 msgstr ""
 
 #: templates/default/apply.html:10
@@ -3092,7 +4490,10 @@ msgid "Be a Mentor!"
 msgstr ""
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
 msgstr ""
 
 #: templates/default/coach.html:16 templates/default/values.html:5
@@ -3100,15 +4501,23 @@ msgid "Django Girls"
 msgstr ""
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
 msgstr ""
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 msgstr ""
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
 msgstr ""
 
 #: templates/default/faq.html:6
@@ -3116,7 +4525,10 @@ msgid "Do I need to know anything about websites or programming?"
 msgstr ""
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
 msgstr ""
 
 #: templates/default/faq.html:18
@@ -3124,7 +4536,11 @@ msgid "I am not living in Germany, can I attend?"
 msgstr ""
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
 msgstr ""
 
 #: templates/default/faq.html:31
@@ -3132,7 +4548,10 @@ msgid "Should I bring my own laptop?"
 msgstr ""
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
 msgstr ""
 
 #: templates/default/faq.html:45
@@ -3140,7 +4559,10 @@ msgid "Do I need to have something installed on my laptop?"
 msgstr ""
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
 msgstr ""
 
 #: templates/default/faq.html:58
@@ -3148,7 +4570,11 @@ msgid "Is EuroPython conference good for a total beginner?"
 msgstr ""
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
 msgstr ""
 
 #: templates/default/faq.html:70
@@ -3156,11 +4582,17 @@ msgid "Is food provided?"
 msgstr ""
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
 msgstr ""
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
 msgstr ""
 
 #: templates/default/partners.html:3
@@ -3168,23 +4600,40 @@ msgid "Sponsors"
 msgstr ""
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
 msgstr ""
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
 msgstr ""
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
 msgstr ""
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
 msgstr ""
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
 msgstr ""
 
 #: templates/default/values.html:33
@@ -3192,7 +4641,10 @@ msgid "Apply for the workshop!"
 msgstr ""
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
 msgstr ""
 
 #: templates/default/values.html:43
@@ -3200,7 +4652,9 @@ msgid "As a workshop attendee you will:"
 msgstr ""
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
 msgstr ""
 
 #: templates/default/values.html:48
@@ -3208,7 +4662,9 @@ msgid "be fed by us: during our event, food is provided"
 msgstr ""
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
 msgstr ""
 
 #: templates/donations/donate.html:13
@@ -3220,19 +4676,37 @@ msgid "Our mission:"
 msgstr ""
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
 msgstr ""
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
 msgstr ""
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
 msgstr ""
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
 msgstr ""
 
 #: templates/donations/donate.html:54
@@ -3248,11 +4722,19 @@ msgid "Monthly donations"
 msgstr ""
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
 msgstr ""
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
 
 #: templates/donations/donate.html:105
@@ -3260,11 +4742,16 @@ msgid "One-time donations"
 msgstr ""
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
 msgstr ""
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
 msgstr ""
 
 #: templates/donations/donate.html:121
@@ -3284,15 +4771,10 @@ msgid "Humble Bundle Store"
 msgstr ""
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr ""
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr ""
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
 msgstr ""
 
 #: templates/donations/donate.html:161
@@ -3308,11 +4790,26 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr ""
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
 msgstr ""
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
 msgstr ""
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
@@ -3324,11 +4821,20 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr ""
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
 msgstr ""
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
 msgstr ""
 
 #: templates/donations/donate.html:213
@@ -3336,11 +4842,15 @@ msgid "Django Girls Summit:"
 msgstr ""
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
 msgstr ""
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
 msgstr ""
 
 #: templates/donations/error.html:7
@@ -3355,16 +4865,52 @@ msgstr ""
 msgid "Back to donation page"
 msgstr ""
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
 #: templates/donations/success.html:8
+#, python-format
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:3
+#, python-format
 msgid "Hello team %(city)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:8
@@ -3372,7 +4918,12 @@ msgid "Numbers"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:17
@@ -3380,7 +4931,10 @@ msgid "Tell us how it went!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:22
@@ -3388,7 +4942,12 @@ msgid "Share your experiences"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:27
@@ -3396,7 +4955,10 @@ msgid "Upload your photos"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:32
@@ -3404,7 +4966,11 @@ msgid "Donation"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:41
@@ -3412,11 +4978,19 @@ msgid "Discount in our store"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:55
@@ -3424,9 +4998,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -3437,10 +5011,12 @@ msgid "Hi there!"
 msgstr ""
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
 msgstr ""
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3449,29 +5025,39 @@ msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr ""
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
 msgstr ""
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
 msgstr ""
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3480,21 +5066,37 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
 msgstr ""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr ""
 
@@ -3503,11 +5105,17 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:17
@@ -3518,8 +5126,19 @@ msgstr ""
 msgid "Hello,"
 msgstr ""
 
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:16
@@ -3531,11 +5150,36 @@ msgid "Being an awesome person - already done! :)"
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
 msgstr ""
 
 #: templates/emails/organize/application_notification.html:3
@@ -3612,7 +5256,9 @@ msgid "Do you have potential coaches in mind?"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:9
@@ -3624,14 +5270,17 @@ msgid "1) Email address"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:22
@@ -3639,7 +5288,9 @@ msgid "Password:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:30
@@ -3647,7 +5298,9 @@ msgid "You can also add this inbox to your email client:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:39
@@ -3655,19 +5308,29 @@ msgid "2) Website"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:65
@@ -3675,30 +5338,40 @@ msgid "3) Organizers community"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -3707,55 +5380,91 @@ msgid "Hello there,"
 msgstr ""
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
 msgstr ""
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
 msgstr ""
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
 msgstr ""
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
 msgstr ""
 
 #: templates/global/footer.html:10
@@ -3770,12 +5479,12 @@ msgstr ""
 msgid "Chat with us!"
 msgstr ""
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr ""
-
 #: templates/global/footer.html:14
 msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
 msgstr ""
 
 #: templates/global/footer.html:20
@@ -3792,6 +5501,10 @@ msgstr ""
 
 #: templates/global/footer.html:25
 msgid "Sponsor us"
+msgstr ""
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
 msgstr ""
 
 #: templates/global/footer.html:30
@@ -3819,22 +5532,27 @@ msgid "Privacy & Cookies"
 msgstr ""
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr ""
 
 #: templates/global/footer.html:61
+#, python-format
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr ""
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
 msgstr ""
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
 msgstr ""
 
 #: templates/global/footer.html:64
+#, python-format
 msgid "<b>%(countries_count)s</b> countries"
 msgstr ""
 
@@ -3846,8 +5564,12 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
 msgstr ""
 
 #: templates/global/menu.html:31
@@ -3867,7 +5589,11 @@ msgid "Q: How can I register?"
 msgstr ""
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
 msgstr ""
 
 #: templates/includes/_faq.html:23
@@ -3875,7 +5601,12 @@ msgid "Q: I missed the deadline! Can I still apply to a workshop?"
 msgstr ""
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
 msgstr ""
 
 #: templates/includes/_faq.html:41
@@ -3883,15 +5614,23 @@ msgid "Q: I want to coach or sponsor an event!"
 msgstr ""
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
 msgstr ""
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
 msgstr ""
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
 msgstr ""
 
 #: templates/includes/_no_event.html:5
@@ -3903,7 +5642,8 @@ msgid "Sign up for our newsletter"
 msgstr ""
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
 msgstr ""
 
 #: templates/includes/_no_event.html:16
@@ -3915,11 +5655,38 @@ msgid "Your city"
 msgstr ""
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
 msgstr ""
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
+msgstr ""
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr ""
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr ""
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
 msgstr ""
 
 #: templates/organize/commitment.html:20
@@ -3927,23 +5694,36 @@ msgid "Django Girls Organizer Commitement"
 msgstr ""
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
 msgstr ""
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
 msgstr ""
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
 msgstr ""
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
 msgstr ""
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
 msgstr ""
 
 #: templates/organize/commitment.html:49
@@ -3955,7 +5735,10 @@ msgid "Welcome to Django Girls!"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:14
@@ -3975,7 +5758,8 @@ msgid "Our private community of organizers on Slack (a group chat application)"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:31
@@ -3986,12 +5770,96 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:80
@@ -4000,17 +5868,16 @@ msgstr ""
 msgid "Go to next step"
 msgstr ""
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr ""
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:73
@@ -4018,7 +5885,9 @@ msgid "Check boxes next to all the things that describe you"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:25
@@ -4048,6 +5917,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -4056,7 +5926,10 @@ msgid "Your organizing team"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
 msgstr ""
 
 #: templates/organize/form/step4_workshop_type.html:25
@@ -4082,10 +5955,6 @@ msgstr ""
 #: templates/organize/form/step5_workshop.html:32
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:46
@@ -4115,7 +5984,10 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:89
@@ -4134,43 +6006,42 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -4180,7 +6051,9 @@ msgid "How will you host your workshop remotely?"
 msgstr ""
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:15
@@ -4188,23 +6061,39 @@ msgid "You rock!"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
 msgstr ""
 
 #: templates/organize/index.html:9
@@ -4212,11 +6101,13 @@ msgid "Organize Django Girls workshop"
 msgstr ""
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr ""
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
 msgstr ""
 
 #: templates/organize/index.html:24
@@ -4224,15 +6115,24 @@ msgid "In-Person Workshops"
 msgstr ""
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
 msgstr ""
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
 msgstr ""
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
 msgstr ""
 
 #: templates/organize/index.html:47
@@ -4240,15 +6140,26 @@ msgid "Remote Workshops"
 msgstr ""
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
 msgstr ""
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
 msgstr ""
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/organize/index.html:73
@@ -4256,7 +6167,9 @@ msgid "The Value of Organizing Django Girls"
 msgstr ""
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
 msgstr ""
 
 #: templates/organize/index.html:80
@@ -4288,31 +6201,50 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+msgid "Apply for Event Sponsorship"
+msgstr ""
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
 msgstr ""
 
 #: templates/organize/prerequisites.html:29
@@ -4320,19 +6252,17 @@ msgid "Prerequisities to organize a Django Girls workshop"
 msgstr ""
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr ""
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr ""
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:51
@@ -4360,7 +6290,9 @@ msgid "You’re at least 18 years old"
 msgstr ""
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
 msgstr ""
 
 #: templates/organize/prerequisites.html:93
@@ -4368,7 +6300,9 @@ msgid "The event you’re organizing will be non-profit"
 msgstr ""
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
 msgstr ""
 
 #: templates/organize/prerequisites.html:111
@@ -4380,7 +6314,11 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr ""
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
 msgstr ""
 
 #: templates/organize/suspend.html:18
@@ -4392,7 +6330,10 @@ msgid "Password Reset Complete"
 msgstr ""
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:4
@@ -4400,7 +6341,9 @@ msgid "Password Reset"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:11
@@ -4413,7 +6356,11 @@ msgid "Check Your"
 msgstr ""
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:4
@@ -4421,7 +6368,10 @@ msgid "Forget your password?"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
 msgstr ""
 
 #: templates/registration/password_reset_form.html:11
@@ -4438,23 +6388,38 @@ msgid "Fill the form available on this page to apply for a GitHub grant."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
 msgstr ""
 
 #: templates/story/stories.html:9
@@ -4462,372 +6427,1516 @@ msgid "Django Girls Story"
 msgstr ""
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
 msgstr ""
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
 msgstr ""
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
 msgstr ""
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
 msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
 msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
 msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
 msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
 msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
 msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
 msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+msgid "Options"
 msgstr ""
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+msgid "Repeat for confirmation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+msgid "Error: The two entered values do not match."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+msgid "Syndication"
+msgstr ""
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+msgid "Enter a valid email address."
+msgstr ""
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+msgid "Duration"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+msgid "Floating point number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
 msgstr ""
 
-#: templates/core/coc.html:57
-msgid "In short"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
 msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+msgid "IPv4 address"
 msgstr ""
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+msgid "IP address"
 msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
 msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
 msgstr ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
 msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
 msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
 msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
 msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
 msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
 msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
 msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
 msgstr ""
 
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+msgid "A JSON object"
 msgstr ""
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
 msgstr ""
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
 msgstr ""
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
 msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
 msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
 msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+msgid "Enter a whole number."
 msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
 msgstr ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
 msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
 msgstr ""
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
 msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sat"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
 msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
 msgstr ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
 msgstr ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
 msgstr ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
 msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
 msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
 msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
 msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
 msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
 msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
 msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
 msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
 msgstr ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
 msgstr ""
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
 msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
 msgstr ""
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
 msgstr ""
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
 msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
 msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
 msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
 msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
 msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
 msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
 msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
-#: templates/global/menu.html:25
-msgid "Jobs"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
 msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""

--- a/locale/pt/LC_MESSAGES/django.po
+++ b/locale/pt/LC_MESSAGES/django.po
@@ -1,19 +1,26 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: pt\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: pt\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
+msgstr ""
+
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
 msgstr ""
 
 #: applications/models.py:19
@@ -21,17 +28,30 @@ msgid "Apply for a spot at Django Girls [City]!"
 msgstr ""
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
 msgstr ""
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
@@ -67,7 +87,7 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr ""
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr ""
 
 #: applications/models.py:98
@@ -127,27 +147,27 @@ msgstr ""
 msgid "RSVP status"
 msgstr ""
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr ""
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr ""
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr ""
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr ""
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr "Destinatários"
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr ""
 
@@ -164,34 +184,23 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr ""
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
 msgstr ""
 
 #: applications/questions.py:59
 msgid "Yes, please!"
 msgstr "Sim, por favor!"
 
-#. This translation can have two forms, masculine and feminine, that do not have counterpart in English:
-#. M: "Não, obrigado."
-#. F: "Não, obrigada."
-#. Do we handle this kind of differentiation?
 #: applications/questions.py:59
 msgid "No, thank you."
 msgstr "Não, obrigado."
 
-#. Here, Portuguese can have two forms - formal and informal / personal.
-#. Formal: Qual o seu nome?
-#. Informal / personal: Qual o teu nome?
-#. 
-#. Which communication style should we adopt?
 #: applications/questions.py:67
 msgid "What's your name?"
 msgstr "Qual o seu nome?"
 
-#. Here the same question of formal informal applies: seu / teu.
-#. Also, "e-mail" still English, however is quite commonly used in the Portuguese language.
-#. "e-mail" can be translated to "correio electrónico".
-#. What's the choice?
 #: applications/questions.py:71
 msgid "Your e-mail address:"
 msgstr "O seu endereço de e-mail:"
@@ -225,11 +234,16 @@ msgid "What is your current level of experience with programming?"
 msgstr ""
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
 msgstr ""
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
 msgstr ""
 
 #: applications/questions.py:115
@@ -253,7 +267,12 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr ""
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
 msgstr ""
 
 #: applications/questions.py:138
@@ -261,19 +280,29 @@ msgid "How did you hear about Django Girls?"
 msgstr ""
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
 msgstr ""
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
 msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr ""
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
 msgstr ""
 
 #: applications/questions.py:164
@@ -284,32 +313,64 @@ msgstr ""
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr ""
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr ""
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr ""
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr ""
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr ""
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
+msgstr ""
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
 msgstr ""
 
 #: contact/forms.py:15
@@ -356,7 +417,7 @@ msgstr ""
 msgid "page URL"
 msgstr ""
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr ""
 
@@ -380,8 +441,55 @@ msgstr ""
 msgid "You cannot remove yourself from a team."
 msgstr ""
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr ""
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
+msgstr ""
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr ""
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr ""
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr ""
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr ""
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr ""
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr ""
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
 msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
@@ -394,10 +502,6 @@ msgstr ""
 
 #: core/admin/user.py:19
 msgid "Important dates"
-msgstr ""
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
 msgstr ""
 
 #: core/default_eventpage_content.py:60
@@ -436,56 +540,93 @@ msgstr ""
 msgid "E-mail address"
 msgstr ""
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr ""
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr ""
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr ""
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr ""
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr ""
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
 msgstr ""
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
 msgstr ""
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr ""
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr ""
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr ""
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr ""
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr ""
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr ""
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr ""
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr ""
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr ""
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr ""
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
 msgstr ""
 
 #: organize/admin.py:16
@@ -496,21 +637,30 @@ msgstr ""
 msgid "Move selected application to in review"
 msgstr ""
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr ""
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr ""
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr ""
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr ""
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
+msgstr ""
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
 
 #: organize/constants.py:4
@@ -557,135 +707,164 @@ msgstr ""
 msgid "Deployed"
 msgstr ""
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr ""
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+msgid "No, it's my first time organizing Django Girls"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr ""
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr ""
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr ""
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr ""
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
+#: organize/forms.py:109
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
 msgstr ""
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
 msgstr ""
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr ""
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr ""
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr ""
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr ""
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr ""
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr ""
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr ""
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr ""
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr ""
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr ""
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr ""
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr ""
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] ""
 msgstr[1] ""
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr ""
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -772,10 +951,13 @@ msgid "payments"
 msgstr ""
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
 msgstr[0] ""
@@ -790,7 +972,9 @@ msgid "Section background"
 msgstr ""
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
 msgstr ""
 
 #: pictures/models.py:39
@@ -805,11 +989,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -822,11 +1006,15 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr ""
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:5
@@ -834,11 +1022,20 @@ msgid "Submitted applications"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
 msgstr ""
 
 #: templates/admin/core/event/view_add_organizers.html:6
@@ -858,7 +1055,7 @@ msgid "Remove event organizers"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -866,6 +1063,7 @@ msgid "To get started, choose an event:"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, python-format
 msgid "Organizers of %(event_name)s"
 msgstr ""
 
@@ -882,16 +1080,44 @@ msgid "Action"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr ""
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+msgid "Blacklist Organizer"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/change_form.html:15
@@ -910,19 +1136,28 @@ msgstr ""
 msgid "Reject application"
 msgstr ""
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr ""
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -932,14 +1167,20 @@ msgid "Yes, I'm sure"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -948,10 +1189,12 @@ msgid "Scores"
 msgstr ""
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr ""
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr ""
 
@@ -977,6 +1220,7 @@ msgid "Save & draw next"
 msgstr ""
 
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr ""
 
@@ -1057,17 +1301,27 @@ msgid "Nothing to see here..."
 msgstr ""
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
 msgstr ""
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
 msgstr ""
 
@@ -1076,6 +1330,7 @@ msgid "Submit your application"
 msgstr ""
 
 #: templates/applications/communication.html:14
+#, python-format
 msgid "Send email to applicants of %(title)s"
 msgstr ""
 
@@ -1109,6 +1364,7 @@ msgid "Create one!"
 msgstr ""
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr ""
 
@@ -1137,8 +1393,11 @@ msgid "Email preview"
 msgstr ""
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
 msgstr ""
 
@@ -1151,20 +1410,31 @@ msgid "Emails that failed to sent:"
 msgstr ""
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
 msgstr ""
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
 msgstr ""
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 msgstr ""
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
@@ -1189,8 +1459,11 @@ msgid "To be sure your email reach the right person, check this FAQ first!"
 msgstr ""
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
 msgstr ""
@@ -1204,7 +1477,10 @@ msgid "Django Girls Annual Report 2015"
 msgstr ""
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
 msgstr ""
 
 #: templates/core/2015.html:25
@@ -1220,7 +1496,14 @@ msgid "Financial Transparency 💰🔍"
 msgstr ""
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
 msgstr ""
 
 #: templates/core/2015.html:58
@@ -1228,11 +1511,23 @@ msgid "Expenses 💸"
 msgstr ""
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
 msgstr ""
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
 msgstr ""
 
 #: templates/core/2015.html:77
@@ -1245,6 +1540,7 @@ msgid "Amount"
 msgstr ""
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr ""
 
@@ -1277,11 +1573,23 @@ msgid "Income 🌟👀"
 msgstr ""
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
 msgstr ""
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
 msgstr ""
 
 #: templates/core/2015.html:122
@@ -1289,6 +1597,7 @@ msgid "Income"
 msgstr ""
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr ""
 
@@ -1301,6 +1610,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr ""
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr ""
 
@@ -1325,7 +1635,11 @@ msgid "Total income"
 msgstr ""
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
 msgstr ""
 
 #: templates/core/2015.html:151
@@ -1337,19 +1651,37 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr ""
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
 msgstr ""
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
 msgstr ""
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
 msgstr ""
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
 msgstr ""
 
 #: templates/core/2015.html:187
@@ -1357,75 +1689,173 @@ msgid "Achievements & Events in 2015 🏆🏅"
 msgstr ""
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
 msgstr ""
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
 msgstr ""
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
 msgstr ""
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
 msgstr ""
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
 msgstr ""
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
 msgstr ""
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
 msgstr ""
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
 msgstr ""
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
 msgstr ""
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
 msgstr ""
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
 msgstr ""
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
 msgstr ""
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
 msgstr ""
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
 msgstr ""
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
 msgstr ""
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
 msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
 msgstr ""
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
 msgstr ""
 
 #: templates/core/2015.html:351
@@ -1433,39 +1863,95 @@ msgid "Success stories 💖"
 msgstr ""
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
 msgstr ""
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
 msgstr ""
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
 msgstr ""
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
 msgstr ""
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
 msgstr ""
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
 msgstr ""
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
 msgstr ""
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
 msgstr ""
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
 msgstr ""
 
 #: templates/core/2015.html:461
@@ -1477,15 +1963,31 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr ""
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
 msgstr ""
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
 msgstr ""
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
 msgstr ""
 
 #: templates/core/2015.html:479
@@ -1497,43 +1999,77 @@ msgid "Sponsors 📢️"
 msgstr ""
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
 msgstr ""
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
 msgstr ""
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
@@ -1541,7 +2077,10 @@ msgid "Django Girls Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
 msgstr ""
 
 #: templates/core/2016-2017.html:26
@@ -1549,11 +2088,25 @@ msgid "Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
 msgstr ""
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
 msgstr ""
 
 #: templates/core/2016-2017.html:50
@@ -1561,35 +2114,55 @@ msgid "✨ Highlights ✨"
 msgstr ""
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
 msgstr ""
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
 msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr ""
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:94
@@ -1645,11 +2218,23 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr ""
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
 msgstr ""
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
 msgstr ""
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
@@ -1661,11 +2246,22 @@ msgid "🎁 Organiser Starter Kits"
 msgstr ""
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
 msgstr ""
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
 msgstr ""
 
 #: templates/core/2016-2017.html:169
@@ -1673,7 +2269,12 @@ msgid "💰 Fundraising"
 msgstr ""
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
 msgstr ""
 
 #: templates/core/2016-2017.html:183
@@ -1705,11 +2306,31 @@ msgid "Participants Survey"
 msgstr ""
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
 msgstr ""
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
 msgstr ""
 
 #: templates/core/2016-2017.html:227
@@ -1717,15 +2338,29 @@ msgid "Participants’ Involvement in Tech Activities"
 msgstr ""
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
 msgstr ""
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
 msgstr ""
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
 msgstr ""
 
 #: templates/core/2016-2017.html:258
@@ -1733,19 +2368,33 @@ msgid "Participants’ learning to code after the workshop"
 msgstr ""
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
 msgstr ""
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
 msgstr ""
 
 #: templates/core/2016-2017.html:291
@@ -1753,19 +2402,35 @@ msgid "Participants’ Employment in Tech after attending workshops"
 msgstr ""
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
+#, python-format
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
 msgstr ""
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
 msgstr ""
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
 msgstr ""
 
 #: templates/core/2016-2017.html:326
@@ -1773,19 +2438,39 @@ msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr ""
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
 msgstr ""
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
 msgstr ""
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:362
@@ -1793,15 +2478,152 @@ msgid "Summary"
 msgstr ""
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
 msgstr ""
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
 msgstr ""
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
+msgstr ""
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr ""
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr ""
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr ""
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr ""
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
 msgstr ""
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
@@ -1810,7 +2632,12 @@ msgid "Contribute"
 msgstr ""
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
 msgstr ""
 
 #: templates/core/contribute.html:22
@@ -1818,11 +2645,22 @@ msgid "Support us!"
 msgstr ""
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
 msgstr ""
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
 msgstr ""
 
 #: templates/core/contribute.html:46
@@ -1830,11 +2668,17 @@ msgid "Organize!"
 msgstr ""
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
 msgstr ""
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:72
@@ -1842,15 +2686,23 @@ msgid "Coach!"
 msgstr ""
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
 msgstr ""
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
 msgstr ""
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
 msgstr ""
 
 #: templates/core/contribute.html:99
@@ -1862,11 +2714,15 @@ msgid "Computer screen with a console and a webpage."
 msgstr ""
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
 msgstr ""
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:123
@@ -1878,11 +2734,16 @@ msgid "A note book and a pen."
 msgstr ""
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
 msgstr ""
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
 msgstr ""
 
 #: templates/core/contribute.html:140
@@ -1894,11 +2755,18 @@ msgid "A computer screen saying hello and golden balloons saying yay!."
 msgstr ""
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
 msgstr ""
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
 msgstr ""
 
 #: templates/core/contribute.html:166
@@ -1910,11 +2778,17 @@ msgid "A web page opened on a computer."
 msgstr ""
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
 msgstr ""
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
 msgstr ""
 
 #: templates/core/contribute.html:188
@@ -1926,11 +2800,16 @@ msgid "A pile a tattoo."
 msgstr ""
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
 msgstr ""
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:11
@@ -1938,7 +2817,13 @@ msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
@@ -1946,14 +2831,22 @@ msgid "Our awesome supporters ✨"
 msgstr ""
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
 msgstr ""
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
 msgstr ""
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
@@ -1982,7 +2875,11 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr ""
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
 msgstr ""
 
 #: templates/core/faq.html:20
@@ -1998,27 +2895,67 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr ""
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
 msgstr ""
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
 msgstr ""
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
 msgstr ""
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
 msgstr ""
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
 msgstr ""
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
 msgstr ""
 
 #: templates/core/faq.html:109
@@ -2026,7 +2963,9 @@ msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr ""
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
 msgstr ""
 
 #: templates/core/faq.html:117
@@ -2034,11 +2973,29 @@ msgid "We are trans-inclusive and welcome applications from all women."
 msgstr ""
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
 msgstr ""
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
 msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
@@ -2055,7 +3012,9 @@ msgid "We inspire women to fall in love with programming."
 msgstr ""
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
 msgstr ""
 
 #: templates/core/index.html:29
@@ -2063,11 +3022,20 @@ msgid "What is Django Girls?"
 msgstr ""
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
 msgstr ""
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
 msgstr ""
 
 #: templates/core/index.html:53
@@ -2075,11 +3043,22 @@ msgid "Django Girls impact"
 msgstr ""
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
 msgstr ""
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
 msgstr ""
 
 #: templates/core/index.html:69
@@ -2091,11 +3070,18 @@ msgid "Bring Django Girls to your city!"
 msgstr ""
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
 msgstr ""
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
 msgstr ""
 
 #: templates/core/index.html:82 templates/organize/index.html:89
@@ -2103,6 +3089,7 @@ msgid "Apply to organize a workshop"
 msgstr ""
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr ""
 
@@ -2111,7 +3098,9 @@ msgid "Badass Django Ladies"
 msgstr ""
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
 msgstr ""
 
 #: templates/core/index.html:125
@@ -2131,7 +3120,15 @@ msgid "Support our work"
 msgstr ""
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
@@ -2139,7 +3136,11 @@ msgid "Make a recurring donation on Patreon"
 msgstr ""
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
 msgstr ""
 
 #: templates/core/index.html:162
@@ -2147,7 +3148,9 @@ msgid "Stay up to date!"
 msgstr ""
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
 msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
@@ -2163,12 +3166,51 @@ msgstr ""
 msgid "See the Django Girls Dispatch archives"
 msgstr ""
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr ""
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr ""
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
 msgstr ""
 
 #: templates/core/newsletter.html:4
@@ -2180,11 +3222,16 @@ msgid "Django Girls Dispatch"
 msgstr ""
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
 msgstr ""
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
 msgstr ""
 
 #: templates/core/newsletter.html:49
@@ -2196,11 +3243,15 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:20
@@ -2220,19 +3271,31 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:53
@@ -2244,15 +3307,25 @@ msgid "Scope of this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:74
@@ -2260,7 +3333,9 @@ msgid "Data Collected"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:79
@@ -2296,7 +3371,9 @@ msgid "operating system (automatically collected); and"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:90
@@ -2308,15 +3385,22 @@ msgid "We will keep any personal Data you submit for 60 months."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:108
@@ -2332,15 +3416,21 @@ msgid "improvement of our products / services;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:115
@@ -2352,15 +3442,25 @@ msgid "Third Party Sites and Services"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:142
@@ -2368,7 +3468,11 @@ msgid "Links to Other Websites"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:151
@@ -2376,7 +3480,12 @@ msgid "Changes of Business Ownership and Control"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:161
@@ -2388,7 +3497,9 @@ msgid "Controlling Use of Your Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:167
@@ -2408,11 +3519,17 @@ msgid "Your Right to Withhold Information"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:178
@@ -2420,7 +3537,9 @@ msgid "Accessing Your Own Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:182
@@ -2428,7 +3547,10 @@ msgid "Security"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:186
@@ -2436,27 +3558,49 @@ msgid "Cookies"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:201
@@ -2464,19 +3608,29 @@ msgid "You can choose to enable or disable Cookies in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:214
@@ -2484,7 +3638,11 @@ msgid "Changes to this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
 msgstr ""
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
@@ -2493,7 +3651,11 @@ msgid "Resources"
 msgstr ""
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
 msgstr ""
 
 #: templates/core/resources.html:22
@@ -2505,7 +3667,10 @@ msgid "Tutorial Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
 msgstr ""
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
@@ -2522,7 +3687,10 @@ msgid "Organize Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
 msgstr ""
 
 #: templates/core/resources.html:67
@@ -2530,7 +3698,10 @@ msgid "Coaching Guide Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
 msgstr ""
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
@@ -2542,7 +3713,10 @@ msgid "Tutorial Extensions Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
 msgstr ""
 
 #: templates/core/terms_conditions.html:4
@@ -2552,11 +3726,17 @@ msgstr ""
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
 msgstr ""
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/terms_conditions.html:18
@@ -2572,7 +3752,10 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr ""
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:39
@@ -2580,7 +3763,9 @@ msgid "Agreement"
 msgstr ""
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
 msgstr ""
 
 #: templates/core/terms_conditions.html:44
@@ -2596,19 +3781,26 @@ msgid "You promise us:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
 msgstr ""
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
 msgstr ""
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:53
@@ -2616,15 +3808,25 @@ msgid "That you won’t do anything that might cause our systems to crash."
 msgstr ""
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
 msgstr ""
 
 #: templates/core/terms_conditions.html:59
@@ -2632,11 +3834,20 @@ msgid "Intellectual property"
 msgstr ""
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:71
@@ -2644,11 +3855,17 @@ msgid "Price and payment"
 msgstr ""
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
 msgstr ""
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:86
@@ -2656,7 +3873,11 @@ msgid "Use of communications facilities"
 msgstr ""
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:90
@@ -2664,51 +3885,79 @@ msgid "you must not use language that may be offensive to other Users;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
 msgstr ""
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
 msgstr ""
 
 #: templates/core/terms_conditions.html:114
@@ -2716,7 +3965,10 @@ msgid "Privacy and cookies"
 msgstr ""
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:123
@@ -2732,7 +3984,9 @@ msgid "that the Site will meet your needs;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:130
@@ -2756,19 +4010,35 @@ msgid "that the Site is secure,"
 msgstr ""
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
 msgstr ""
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
 msgstr ""
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
 msgstr ""
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
 msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
@@ -2776,11 +4046,20 @@ msgid "Events"
 msgstr ""
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
 msgstr ""
 
 #: templates/core/terms_conditions.html:164
@@ -2788,11 +4067,15 @@ msgid "Problems"
 msgstr ""
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
 msgstr ""
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
 msgstr ""
 
 #: templates/core/terms_conditions.html:170
@@ -2800,11 +4083,16 @@ msgid "Availability of the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
 msgstr ""
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:176
@@ -2812,7 +4100,11 @@ msgid "Limitation of liability"
 msgstr ""
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:180
@@ -2820,7 +4112,9 @@ msgid "You use the Site and its Content at your own risk."
 msgstr ""
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
 msgstr ""
 
 #: templates/core/terms_conditions.html:184
@@ -2828,11 +4122,16 @@ msgid "Linking"
 msgstr ""
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
 msgstr ""
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:190
@@ -2840,15 +4139,23 @@ msgid "We can never guarantee that a link will work."
 msgstr ""
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
 msgstr ""
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:199
@@ -2864,7 +4171,9 @@ msgid "you can only link from a site that you own;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:203
@@ -2872,7 +4181,9 @@ msgid "you mustn’t frame our Site on any other site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
 msgstr ""
 
 #: templates/core/terms_conditions.html:208
@@ -2880,11 +4191,18 @@ msgid "Modifications to these T&Cs & the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
 msgstr ""
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
 msgstr ""
 
 #: templates/core/terms_conditions.html:221
@@ -2892,39 +4210,66 @@ msgid "General stuff"
 msgstr ""
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
 msgstr ""
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
 msgstr ""
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
 msgstr ""
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
 msgstr ""
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:235
@@ -2936,15 +4281,22 @@ msgid "Definitions"
 msgstr ""
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
 msgstr ""
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:244
@@ -2952,7 +4304,10 @@ msgid "<b>Organiser</b> means the organiser or promoter of an Event."
 msgstr ""
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:253
@@ -2960,7 +4315,8 @@ msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr ""
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
 msgstr ""
 
 #: templates/core/workshop_box.html:9
@@ -2968,7 +4324,10 @@ msgid "Order Django Girls Workshop Box for your event!"
 msgstr ""
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
 msgstr ""
 
 #: templates/core/workshop_box.html:27
@@ -2976,11 +4335,19 @@ msgid "How it works?"
 msgstr ""
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
 msgstr ""
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
 msgstr ""
 
 #: templates/core/workshop_box.html:44
@@ -3044,7 +4411,11 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr ""
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
 msgstr ""
 
 #: templates/core/workshop_box.html:78
@@ -3052,7 +4423,12 @@ msgid "How to get one?"
 msgstr ""
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
 msgstr ""
 
 #: templates/core/workshop_box.html:86
@@ -3060,7 +4436,9 @@ msgid "Requirements to apply for a free box:"
 msgstr ""
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
 msgstr ""
 
 #: templates/core/workshop_box.html:89
@@ -3072,11 +4450,16 @@ msgid "Application process for your event needs to be open"
 msgstr ""
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
 msgstr ""
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
 msgstr ""
 
 #: templates/default/about.html:4
@@ -3096,7 +4479,9 @@ msgid "Applications are now open!"
 msgstr ""
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
 msgstr ""
 
 #: templates/default/apply.html:10
@@ -3108,7 +4493,10 @@ msgid "Be a Mentor!"
 msgstr ""
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
 msgstr ""
 
 #: templates/default/coach.html:16 templates/default/values.html:5
@@ -3116,15 +4504,23 @@ msgid "Django Girls"
 msgstr ""
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
 msgstr ""
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 msgstr ""
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
 msgstr ""
 
 #: templates/default/faq.html:6
@@ -3132,7 +4528,10 @@ msgid "Do I need to know anything about websites or programming?"
 msgstr ""
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
 msgstr ""
 
 #: templates/default/faq.html:18
@@ -3140,7 +4539,11 @@ msgid "I am not living in Germany, can I attend?"
 msgstr ""
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
 msgstr ""
 
 #: templates/default/faq.html:31
@@ -3148,7 +4551,10 @@ msgid "Should I bring my own laptop?"
 msgstr ""
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
 msgstr ""
 
 #: templates/default/faq.html:45
@@ -3156,7 +4562,10 @@ msgid "Do I need to have something installed on my laptop?"
 msgstr ""
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
 msgstr ""
 
 #: templates/default/faq.html:58
@@ -3164,7 +4573,11 @@ msgid "Is EuroPython conference good for a total beginner?"
 msgstr ""
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
 msgstr ""
 
 #: templates/default/faq.html:70
@@ -3172,11 +4585,17 @@ msgid "Is food provided?"
 msgstr ""
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
 msgstr ""
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
 msgstr ""
 
 #: templates/default/partners.html:3
@@ -3184,23 +4603,40 @@ msgid "Sponsors"
 msgstr ""
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
 msgstr ""
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
 msgstr ""
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
 msgstr ""
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
 msgstr ""
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
 msgstr ""
 
 #: templates/default/values.html:33
@@ -3208,7 +4644,10 @@ msgid "Apply for the workshop!"
 msgstr ""
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
 msgstr ""
 
 #: templates/default/values.html:43
@@ -3216,7 +4655,9 @@ msgid "As a workshop attendee you will:"
 msgstr ""
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
 msgstr ""
 
 #: templates/default/values.html:48
@@ -3224,7 +4665,9 @@ msgid "be fed by us: during our event, food is provided"
 msgstr ""
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
 msgstr ""
 
 #: templates/donations/donate.html:13
@@ -3236,19 +4679,37 @@ msgid "Our mission:"
 msgstr ""
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
 msgstr ""
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
 msgstr ""
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
 msgstr ""
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
 msgstr ""
 
 #: templates/donations/donate.html:54
@@ -3264,11 +4725,19 @@ msgid "Monthly donations"
 msgstr ""
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
 msgstr ""
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
 
 #: templates/donations/donate.html:105
@@ -3276,11 +4745,16 @@ msgid "One-time donations"
 msgstr ""
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
 msgstr ""
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
 msgstr ""
 
 #: templates/donations/donate.html:121
@@ -3300,15 +4774,10 @@ msgid "Humble Bundle Store"
 msgstr ""
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr ""
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr ""
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
 msgstr ""
 
 #: templates/donations/donate.html:161
@@ -3324,11 +4793,26 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr ""
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
 msgstr ""
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
 msgstr ""
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
@@ -3340,11 +4824,20 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr ""
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
 msgstr ""
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
 msgstr ""
 
 #: templates/donations/donate.html:213
@@ -3352,11 +4845,15 @@ msgid "Django Girls Summit:"
 msgstr ""
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
 msgstr ""
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
 msgstr ""
 
 #: templates/donations/error.html:7
@@ -3371,16 +4868,52 @@ msgstr ""
 msgid "Back to donation page"
 msgstr ""
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
 #: templates/donations/success.html:8
+#, python-format
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:3
+#, python-format
 msgid "Hello team %(city)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:8
@@ -3388,7 +4921,12 @@ msgid "Numbers"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:17
@@ -3396,7 +4934,10 @@ msgid "Tell us how it went!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:22
@@ -3404,7 +4945,12 @@ msgid "Share your experiences"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:27
@@ -3412,7 +4958,10 @@ msgid "Upload your photos"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:32
@@ -3420,7 +4969,11 @@ msgid "Donation"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:41
@@ -3428,11 +4981,19 @@ msgid "Discount in our store"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:55
@@ -3440,9 +5001,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -3453,10 +5014,12 @@ msgid "Hi there!"
 msgstr ""
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
 msgstr ""
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3465,29 +5028,39 @@ msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr ""
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
 msgstr ""
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
 msgstr ""
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3496,21 +5069,37 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
 msgstr ""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr ""
 
@@ -3519,11 +5108,17 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:17
@@ -3534,8 +5129,19 @@ msgstr ""
 msgid "Hello,"
 msgstr ""
 
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:16
@@ -3547,11 +5153,36 @@ msgid "Being an awesome person - already done! :)"
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
 msgstr ""
 
 #: templates/emails/organize/application_notification.html:3
@@ -3628,7 +5259,9 @@ msgid "Do you have potential coaches in mind?"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:9
@@ -3640,14 +5273,17 @@ msgid "1) Email address"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:22
@@ -3655,7 +5291,9 @@ msgid "Password:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:30
@@ -3663,7 +5301,9 @@ msgid "You can also add this inbox to your email client:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:39
@@ -3671,19 +5311,29 @@ msgid "2) Website"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:65
@@ -3691,30 +5341,40 @@ msgid "3) Organizers community"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -3723,55 +5383,91 @@ msgid "Hello there,"
 msgstr ""
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
 msgstr ""
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
 msgstr ""
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
 msgstr ""
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
 msgstr ""
 
 #: templates/global/footer.html:10
@@ -3786,12 +5482,12 @@ msgstr ""
 msgid "Chat with us!"
 msgstr ""
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr ""
-
 #: templates/global/footer.html:14
 msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
 msgstr ""
 
 #: templates/global/footer.html:20
@@ -3808,6 +5504,10 @@ msgstr ""
 
 #: templates/global/footer.html:25
 msgid "Sponsor us"
+msgstr ""
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
 msgstr ""
 
 #: templates/global/footer.html:30
@@ -3835,22 +5535,27 @@ msgid "Privacy & Cookies"
 msgstr ""
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr ""
 
 #: templates/global/footer.html:61
+#, python-format
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr ""
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
 msgstr ""
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
 msgstr ""
 
 #: templates/global/footer.html:64
+#, python-format
 msgid "<b>%(countries_count)s</b> countries"
 msgstr ""
 
@@ -3862,8 +5567,12 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
 msgstr ""
 
 #: templates/global/menu.html:31
@@ -3883,7 +5592,11 @@ msgid "Q: How can I register?"
 msgstr ""
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
 msgstr ""
 
 #: templates/includes/_faq.html:23
@@ -3891,7 +5604,12 @@ msgid "Q: I missed the deadline! Can I still apply to a workshop?"
 msgstr ""
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
 msgstr ""
 
 #: templates/includes/_faq.html:41
@@ -3899,15 +5617,23 @@ msgid "Q: I want to coach or sponsor an event!"
 msgstr ""
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
 msgstr ""
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
 msgstr ""
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
 msgstr ""
 
 #: templates/includes/_no_event.html:5
@@ -3919,7 +5645,8 @@ msgid "Sign up for our newsletter"
 msgstr ""
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
 msgstr ""
 
 #: templates/includes/_no_event.html:16
@@ -3931,11 +5658,38 @@ msgid "Your city"
 msgstr ""
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
 msgstr ""
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
+msgstr ""
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr ""
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr ""
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
 msgstr ""
 
 #: templates/organize/commitment.html:20
@@ -3943,23 +5697,36 @@ msgid "Django Girls Organizer Commitement"
 msgstr ""
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
 msgstr ""
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
 msgstr ""
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
 msgstr ""
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
 msgstr ""
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
 msgstr ""
 
 #: templates/organize/commitment.html:49
@@ -3971,7 +5738,10 @@ msgid "Welcome to Django Girls!"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:14
@@ -3991,7 +5761,8 @@ msgid "Our private community of organizers on Slack (a group chat application)"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:31
@@ -4002,12 +5773,96 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:80
@@ -4016,17 +5871,16 @@ msgstr ""
 msgid "Go to next step"
 msgstr ""
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr ""
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:73
@@ -4034,7 +5888,9 @@ msgid "Check boxes next to all the things that describe you"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:25
@@ -4064,6 +5920,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -4072,7 +5929,10 @@ msgid "Your organizing team"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
 msgstr ""
 
 #: templates/organize/form/step4_workshop_type.html:25
@@ -4098,10 +5958,6 @@ msgstr ""
 #: templates/organize/form/step5_workshop.html:32
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:46
@@ -4131,7 +5987,10 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:89
@@ -4150,43 +6009,42 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -4196,7 +6054,9 @@ msgid "How will you host your workshop remotely?"
 msgstr ""
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:15
@@ -4204,23 +6064,39 @@ msgid "You rock!"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
 msgstr ""
 
 #: templates/organize/index.html:9
@@ -4228,11 +6104,13 @@ msgid "Organize Django Girls workshop"
 msgstr ""
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr ""
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
 msgstr ""
 
 #: templates/organize/index.html:24
@@ -4240,15 +6118,24 @@ msgid "In-Person Workshops"
 msgstr ""
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
 msgstr ""
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
 msgstr ""
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
 msgstr ""
 
 #: templates/organize/index.html:47
@@ -4256,15 +6143,26 @@ msgid "Remote Workshops"
 msgstr ""
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
 msgstr ""
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
 msgstr ""
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/organize/index.html:73
@@ -4272,7 +6170,9 @@ msgid "The Value of Organizing Django Girls"
 msgstr ""
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
 msgstr ""
 
 #: templates/organize/index.html:80
@@ -4304,31 +6204,50 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+msgid "Apply for Event Sponsorship"
+msgstr ""
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
 msgstr ""
 
 #: templates/organize/prerequisites.html:29
@@ -4336,19 +6255,17 @@ msgid "Prerequisities to organize a Django Girls workshop"
 msgstr ""
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr ""
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr ""
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:51
@@ -4376,7 +6293,9 @@ msgid "You’re at least 18 years old"
 msgstr ""
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
 msgstr ""
 
 #: templates/organize/prerequisites.html:93
@@ -4384,7 +6303,9 @@ msgid "The event you’re organizing will be non-profit"
 msgstr ""
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
 msgstr ""
 
 #: templates/organize/prerequisites.html:111
@@ -4396,7 +6317,11 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr ""
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
 msgstr ""
 
 #: templates/organize/suspend.html:18
@@ -4408,7 +6333,10 @@ msgid "Password Reset Complete"
 msgstr ""
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:4
@@ -4416,7 +6344,9 @@ msgid "Password Reset"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:11
@@ -4429,7 +6359,11 @@ msgid "Check Your"
 msgstr ""
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:4
@@ -4437,7 +6371,10 @@ msgid "Forget your password?"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
 msgstr ""
 
 #: templates/registration/password_reset_form.html:11
@@ -4454,23 +6391,38 @@ msgid "Fill the form available on this page to apply for a GitHub grant."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
 msgstr ""
 
 #: templates/story/stories.html:9
@@ -4478,372 +6430,1544 @@ msgid "Django Girls Story"
 msgstr ""
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
 msgstr ""
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
 msgstr ""
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
 msgstr ""
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
 msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
 msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
 msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
 msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
 msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
 msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
 msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+#, fuzzy
+#| msgid "Applications"
+msgid "Options"
+msgstr "Inscrições"
+
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+msgid "Repeat for confirmation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+msgid "Error: The two entered values do not match."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+#, fuzzy
+#| msgid "Applications"
+msgid "Syndication"
+msgstr "Inscrições"
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+#, fuzzy
+#| msgid "Your e-mail address:"
+msgid "Enter a valid email address."
+msgstr "O seu endereço de e-mail:"
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+msgid "Duration"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+msgid "Floating point number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
 msgstr ""
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
 msgstr ""
 
-#: templates/core/coc.html:57
-msgid "In short"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+msgid "IPv4 address"
 msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+msgid "IP address"
 msgstr ""
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
 msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
 msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
 msgstr ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
 msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
 msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
 msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
 msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
 msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
 msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
 msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
 msgstr ""
 
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+msgid "A JSON object"
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
 msgstr ""
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
 msgstr ""
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
 msgstr ""
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
 msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
 msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+msgid "Enter a whole number."
 msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
 msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
 msgstr ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
 msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
 msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sat"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
 msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
 msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
 msgstr ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
 msgstr ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
 msgstr ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
 msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
 msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
 msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
 msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
 msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
 msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
 msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
 msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
 msgstr ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
 msgstr ""
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
 msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
 msgstr ""
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
 msgstr ""
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
 msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
 msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
 msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
 msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
 msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
 msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
 msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
 msgstr ""
 
-#: templates/global/menu.html:25
-msgid "Jobs"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
 msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
 msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
 msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
 msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
 msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
 msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
 msgstr ""
 
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
+msgstr ""
+
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""

--- a/locale/pt_BR/LC_MESSAGES/django.po
+++ b/locale/pt_BR/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2023-06-09 23:21+0000\n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -19,7 +19,7 @@ msgstr ""
 "Plural-Forms: nplurals=INTEGER; plural=EXPRESSION;\n"
 
 #: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
@@ -95,7 +95,7 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr ""
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr ""
 
 #: applications/models.py:98
@@ -155,27 +155,27 @@ msgstr ""
 msgid "RSVP status"
 msgstr ""
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr ""
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr ""
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr ""
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr ""
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr ""
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr ""
 
@@ -303,6 +303,7 @@ msgid ""
 msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr ""
 
@@ -320,59 +321,64 @@ msgstr ""
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
+#: applications/views.py:254 applications/views.py:280
 msgid "Missing parameters"
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
+#: applications/views.py:265 applications/views.py:288
 msgid "Applications have been updated"
 msgstr ""
 
-#: applications/views.py:299
+#: applications/views.py:305
 #, python-format
 msgid ""
 "Something went wrong with your RSVP link. Please contact us at %(email)s "
 "with your name."
 msgstr ""
 
-#: applications/views.py:309
+#: applications/views.py:315
 msgid ""
 "Your participation in the workshop has been confirmed! We can't wait to meet "
 "you. We will be in touch with details soon."
 msgstr ""
 
-#: applications/views.py:315
+#: applications/views.py:321
 msgid ""
 "Your answer has been saved, thanks for letting us know. Your spot will be "
 "assigned to another person on the waiting list."
 msgstr ""
 
-#: coach/models.py:14
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr ""
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr ""
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
+msgstr ""
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
 msgstr ""
 
 #: contact/forms.py:15
@@ -419,7 +425,7 @@ msgstr ""
 msgid "page URL"
 msgstr ""
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr ""
 
@@ -443,23 +449,23 @@ msgstr ""
 msgid "You cannot remove yourself from a team."
 msgstr ""
 
-#: core/admin/event.py:235
+#: core/admin/event.py:234
 #, python-format
 msgid "Organizer %(user_name)s has been removed"
 msgstr ""
 
-#: core/admin/event.py:245
+#: core/admin/event.py:244
 msgid "Remove organizers"
 msgstr ""
 
-#: core/admin/event.py:263
+#: core/admin/event.py:262
 #, python-format
 msgid ""
 "%(user_name)s has been added to your event, yay! They've been also invited "
 "to Slack and should receive credentials to login in an e-mail."
 msgstr ""
 
-#: core/admin/event.py:280
+#: core/admin/event.py:279
 msgid "Add organizers"
 msgstr ""
 
@@ -481,6 +487,17 @@ msgstr ""
 
 #: core/admin/forms/user.py:15
 msgid "Enter the same password as above, for verification."
+msgstr ""
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
 msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
@@ -535,67 +552,63 @@ msgstr ""
 msgid "Let's talk about the team. First the main organizer:"
 msgstr ""
 
-#: core/validators.py:12
+#: core/validators.py:11
 msgid ""
 "Event date can't be a year only. Please, provide at least a month and a year."
 msgstr ""
 
-#: core/validators.py:18
+#: core/validators.py:17
 msgid ""
 "Your event date is too close. Workshop date should be at least 3 months (90 "
 "days) from now."
 msgstr ""
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
-msgstr ""
-
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr ""
 
-#: core/views.py:181
+#: core/views.py:177
 #, python-format
 msgid "No translation for language %(lang)s"
 msgstr ""
 
-#: djangogirls/settings.py:107
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr ""
 
-#: djangogirls/settings.py:108
+#: djangogirls/settings.py:106
 msgid "Brazilian Portuguese"
 msgstr ""
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr ""
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr ""
 
-#: djangogirls/settings.py:111
+#: djangogirls/settings.py:109
 msgid "Korean"
 msgstr ""
 
-#: djangogirls/settings.py:112
+#: djangogirls/settings.py:110
 msgid "Persian"
 msgstr ""
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:111
 msgid "Portuguese"
 msgstr ""
 
-#: djangogirls/settings.py:114
+#: djangogirls/settings.py:112
 msgid "Russian"
 msgstr ""
 
-#: djangogirls/settings.py:115
+#: djangogirls/settings.py:113
 msgid "Spanish"
 msgstr ""
 
@@ -632,28 +645,28 @@ msgstr ""
 msgid "Move selected application to in review"
 msgstr ""
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr ""
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr ""
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr ""
 
-#: organize/admin.py:159
+#: organize/admin.py:165
 msgid "The application is already deployed"
 msgstr ""
 
-#: organize/admin.py:179
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
 msgstr ""
 
-#: organize/admin.py:184
+#: organize/admin.py:190
 #, python-format
 msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
@@ -702,152 +715,159 @@ msgstr ""
 msgid "Deployed"
 msgstr ""
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr ""
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+msgid "No, it's my first time organizing Django Girls"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr ""
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr ""
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr ""
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr ""
 
-#: organize/models.py:39
+#: organize/forms.py:109
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
+msgstr ""
+
+#: organize/models.py:47
 msgid ""
 "You cannot apply to organize another event when you already have another "
 "open event application."
 msgstr ""
 
-#: organize/models.py:59
+#: organize/models.py:68 organize/models.py:79
 msgid ""
 "Your workshops should be at least 6 months apart. Please read our Organizer "
 "Manual."
 msgstr ""
 
-#: organize/models.py:84
+#: organize/models.py:107
 msgid "About organizer"
 msgstr ""
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr ""
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr ""
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr ""
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr ""
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr ""
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr ""
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr ""
 
-#: organize/models.py:94
+#: organize/models.py:117
 msgid ""
 "Information about local restrictions for physical restrictions due to "
 "Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:97
+#: organize/models.py:120
 msgid ""
 "Information about how you will ensure participants' and coaches' safety "
 "during the Covid-19 pandemic"
 msgstr ""
 
-#: organize/models.py:101
+#: organize/models.py:124
 msgid ""
 "Information about how you intend to ensure your workshop is inclusive and "
 "promotes diversity"
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:106
+#: organize/models.py:129
 msgid ""
 "Confirmation that you will postpone or have a remote event if your "
 "governmentregulations for Covid-19 change."
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:32
+#: patreonmanager/admin.py:31
 msgid "Payments"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
 #, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
 msgstr[1] ""
 
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr ""
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:68
+#: patreonmanager/admin.py:67
 msgid "Mark selected payments as completed"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:70
 #, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
@@ -977,11 +997,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -1043,7 +1063,7 @@ msgid "Remove event organizers"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -1078,9 +1098,18 @@ msgstr ""
 msgid "Remove"
 msgstr ""
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+msgid "Blacklist Organizer"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
 msgstr ""
 
 #: templates/admin/globalpartners/globalpartner/change_form.html:16
@@ -3106,7 +3135,7 @@ msgstr ""
 
 #: templates/core/index.html:143
 msgid ""
-"<span class=\"highlighted-number\">$1,661</span> of <span "
+"<span class=\"highlighted-number\">$1,060</span> of <span "
 "class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
@@ -4714,7 +4743,7 @@ msgstr ""
 #, python-format
 msgid ""
 "Are you a company interested in sponsoring us? Our <a href=\"https://drive."
-"google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?"
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
 "usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
 "href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
@@ -4980,9 +5009,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -5025,14 +5054,11 @@ msgid ""
 "    for password and instructions to access it.\n"
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
+#: templates/emails/existing_user.html:33
 msgid ""
-"You can contact hello@ if you need assistance but it’s usually faster to "
-"check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to "
-"post questions to the <a href=\"https://groups.google.com/forum/#!forum/"
-"django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a "
-"href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> "
-"- there are more people that can help you! :)"
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
@@ -5065,10 +5091,19 @@ msgid ""
 "password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
+#: templates/emails/new_user.html:33
+#, python-format
 msgid ""
-"We also invited you to Django Girls Slack, where we chat, communicate and "
-"meet each other!"
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
@@ -5315,38 +5350,39 @@ msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
 msgid ""
-"Django Girls has a growing community of more than 300 organizers. You should "
-"receive an invitation to join a private group on Google Groups and Slack -- "
-"this is where you can chat with other organisers, ask for their help or "
-"advice. Use it wisely and plenty!"
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
+#: templates/emails/organize/event_deployed.html:76
 msgid ""
 "If you need to cancel or postpone your event, it’s not a problem at all! "
 "Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
+#: templates/emails/organize/event_deployed.html:85
 msgid ""
 "Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
 "Google Group of Django Girls Organizers or Slack channel - there are always "
 "more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -5410,11 +5446,11 @@ msgid ""
 "world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
+#: templates/event/base.html:16
 msgid ""
 "Django Girls is a one-day workshop about programming in Python and Django "
 "tailored for women."
@@ -5424,19 +5460,19 @@ msgstr ""
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
+#: templates/global/base.html:16
 msgid ""
 "Django Girls is a one-day workshop about programming in Python and Django "
 "for women."
 msgstr ""
 
-#: templates/global/base.html:12
+#: templates/global/base.html:20
 msgid ""
 "Django Girls is a one-day workshop about programming in Python and Django "
 "for women"
 msgstr ""
 
-#: templates/global/base.html:14
+#: templates/global/base.html:22
 msgid ""
 "Join us and become a female developer! Build your first website in Python "
 "and Django in a friendly, safe environment."
@@ -5745,6 +5781,84 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:31
 #: templates/organize/form/step2_application.html:25
 msgid "Application to organize a workshop"
@@ -5814,6 +5928,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -5913,68 +6028,31 @@ msgid ""
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid ""
-"Please provide information on how you plan to ensure safety for attendees "
-"and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
 #: templates/organize/form/step5_workshop_remote.html:157
 msgid ""
 "How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
 msgid ""
 "Please tell us how you intend to make sure your workshop is inclusive to "
 "people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
 msgid ""
 "Please provide any additional information you may want to share with us and "
 "may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid ""
-"Will you change your workshop to remote or postpone if the situation changes "
-"in your country?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:231
-msgid ""
-"Confirm you will postpone or host remote workshop if Covid-19 situation "
-"changes in your city."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:237
-msgid ""
-" I confirm that should my local restrictions change to prevent the workshop "
-"from going ahead in person safely, I will change to a remote workshop, or "
-"postpone until restrictions are lifted and it is safe to go ahead."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -6134,10 +6212,14 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+msgid "Apply for Event Sponsorship"
+msgstr ""
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
+#: templates/organize/index.html:124
 msgid ""
 "Django Girls helped me gain more self-confidence and gave me a boost to keep "
 "learning. I’ve created my own blog and then prepared workshops and taught "
@@ -6145,15 +6227,15 @@ msgid ""
 "people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
+#: templates/organize/index.html:145
 msgid ""
 "Organizers of Django Girls Windhoek, Namibia share their experience of "
 "organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
@@ -6161,7 +6243,7 @@ msgid ""
 "more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
+#: templates/organize/index.html:154
 msgid ""
 "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
 "organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
@@ -6169,7 +6251,7 @@ msgid ""
 "more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
+#: templates/organize/index.html:163
 msgid ""
 "Learn how Django Girls Seoul built a local tech community using events as "
 "their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
@@ -6381,4 +6463,1513 @@ msgid ""
 "If you would like to suggest someone to be featured in “Your Django "
 "Story” (or would like to nominate yourself!), please <a href=\"mailto:"
 "story@djangogirls.org\">contact us!</a>"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+msgid "Options"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+msgid "Repeat for confirmation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+msgid "Error: The two entered values do not match."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+msgid "Syndication"
+msgstr ""
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+msgid "Enter a valid email address."
+msgstr ""
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+msgid "Duration"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+msgid "Floating point number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+msgid "IPv4 address"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+msgid "IP address"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+msgid "A JSON object"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
+msgstr ""
+
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+msgid "Enter a whole number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sat"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
+msgstr ""
+
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
 msgstr ""

--- a/locale/ru/LC_MESSAGES/django.po
+++ b/locale/ru/LC_MESSAGES/django.po
@@ -1,37 +1,58 @@
 msgid ""
 msgstr ""
+"Project-Id-Version: djangogirls\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2024-04-22 10:00+0200\n"
+"Language: ru\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: POEditor.com\n"
-"Project-Id-Version: djangogirls\n"
-"Language: ru\n"
-"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
+"Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && "
+"n%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
 
-#: applications/decorators.py:22
-msgid "\"City\" slug must be present to user this decorator."
+#: applications/decorators.py:21
+msgid "\"page_url\" slug must be present to use this decorator."
 msgstr ""
 
 #: applications/forms.py:42
 msgid "Application for this e-mail already exists."
 msgstr "Приложение для этой электронной почты уже существует."
 
+#: applications/forms.py:80
+#, python-format
+msgid "Confirmation of your application for %(page_title)s"
+msgstr ""
+
 #: applications/models.py:19
 msgid "Apply for a spot at Django Girls [City]!"
 msgstr ""
 
 #: applications/models.py:22
-msgid "Yay! We're so excited you want to be a part of our workshop. Please mind that filling out the form below does not give you a place on the workshop, but a chance to get one. The application process is open from {INSERT DATE} until {INSERT DATE}. If you're curious about the criteria we use to choose applicants, you can read about it on <a href='http://blog.djangogirls.org/post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</a>. Good luck!"
+msgid ""
+"Yay! We're so excited you want to be a part of our workshop. Please mind "
+"that filling out the form below does not give you a place on the workshop, "
+"but a chance to get one. The application process is open from {INSERT DATE} "
+"until {INSERT DATE}. If you're curious about the criteria we use to choose "
+"applicants, you can read about it on <a href='http://blog.djangogirls.org/"
+"post/91067112853/djangogirls-how-we-scored-applications'>Django Girls blog</"
+"a>. Good luck!"
 msgstr ""
 
 #: applications/models.py:35
-msgid "Hi there!\n"
+msgid ""
+"Hi there!\n"
 "\n"
-"This is a confirmation of your application to <a href=\"http://djangogirls.org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're proud of you!\n"
+"This is a confirmation of your application to <a href=\"http://djangogirls."
+"org/{city}\">Django Girls {CITY}</a>. Yay! That's a huge step already, we're "
+"proud of you!\n"
 "\n"
-"Mind that this is not a confirmation of participation in the event, but a confirmation that we received your application.\n"
+"Mind that this is not a confirmation of participation in the event, but a "
+"confirmation that we received your application.\n"
 "\n"
-"You'll receive an email from the team that organizes Django Girls {CITY} soon. You can always reach them by answering to this email or by writing to {your event mail}.\n"
+"You'll receive an email from the team that organizes Django Girls {CITY} "
+"soon. You can always reach them by answering to this email or by writing to "
+"{your event mail}.\n"
 "For your reference, we're attaching your answers below.\n"
 "\n"
 "Hugs, cupcakes and high-fives!\n"
@@ -67,7 +88,7 @@ msgid "List all available options, separated with semicolon (;)"
 msgstr ""
 
 #: applications/models.py:94 applications/models.py:99
-msgid "Used only with 'Choices' question type"
+msgid "Used only with \"Choices\" question type"
 msgstr ""
 
 #: applications/models.py:98
@@ -127,27 +148,27 @@ msgstr ""
 msgid "RSVP status"
 msgstr ""
 
-#: applications/models.py:255
+#: applications/models.py:258
 msgid "5 being the most positive, 1 being the most negative."
 msgstr ""
 
-#: applications/models.py:259
+#: applications/models.py:262
 msgid "Any extra comments?"
 msgstr ""
 
-#: applications/models.py:273
+#: applications/models.py:279
 msgid "Content of the email"
 msgstr ""
 
-#: applications/models.py:274
+#: applications/models.py:280
 msgid "You can use HTML syntax in this message. Preview on the right."
 msgstr ""
 
-#: applications/models.py:279 templates/applications/communication.html:22
+#: applications/models.py:285 templates/applications/communication.html:22
 msgid "Recipients"
 msgstr ""
 
-#: applications/models.py:280
+#: applications/models.py:286
 msgid "Only people assigned to chosen group will receive this email."
 msgstr ""
 
@@ -164,7 +185,9 @@ msgid "Do you want to receive news from the Django Girls team?"
 msgstr ""
 
 #: applications/questions.py:55
-msgid "No spam, pinky swear! Only helpful programming tips and latest news from the Django Girls world. We send it once every two weeks."
+msgid ""
+"No spam, pinky swear! Only helpful programming tips and latest news from the "
+"Django Girls world. We send it once every two weeks."
 msgstr ""
 
 #: applications/questions.py:59
@@ -212,11 +235,16 @@ msgid "What is your current level of experience with programming?"
 msgstr ""
 
 #: applications/questions.py:99
-msgid "I'm a total beginner, I don't know anything about it; I've tried some HTML or CSS before; I've tried some JavaScript before; I've done a few lessons of Python; I've built a website before; I work as a programmer"
+msgid ""
+"I'm a total beginner, I don't know anything about it; I've tried some HTML "
+"or CSS before; I've tried some JavaScript before; I've done a few lessons of "
+"Python; I've built a website before; I work as a programmer"
 msgstr ""
 
 #: applications/questions.py:108
-msgid "If you checked anything other than beginner, could you tell us a bit more about your programming knowledge?"
+msgid ""
+"If you checked anything other than beginner, could you tell us a bit more "
+"about your programming knowledge?"
 msgstr ""
 
 #: applications/questions.py:115
@@ -240,7 +268,12 @@ msgid "How are you planning to share what you've learnt with others?"
 msgstr ""
 
 #: applications/questions.py:127
-msgid "Django Girls is a volunteer-run organisation and we look for people who are active and can help us help more women get into the field. We want you to share what you learn at the workshop with others in different ways: by organising a Django Girls event in your city, talking about Django Girls on your local meetups, writing a blog or simply teaching your friends."
+msgid ""
+"Django Girls is a volunteer-run organisation and we look for people who are "
+"active and can help us help more women get into the field. We want you to "
+"share what you learn at the workshop with others in different ways: by "
+"organising a Django Girls event in your city, talking about Django Girls on "
+"your local meetups, writing a blog or simply teaching your friends."
 msgstr ""
 
 #: applications/questions.py:138
@@ -248,19 +281,29 @@ msgid "How did you hear about Django Girls?"
 msgstr ""
 
 #: applications/questions.py:145
-msgid "I acknowledge that some of my data will be used on Third Party Sites and Services."
+msgid ""
+"I acknowledge that some of my data will be used on Third Party Sites and "
+"Services."
 msgstr ""
 
-#: applications/questions.py:158
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Mandrill to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: applications/questions.py:147
+msgid ""
+"Data collected through this form is used only for the purpose of Django "
+"Girls events. We're using Third Party Sites and Services to make it happen: "
+"for example, we're using Sendgrid to send you emails. Don't worry: We don't "
+"share your data with spammers, and we don't sell it! More info on our "
+"Privacy policy <a href='/privacy-cookies/'>here</a>."
 msgstr ""
 
 #: applications/questions.py:155
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:739
 msgid "Yes"
 msgstr ""
 
 #: applications/questions.py:161
-msgid "It is important that all attendees comply with the <a href='/coc/'>Django Girls Code of Conduct</a>"
+msgid ""
+"It is important that all attendees comply with the <a href='/coc/'>Django "
+"Girls Code of Conduct</a>"
 msgstr ""
 
 #: applications/questions.py:164
@@ -271,32 +314,64 @@ msgstr ""
 msgid "Yay! Your application has been saved. You'll hear from us soon!"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application Number"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Application State"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "RSVP Status"
 msgstr ""
 
-#: applications/views.py:119
+#: applications/views.py:120
 msgid "Average Score"
 msgstr ""
 
-#: coach/models.py:14
+#: applications/views.py:254 applications/views.py:280
+msgid "Missing parameters"
+msgstr ""
+
+#: applications/views.py:265 applications/views.py:288
+msgid "Applications have been updated"
+msgstr ""
+
+#: applications/views.py:305
+#, python-format
+msgid ""
+"Something went wrong with your RSVP link. Please contact us at %(email)s "
+"with your name."
+msgstr ""
+
+#: applications/views.py:315
+msgid ""
+"Your participation in the workshop has been confirmed! We can't wait to meet "
+"you. We will be in touch with details soon."
+msgstr ""
+
+#: applications/views.py:321
+msgid ""
+"Your answer has been saved, thanks for letting us know. Your spot will be "
+"assigned to another person on the waiting list."
+msgstr ""
+
+#: coach/models.py:15
 msgid "No @, No http://, just username"
 msgstr ""
 
-#: coach/models.py:17
+#: coach/models.py:18
 msgid "For best display keep it square"
 msgstr ""
 
-#: coach/models.py:23
+#: coach/models.py:24
 msgid "Coaches"
+msgstr ""
+
+#: coach/models.py:36
+#, python-format
+msgid "Coach with name %s and twitter_handle %s already exists."
 msgstr ""
 
 #: contact/forms.py:15
@@ -343,7 +418,7 @@ msgstr ""
 msgid "page URL"
 msgstr ""
 
-#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:86
+#: core/admin/event.py:115 core/admin/event.py:155 organize/admin.py:87
 msgid "Event info"
 msgstr ""
 
@@ -367,8 +442,55 @@ msgstr ""
 msgid "You cannot remove yourself from a team."
 msgstr ""
 
-#: core/admin/event.py:245
+#: core/admin/event.py:234
+#, python-format
+msgid "Organizer %(user_name)s has been removed"
+msgstr ""
+
+#: core/admin/event.py:244
 msgid "Remove organizers"
+msgstr ""
+
+#: core/admin/event.py:262
+#, python-format
+msgid ""
+"%(user_name)s has been added to your event, yay! They've been also invited "
+"to Slack and should receive credentials to login in an e-mail."
+msgstr ""
+
+#: core/admin/event.py:279
+msgid "Add organizers"
+msgstr ""
+
+#: core/admin/flat_page.py:9
+msgid "Change this only if you know what you are doing"
+msgstr ""
+
+#: core/admin/forms/user.py:9
+msgid "The two password fields didn't match."
+msgstr ""
+
+#: core/admin/forms/user.py:11
+msgid "Password"
+msgstr ""
+
+#: core/admin/forms/user.py:13
+msgid "Password confirmation"
+msgstr ""
+
+#: core/admin/forms/user.py:15
+msgid "Enter the same password as above, for verification."
+msgstr ""
+
+#: core/admin/organizerissue.py:55
+#, python-format
+msgid "Organizer %(organizer)s, of %(event)s has been blacklisted."
+msgstr ""
+
+#: core/admin/organizerissue.py:65
+#, python-format
+msgid ""
+"Blacklisting for organizer %(organizer)s, of %(event)s has been reversed."
 msgstr ""
 
 #: core/admin/user.py:12 core/admin/user.py:18
@@ -381,10 +503,6 @@ msgstr ""
 
 #: core/admin/user.py:19
 msgid "Important dates"
-msgstr ""
-
-#: core/admin/flat_page.py:9
-msgid "Change this only if you know what you are doing"
 msgstr ""
 
 #: core/default_eventpage_content.py:60
@@ -423,56 +541,93 @@ msgstr ""
 msgid "E-mail address"
 msgstr ""
 
-#: core/admin/forms/user.py:9
-msgid "The two password fields didn't match."
-msgstr ""
-
-#: core/admin/forms/user.py:11
-msgid "Password"
-msgstr ""
-
-#: core/admin/forms/user.py:13
-msgid "Password confirmation"
-msgstr ""
-
-#: core/admin/forms/user.py:15
-msgid "Enter the same password as above, for verification."
-msgstr ""
-
 #: core/management_utils.py:17
 msgid "Let's talk about the team. First the main organizer:"
 msgstr ""
 
-#: core/validators.py:12
-msgid "Event date can't be a year only. Please, provide at least a month and a year."
+#: core/validators.py:11
+msgid ""
+"Event date can't be a year only. Please, provide at least a month and a year."
 msgstr ""
 
-#: core/validators.py:18
-msgid "Your event date is too close. Workshop date should be at least 3 months (90 days) from now."
+#: core/validators.py:17
+msgid ""
+"Your event date is too close. Workshop date should be at least 3 months (90 "
+"days) from now."
 msgstr ""
 
-#: core/validators.py:24
+#: core/validators.py:23
 msgid "Event date should be in the future"
 msgstr ""
 
-#: core/views.py:100
+#: core/views.py:96
 msgid "List of Django Girls events around the world"
 msgstr ""
 
-#: djangogirls/settings.py:107
+#: core/views.py:177
+#, python-format
+msgid "No translation for language %(lang)s"
+msgstr ""
+
+#: djangogirls/settings.py:105
 msgid "English"
 msgstr ""
 
-#: djangogirls/settings.py:109
+#: djangogirls/settings.py:106
+msgid "Brazilian Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:107
 msgid "French"
 msgstr ""
 
-#: djangogirls/settings.py:110
+#: djangogirls/settings.py:108
 msgid "German"
 msgstr ""
 
-#: djangogirls/settings.py:113
+#: djangogirls/settings.py:109
+msgid "Korean"
+msgstr ""
+
+#: djangogirls/settings.py:110
+msgid "Persian"
+msgstr ""
+
+#: djangogirls/settings.py:111
 msgid "Portuguese"
+msgstr ""
+
+#: djangogirls/settings.py:112
+msgid "Russian"
+msgstr ""
+
+#: djangogirls/settings.py:113
+msgid "Spanish"
+msgstr ""
+
+#: globalpartners/admin.py:53
+#, python-format
+msgid ""
+"Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:64
+#, python-format
+msgid ""
+"Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:75
+#, python-format
+msgid ""
+"Request for promotional material email for %(contact_person)s, of "
+"%(company_name)s has been sent."
+msgstr ""
+
+#: globalpartners/admin.py:86
+#, python-format
+msgid ""
+"Thank you email for %(contact_person)s, of %(company_name)s has been sent."
 msgstr ""
 
 #: organize/admin.py:16
@@ -483,21 +638,30 @@ msgstr ""
 msgid "Move selected application to in review"
 msgstr ""
 
-#: organize/admin.py:76
+#: organize/admin.py:77
 msgid "Application info"
 msgstr ""
 
-#: organize/admin.py:102
+#: organize/admin.py:103
 #: templates/emails/organize/application_notification.html:34
 msgid "Application"
 msgstr ""
 
-#: organize/admin.py:127
+#: organize/admin.py:128
 msgid "Main organizer"
 msgstr ""
 
-#: organize/admin.py:179
+#: organize/admin.py:165
+msgid "The application is already deployed"
+msgstr ""
+
+#: organize/admin.py:185
 msgid "Invalid status provided for application"
+msgstr ""
+
+#: organize/admin.py:190
+#, python-format
+msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
 msgstr ""
 
 #: organize/constants.py:4
@@ -544,109 +708,141 @@ msgstr ""
 msgid "Deployed"
 msgstr ""
 
-#: organize/forms.py:18
+#: organize/forms.py:17
 msgid "Yes, I organized Django Girls"
 msgstr ""
 
-#: organize/forms.py:19
-msgid "No, it’s my first time organizing Django Girls"
+#: organize/forms.py:18
+msgid "No, it's my first time organizing Django Girls"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "Remote"
 msgstr ""
 
-#: organize/forms.py:22
+#: organize/forms.py:21
 msgid "In-Person"
 msgstr ""
 
-#: organize/forms.py:34 organize/forms.py:36
+#: organize/forms.py:33 organize/forms.py:35
 #: templates/organize/form/step1_previous_event.html:75
 msgid "Choose event"
 msgstr ""
 
-#: organize/forms.py:43
+#: organize/forms.py:42
 msgid "You have to choose an event."
 msgstr ""
 
-#: organize/forms.py:128 templates/organize/form/step5_workshop.html:79
+#: organize/forms.py:95 organize/forms.py:121
+#: templates/organize/form/step5_workshop.html:79
 #: templates/organize/form/step5_workshop_remote.html:79
 msgid "Choose country"
 msgstr ""
 
-#: organize/models.py:39
-msgid "You cannot apply to organize another event when you already have another open event application."
+#: organize/forms.py:109
+msgid ""
+"Please enter a valid date, which is at least 3 months (90 days) from now."
 msgstr ""
 
-#: organize/models.py:59
-msgid "Your workshops should be at least 6 months apart. Please read our Organizer Manual."
+#: organize/models.py:47
+msgid ""
+"You cannot apply to organize another event when you already have another "
+"open event application."
 msgstr ""
 
-#: organize/models.py:84
+#: organize/models.py:68 organize/models.py:79
+msgid ""
+"Your workshops should be at least 6 months apart. Please read our Organizer "
+"Manual."
+msgstr ""
+
+#: organize/models.py:107
 msgid "About organizer"
 msgstr ""
 
-#: organize/models.py:85
+#: organize/models.py:108
 msgid "Motivations to organize"
 msgstr ""
 
-#: organize/models.py:86
+#: organize/models.py:109
 msgid "Involvement in Django Girls"
 msgstr ""
 
-#: organize/models.py:87
+#: organize/models.py:110
 msgid "Experience with organizing other events"
 msgstr ""
 
-#: organize/models.py:88
+#: organize/models.py:111
 msgid "Information about your potential venue"
 msgstr ""
 
-#: organize/models.py:89
+#: organize/models.py:112
 msgid "Information about your potential sponsorship"
 msgstr ""
 
-#: organize/models.py:90
+#: organize/models.py:113
 msgid "Information about your potential coaches"
 msgstr ""
 
-#: organize/models.py:92
+#: organize/models.py:115
 msgid "Information about how you will host your remote workshop"
 msgstr ""
 
-#: organize/models.py:97
-msgid "Information about how you will ensure participants' and coaches' safety during the Covid-19 pandemic"
+#: organize/models.py:117
+msgid ""
+"Information about local restrictions for physical restrictions due to "
+"Covid-19 pandemic."
 msgstr ""
 
-#: organize/models.py:101
-msgid "Information about how you intend to ensure your workshop is inclusive and promotes diversity"
+#: organize/models.py:120
+msgid ""
+"Information about how you will ensure participants' and coaches' safety "
+"during the Covid-19 pandemic"
 msgstr ""
 
-#: organize/models.py:103
+#: organize/models.py:124
+msgid ""
+"Information about how you intend to ensure your workshop is inclusive and "
+"promotes diversity"
+msgstr ""
+
+#: organize/models.py:126
 msgid "Any additional information you think may help your application"
 msgstr ""
 
-#: organize/models.py:125
+#: organize/models.py:129
+msgid ""
+"Confirmation that you will postpone or have a remote event if your "
+"governmentregulations for Covid-19 change."
+msgstr ""
+
+#: organize/models.py:148
 msgid "Can accept Organize Applications"
 msgstr ""
 
-#: organize/models.py:224
+#: organize/models.py:244
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:54
 msgid "This field is required."
 msgstr ""
 
-#: organize/models.py:269
+#: organize/models.py:289
 msgid "Co-organizer"
 msgstr ""
 
-#: organize/models.py:270
+#: organize/models.py:290
 msgid "Co-organizers"
 msgstr ""
 
-#: patreonmanager/admin.py:24
+#: patreonmanager/admin.py:23
 msgid "Twitter"
 msgstr ""
 
-#: patreonmanager/admin.py:36 patreonmanager/admin.py:41
+#: patreonmanager/admin.py:31
+msgid "Payments"
+msgstr ""
+
+#: patreonmanager/admin.py:35 patreonmanager/admin.py:40
+#, python-format
 msgid "%d payment"
 msgid_plural "%d payments"
 msgstr[0] ""
@@ -654,29 +850,26 @@ msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
 
-#: patreonmanager/admin.py:32
-msgid "Payments"
-msgstr ""
-
-#: patreonmanager/admin.py:38
+#: patreonmanager/admin.py:37
 msgid "Uncompleted payments"
 msgstr ""
 
-#: patreonmanager/admin.py:61
+#: patreonmanager/admin.py:60
 msgid "Patron"
 msgstr ""
 
-#: patreonmanager/admin.py:71
+#: patreonmanager/admin.py:67
+msgid "Mark selected payments as completed"
+msgstr ""
+
+#: patreonmanager/admin.py:70
+#, python-format
 msgid "Marked %d payment as completed"
 msgid_plural "Marked %d payments as completed"
 msgstr[0] ""
 msgstr[1] ""
 msgstr[2] ""
 msgstr[3] ""
-
-#: patreonmanager/admin.py:68
-msgid "Mark selected payments as completed"
-msgstr ""
 
 #: patreonmanager/apps.py:7
 msgid "Patreon Manager"
@@ -763,10 +956,13 @@ msgid "payments"
 msgstr ""
 
 #: patreonmanager/templates/admin/patreonmanager/patron/change_form.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                %(counter)s payment\n"
 "            "
-msgid_plural "\n"
+msgid_plural ""
+"\n"
 "                %(counter)s payments\n"
 "            "
 msgstr[0] ""
@@ -783,7 +979,9 @@ msgid "Section background"
 msgstr ""
 
 #: pictures/models.py:34
-msgid "Only use pictures with a <a href='https://creativecommons.org/licenses/'>Creative Commons license</a>."
+msgid ""
+"Only use pictures with a <a href='https://creativecommons.org/"
+"licenses/'>Creative Commons license</a>."
 msgstr ""
 
 #: pictures/models.py:39
@@ -798,11 +996,11 @@ msgstr ""
 msgid "No logo"
 msgstr ""
 
-#: story/models.py:21
+#: story/models.py:15
 msgid "story"
 msgstr ""
 
-#: story/models.py:22
+#: story/models.py:16
 msgid "stories"
 msgstr ""
 
@@ -815,11 +1013,15 @@ msgid "Sorry! The page you're looking for isn't available."
 msgstr ""
 
 #: templates/404.html:13
+#, python-format
 msgid "See all <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
 #: templates/404.html:17
-msgid "<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls workshop in your city."
+#, python-format
+msgid ""
+"<a href=\"%(organise_url)s\">Find out</a> about organizing a Django Girls "
+"workshop in your city."
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:5
@@ -827,11 +1029,20 @@ msgid "Submitted applications"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:7
-msgid "To see applications that have been submitted to your workshop, choose an event from the list below:"
+msgid ""
+"To see applications that have been submitted to your workshop, choose an "
+"event from the list below:"
 msgstr ""
 
 #: templates/admin/applications/form/view_submissions.html:16
-msgid "To see submitted applications, you need to <a href=\"%(add_url)s\">add an application form</a> first."
+#, python-format
+msgid ""
+"To see submitted applications, you need to <a href=\"%(add_url)s\">add an "
+"application form</a> first."
+msgstr ""
+
+#: templates/admin/base_site.html:5
+msgid "Django Girls admin"
 msgstr ""
 
 #: templates/admin/core/event/view_add_organizers.html:6
@@ -851,7 +1062,7 @@ msgid "Remove event organizers"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:6
-msgid "Here you can remove exisiting event organizers."
+msgid "Here you can remove existing event organizers."
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:9
@@ -859,6 +1070,7 @@ msgid "To get started, choose an event:"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:20
+#, python-format
 msgid "Organizers of %(event_name)s"
 msgstr ""
 
@@ -875,16 +1087,44 @@ msgid "Action"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
-msgid "'Are you sure that you want to remove organizer %(org_email)s from event %(event_name)s?'"
+#, python-format
+msgid ""
+"'Are you sure that you want to remove organizer %(org_email)s from event "
+"%(event_name)s?'"
 msgstr ""
 
 #: templates/admin/core/event/view_manage_organizers.html:38
 msgid "Remove"
 msgstr ""
 
+#: templates/admin/core/organizerissue/change_form.html:12
 #: templates/admin/globalpartners/globalpartner/change_form.html:12
 #: templates/admin/organize/eventapplication/change_form.html:11
 msgid "Triaging"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:15
+msgid "Blacklist Organizer"
+msgstr ""
+
+#: templates/admin/core/organizerissue/change_form.html:18
+msgid "Reverse Blacklisting Organizer"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:16
+msgid "Send Prospective Sponsor email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:19
+msgid "Send Renewal email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:23
+msgid "Send Promotional Material email"
+msgstr ""
+
+#: templates/admin/globalpartners/globalpartner/change_form.html:26
+msgid "Send Thank You email"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/change_form.html:15
@@ -903,19 +1143,28 @@ msgstr ""
 msgid "Reject application"
 msgstr ""
 
+#: templates/admin/organize/eventapplication/change_form.html:27
+msgid "Application deployed."
+msgstr ""
+
 #: templates/admin/organize/eventapplication/change_form.html:29
 msgid "Application closed."
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:9
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "                Approve %(app_city)s, %(app_country)s application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:14
-msgid "\n"
-"                Are you sure you want to approve the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to approve the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -925,14 +1174,20 @@ msgid "Yes, I'm sure"
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:24
-msgid "\n"
-"                Reject %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Reject %(application.city)s, %(application.country)s "
+"application?\n"
 "            "
 msgstr ""
 
 #: templates/admin/organize/eventapplication/view_change_status.html:29
-msgid "\n"
-"                Are you sure you want to reject the %(application.city)s, %(application.country)s application?\n"
+#, python-format
+msgid ""
+"\n"
+"                Are you sure you want to reject the %(application.city)s, "
+"%(application.country)s application?\n"
 "            "
 msgstr ""
 
@@ -941,10 +1196,12 @@ msgid "Scores"
 msgstr ""
 
 #: templates/applications/application_detail.html:32
+#, python-format
 msgid "Average score: %(avg_score)s"
 msgstr ""
 
 #: templates/applications/application_detail.html:37
+#, python-format
 msgid "Your score: %(user_score.score)s"
 msgstr ""
 
@@ -970,6 +1227,7 @@ msgid "Save & draw next"
 msgstr ""
 
 #: templates/applications/applications.html:20
+#, python-format
 msgid "Applications for %(title)s"
 msgstr ""
 
@@ -1050,17 +1308,27 @@ msgid "Nothing to see here..."
 msgstr ""
 
 #: templates/applications/apply.html:26
-msgid "Attention! This form doesn't have a question with type \"email\"! It's important to collect emails of candidates correctly, otherwise you won't be able to email them through our system. :sadpanda:"
+msgid ""
+"Attention! This form doesn't have a question with type \"email\"! It's "
+"important to collect emails of candidates correctly, otherwise you won't be "
+"able to email them through our system. :sadpanda:"
 msgstr ""
 
 #: templates/applications/apply.html:35
-msgid "\n"
-"                Hi there! If you can see this message, it means people can't register to your event.\n"
+#, python-format
+msgid ""
+"\n"
+"                Hi there! If you can see this message, it means people can't "
+"register to your event.\n"
 "                If you want to open registrations, go to\n"
-"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/\">your form in the admin interface</a> and\n"
-"                make sure \"Application process\" fields are correctly configured. Note: we have a\n"
-"                <a href=\"https://github.com/DjangoGirls/djangogirls/issues/240\">timezone problem</a>! To be sure your\n"
-"                form is open, use the time given by our server (available in the top part of your admin interface). Sorry 😓\n"
+"                <a href=\"/admin/applications/form/%(form_obj.pk)s/change/"
+"\">your form in the admin interface</a> and\n"
+"                make sure \"Application process\" fields are correctly "
+"configured. Note: we have a\n"
+"                <a href=\"https://github.com/DjangoGirls/djangogirls/"
+"issues/240\">timezone problem</a>! To be sure your\n"
+"                form is open, use the time given by our server (available in "
+"the top part of your admin interface). Sorry 😓\n"
 "            "
 msgstr ""
 
@@ -1069,6 +1337,7 @@ msgid "Submit your application"
 msgstr ""
 
 #: templates/applications/communication.html:14
+#, python-format
 msgid "Send email to applicants of %(title)s"
 msgstr ""
 
@@ -1102,6 +1371,7 @@ msgid "Create one!"
 msgstr ""
 
 #: templates/applications/compose_email.html:14
+#, python-format
 msgid "Edit email for %(title)s"
 msgstr ""
 
@@ -1130,8 +1400,11 @@ msgid "Email preview"
 msgstr ""
 
 #: templates/applications/compose_email.html:40
-msgid "\n"
-"                      This email was sent on %(sent)s by %(author)s to %(num_rec)s recipients.\n"
+#, python-format
+msgid ""
+"\n"
+"                      This email was sent on %(sent)s by %(author)s to "
+"%(num_rec)s recipients.\n"
 "                  "
 msgstr ""
 
@@ -1144,20 +1417,31 @@ msgid "Emails that failed to sent:"
 msgstr ""
 
 #: templates/applications/event_not_live.html:11
-msgid "The event for %(city|title)s has already happened and the webpage is no longer live."
+#, python-format
+msgid ""
+"The event for %(city|title)s has already happened and the webpage is no "
+"longer live."
 msgstr ""
 
 #: templates/applications/event_not_live.html:18
-msgid "\n"
-"                        The event page for %(city|title)s will be coming soon.\n"
+#, python-format
+msgid ""
+"\n"
+"                        The event page for %(city|title)s will be coming "
+"soon.\n"
 "                    "
 msgstr ""
 
 #: templates/applications/event_not_live.html:24
-msgid "If you want to contact the organizers of this event, you can email them at <a href=\"mailto:%(page_url)s@djangogirls.org\">%(page_url|lower)s@djangogirls.org</a>"
+#, python-format
+msgid ""
+"If you want to contact the organizers of this event, you can email them at "
+"<a href=\"mailto:%(page_url)s@djangogirls."
+"org\">%(page_url|lower)s@djangogirls.org</a>"
 msgstr ""
 
 #: templates/applications/event_not_live.html:31
+#, python-format
 msgid "See all other <a href=\"%(events_url)s\">upcoming events</a>."
 msgstr ""
 
@@ -1182,8 +1466,11 @@ msgid "To be sure your email reach the right person, check this FAQ first!"
 msgstr ""
 
 #: templates/contact/contact.html:22
-msgid "\n"
-"            If you didn't find what you wanted, please check our extended <a href=\"%(faq_url)s\">FAQ section</a>\n"
+#, python-format
+msgid ""
+"\n"
+"            If you didn't find what you wanted, please check our extended <a "
+"href=\"%(faq_url)s\">FAQ section</a>\n"
 "            or use the form below. :)\n"
 "          "
 msgstr ""
@@ -1197,7 +1484,10 @@ msgid "Django Girls Annual Report 2015"
 msgstr ""
 
 #: templates/core/2015.html:6 templates/core/2015.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2015 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2015."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2015 was an absolutely incredible year for Django Girls. Read all "
+"about our challenges and achievements from 2015."
 msgstr ""
 
 #: templates/core/2015.html:25
@@ -1213,7 +1503,14 @@ msgid "Financial Transparency 💰🔍"
 msgstr ""
 
 #: templates/core/2015.html:52
-msgid "Financial fundraising for Django Girls began in February 2015, when we started our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a> and budget tracking. In June 2015 we incorporated the non-profit <a href=\"https://djangogirls.org/foundation/\">Django Girls Foundation</a> in England. While we're still working on the best way to present our finances, here is a first step: aggregated data about our expenses and income in 2015."
+msgid ""
+"Financial fundraising for Django Girls began in February 2015, when we "
+"started our <a href=\"https://www.patreon.com/djangogirls\">Patreon "
+"campaign</a> and budget tracking. In June 2015 we incorporated the non-"
+"profit <a href=\"https://djangogirls.org/foundation/\">Django Girls "
+"Foundation</a> in England. While we're still working on the best way to "
+"present our finances, here is a first step: aggregated data about our "
+"expenses and income in 2015."
 msgstr ""
 
 #: templates/core/2015.html:58
@@ -1221,11 +1518,23 @@ msgid "Expenses 💸"
 msgstr ""
 
 #: templates/core/2015.html:60
-msgid "In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> position encompassed the majority (70%%) of all of our costs. The Awesomeness Ambassador is responsible for running the daily operations of the organization: responding to organizer's requests, handling our mail, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+#, python-format
+msgid ""
+"In total, <span>we spent $6,095.80 USD in 2015</span>. The <a href=\"https://"
+"djangogirls.org/pages/awesomness-ambassador/\">Awesomeness Ambassador</a> "
+"position encompassed the majority (70%%) of all of our costs. The "
+"Awesomeness Ambassador is responsible for running the daily operations of "
+"the organization: responding to organizer's requests, handling our mail, "
+"doing administrative tasks, updating the blog and newsletter, and "
+"maintaining the website and resources."
 msgstr ""
 
 #: templates/core/2015.html:68
-msgid "Another significant cost was sending some Django Girls team members to EuroPython, but that cost was entirely offset by a generous grant from Divio. Their sponsorship completely covered the cost of sending 3 of Django Girls team members to EuroPython in Spain."
+msgid ""
+"Another significant cost was sending some Django Girls team members to "
+"EuroPython, but that cost was entirely offset by a generous grant from "
+"Divio. Their sponsorship completely covered the cost of sending 3 of Django "
+"Girls team members to EuroPython in Spain."
 msgstr ""
 
 #: templates/core/2015.html:77
@@ -1238,6 +1547,7 @@ msgid "Amount"
 msgstr ""
 
 #: templates/core/2015.html:79
+#, python-format
 msgid "%% of expenses"
 msgstr ""
 
@@ -1270,11 +1580,23 @@ msgid "Income 🌟👀"
 msgstr ""
 
 #: templates/core/2015.html:102
-msgid "<span>We raised $37,157.5 USD in 2015</span>. The most significant part of our incomes comes from one company: <a href=\"https://www.elastic.co/\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for 2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador position with an additional $5,645.19 USD."
+#, python-format, python-brace-format
+msgid ""
+"<span>We raised $37,157.5 USD in 2015</span>. The most significant part of "
+"our incomes comes from one company: <a href=\"https://www.elastic.co/"
+"\">Elastic</a>. Their generosity accounts for 60%% of our overall budget for "
+"2015: they <a href=\"http://blog.djangogirls.org/post/135185350903/meet-our-"
+"new-sponsor-elastic\">donated $17,000 USD</a> from the tickets sales for "
+"Elastic{ON} Tour event series, and sponsored our Awesomeness Ambassador "
+"position with an additional $5,645.19 USD."
 msgstr ""
 
 #: templates/core/2015.html:113
-msgid "We also raised almost 19%% of our total income through <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a month from 48 people or organizations."
+#, python-format
+msgid ""
+"We also raised almost 19%% of our total income through <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>. We're currently receiving $899 USD a "
+"month from 48 people or organizations."
 msgstr ""
 
 #: templates/core/2015.html:122
@@ -1282,6 +1604,7 @@ msgid "Income"
 msgstr ""
 
 #: templates/core/2015.html:124
+#, python-format
 msgid "%% of income"
 msgstr ""
 
@@ -1294,6 +1617,7 @@ msgid "Elastic sponsorship of Awesomeness Ambassador"
 msgstr ""
 
 #: templates/core/2015.html:132
+#, python-brace-format
 msgid "Elastic{ON} Tour donation"
 msgstr ""
 
@@ -1318,7 +1642,11 @@ msgid "Total income"
 msgstr ""
 
 #: templates/core/2015.html:144
-msgid "<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> We're incredibly thankful to all the generous people and organizations that donated this year and helped us secure a budget for even more activities in 2016."
+msgid ""
+"<span>Our total balance for end-of-year 2015 is $31,061.70 USD. </span> "
+"We're incredibly thankful to all the generous people and organizations that "
+"donated this year and helped us secure a budget for even more activities in "
+"2016."
 msgstr ""
 
 #: templates/core/2015.html:151
@@ -1330,19 +1658,37 @@ msgid "In 2016, we're planning to focus on the following initiatives:"
 msgstr ""
 
 #: templates/core/2015.html:155
-msgid "Make the Django Girls Foundation sustainable by growing our monthly recurring income to cover recurring costs. Currently, we need at least $1,500 a month to cover the costs of accounting, the Ambassador's salary, and the cost of other services we're using to maintain the website. We want to grow this revenue by focusing more effort on our <a href=\"https://www.patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more organizations with a fundraising deck, and establishing a permanent online merchandise store. (T-shirts all the time! 👕)"
+msgid ""
+"Make the Django Girls Foundation sustainable by growing our monthly "
+"recurring income to cover recurring costs. Currently, we need at least "
+"$1,500 a month to cover the costs of accounting, the Ambassador's salary, "
+"and the cost of other services we're using to maintain the website. We want "
+"to grow this revenue by focusing more effort on our <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon campaign</a>, reaching out to more "
+"organizations with a fundraising deck, and establishing a permanent online "
+"merchandise store. (T-shirts all the time! 👕)"
 msgstr ""
 
 #: templates/core/2015.html:165
-msgid "We would like to start the Django Girls Box: we would allow all organizers to order a free box of Django Girls stickers, room decorations, cheat sheets, balloons, pins and other small goodies that are almost always ordered for workshops 🎈🍬. We can significantly decrease the cost of that merchandise for all workshops by pre-purchasing them in bulk."
+msgid ""
+"We would like to start the Django Girls Box: we would allow all organizers "
+"to order a free box of Django Girls stickers, room decorations, cheat "
+"sheets, balloons, pins and other small goodies that are almost always "
+"ordered for workshops 🎈🍬. We can significantly decrease the cost of that "
+"merchandise for all workshops by pre-purchasing them in bulk."
 msgstr ""
 
 #: templates/core/2015.html:170
-msgid "We're expecting that the cost of hiring the Awesomeness Ambassador will increase next year for a variety of reasons, so we're preparing for that."
+msgid ""
+"We're expecting that the cost of hiring the Awesomeness Ambassador will "
+"increase next year for a variety of reasons, so we're preparing for that."
 msgstr ""
 
 #: templates/core/2015.html:175
-msgid "We're planning to organize our first Django Girls Summit: a two days unconference where organizers could meet and share their experiences about Django Girls workshops. 👭👫"
+msgid ""
+"We're planning to organize our first Django Girls Summit: a two days "
+"unconference where organizers could meet and share their experiences about "
+"Django Girls workshops. 👭👫"
 msgstr ""
 
 #: templates/core/2015.html:187
@@ -1350,75 +1696,173 @@ msgid "Achievements & Events in 2015 🏆🏅"
 msgstr ""
 
 #: templates/core/2015.html:188
-msgid "2015 was a pretty exciting year for us. Here is a rundown of what happened, season by season."
+msgid ""
+"2015 was a pretty exciting year for us. Here is a rundown of what happened, "
+"season by season."
 msgstr ""
 
 #: templates/core/2015.html:197
-msgid "At the very beginning of the year, Ola & Ola decided that they need help to keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a Support Team</a> (back then called a core team). This is when the first formal processes for creating new events, adding new organizers, and making decisions were established. We began documenting those processes in a tiny <a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
+msgid ""
+"At the very beginning of the year, Ola & Ola decided that they need help to "
+"keep growing Django Girls, and invited <a href=\"http://blog.djangogirls.org/"
+"post/108268319658/django-girls-core-team-grows\">Ania & Baptiste to form a "
+"Support Team</a> (back then called a core team). This is when the first "
+"formal processes for creating new events, adding new organizers, and making "
+"decisions were established. We began documenting those processes in a tiny "
+"<a href=\"https://github.com/DjangoGirls/wiki\">wiki</a>."
 msgstr ""
 
 #: templates/core/2015.html:205
-msgid "The first quarter kept us busy with wonderful people knocking to our doors, asking us if they can help with translating the tutorial. We chose <a href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as our translation platform, and began a never-ending process of figuring out how this translation thing even works. The Polish translation was the first one to be published that year!"
+msgid ""
+"The first quarter kept us busy with wonderful people knocking to our doors, "
+"asking us if they can help with translating the tutorial. We chose <a "
+"href=\"https://crowdin.com/project/django-girls-tutorial\">Crowdin</a> as "
+"our translation platform, and began a never-ending process of figuring out "
+"how this translation thing even works. The Polish translation was the first "
+"one to be published that year!"
 msgstr ""
 
 #: templates/core/2015.html:212
-msgid "The end of winter was marked with a Django Girls booth at PyCon US. We had a wonderful time answering everyone's questions and spreading the word about Django Girls. We also debuted the <a href=\"https://cottonbureau.com/products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
+msgid ""
+"The end of winter was marked with a Django Girls booth at PyCon US. We had a "
+"wonderful time answering everyone's questions and spreading the word about "
+"Django Girls. We also debuted the <a href=\"https://cottonbureau.com/"
+"products/this-is-what-a-programmer-looks-like\">&ldquo;This is what a "
+"programmer looks like&rdquo; t-shirts</a>, and sold 100 of them!"
 msgstr ""
 
 #: templates/core/2015.html:219
-msgid "Through the whole year, we kept promoting badass Django developers by publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing women on our blog</a> -- one for each week of the year. Huge thank you to Anna Ossowski who led this project for over a year, and to <a href=\"http://blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-lowe\">Adrienne Lowe</a> who is now in charge of it."
+msgid ""
+"Through the whole year, we kept promoting badass Django developers by "
+"publishing <a href=\"https://djangogirls.org/story/\">53 stories of amazing "
+"women on our blog</a> -- one for each week of the year. Huge thank you to "
+"Anna Ossowski who led this project for over a year, and to <a href=\"http://"
+"blog.djangogirls.org/post/132398930020/your-django-story-meet-adrienne-"
+"lowe\">Adrienne Lowe</a> who is now in charge of it."
 msgstr ""
 
 #: templates/core/2015.html:236
-msgid "We focused on improving our organizer's tools. Thanks to the hard work of our volunteers, we've seen some incredible contributions to our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also built an Applications tool for organizers that finally allows them to receive and score applications through the Django Girls website, instead of Google Forms and Spreadsheets. Phew!"
+msgid ""
+"We focused on improving our organizer's tools. Thanks to the hard work of "
+"our volunteers, we've seen some incredible contributions to our <a "
+"href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>. We also "
+"built an Applications tool for organizers that finally allows them to "
+"receive and score applications through the Django Girls website, instead of "
+"Google Forms and Spreadsheets. Phew!"
 msgstr ""
 
 #: templates/core/2015.html:243
-msgid "More people joined the Support Team: we welcomed <a href=\"http://blog.djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing our transparency efforts. We spent a significant amount of time writing new documentation and improving current internal docs, and then open sourced it in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support Team Wiki</a>. From now on, everything about what we believe and how we work is open and public."
+msgid ""
+"More people joined the Support Team: we welcomed <a href=\"http://blog."
+"djangogirls.org/post/120136694238/welcome-kasia-and-geoffrey-to-django-girls-"
+"core\"> Kasia and Geoffrey</a>. This also kicked off a process of increasing "
+"our transparency efforts. We spent a significant amount of time writing new "
+"documentation and improving current internal docs, and then open sourced it "
+"in a form of the <a href=\"https://github.com/DjangoGirls/wiki\">Support "
+"Team Wiki</a>. From now on, everything about what we believe and how we work "
+"is open and public."
 msgstr ""
 
 #: templates/core/2015.html:251
-msgid "In May, we also made a major update to the Django Girls tutorial, <a href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-to-python-anywhere\">rewriting the deploy chapter</a> to use Python Anywhere. Big thank you to Harry Percival for making it possible."
+msgid ""
+"In May, we also made a major update to the Django Girls tutorial, <a "
+"href=\"http://blog.djangogirls.org/post/118716365753/django-girls-now-deploy-"
+"to-python-anywhere\">rewriting the deploy chapter</a> to use Python "
+"Anywhere. Big thank you to Harry Percival for making it possible."
 msgstr ""
 
 #: templates/core/2015.html:257
-msgid "Last, but definitely not least, we incorporated the Django Girls Foundation during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on them, and made it official. Django Girls is now a charity!"
+msgid ""
+"Last, but definitely not least, we incorporated the Django Girls Foundation "
+"during DjangoCon Europe 2015. We signed the papers, put the emoji sticker on "
+"them, and made it official. Django Girls is now a charity!"
 msgstr ""
 
 #: templates/core/2015.html:273
-msgid "Oh my, summer was one hell of a ride. First, the Birthday Party! <a href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a park, shared cupcakes, raised some glasses of sangria, and played a couple of games."
+msgid ""
+"Oh my, summer was one hell of a ride. First, the Birthday Party! <a "
+"href=\"http://blog.djangogirls.org/post/125086409433/django-girls-1st-"
+"birthday-thank-you\">Django Girls' 1st Birthday Party</a> happened at "
+"EuroPython on the 22nd of July. We celebrated with 50 wonderful friends in a "
+"park, shared cupcakes, raised some glasses of sangria, and played a couple "
+"of games."
 msgstr ""
 
 #: templates/core/2015.html:279
-msgid "August was also the month when the <a href=\"http://blog.djangogirls.org/post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of our website were born. This happened thanks to amazing work of Marysia Lowas-Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn more about Django by contributing to open source, as well as Becky Smith who mentored them, and Ania Warzecha who provided guidance and merged the final pull request. YAY!"
+msgid ""
+"August was also the month when the <a href=\"http://blog.djangogirls.org/"
+"post/126496144993/django-girls-winter-of-code\">Jobs & Meetups</a> pages of "
+"our website were born. This happened thanks to amazing work of Marysia Lowas-"
+"Rzechonek & Kasia Siedlarek, both Django Girls attendees who wanted to learn "
+"more about Django by contributing to open source, as well as Becky Smith who "
+"mentored them, and Ania Warzecha who provided guidance and merged the final "
+"pull request. YAY!"
 msgstr ""
 
 #: templates/core/2015.html:287
-msgid "Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/post/125437235598/yay-lacey-williams-henschel-is-joining-the-django\">invited Lacey to join us</a>. Right from the start, she did an amazing job of establishing new processes, improving old ones, and increasing our transparency efforts."
+msgid ""
+"Growing the Support Team yet again, we <a href=\"http://blog.djangogirls.org/"
+"post/125437235598/yay-lacey-williams-henschel-is-joining-the-"
+"django\">invited Lacey to join us</a>. Right from the start, she did an "
+"amazing job of establishing new processes, improving old ones, and "
+"increasing our transparency efforts."
 msgstr ""
 
 #: templates/core/2015.html:293
-msgid "Summer also kept us incredibly busy with a process of hiring Awesomeness Ambassador -- our first paid staff member! We spent literally hundreds of hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you want to learn more about the recruitment process, <a href=\"http://blog.djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-from-our\">we shared it in detail on our blog</a>."
+msgid ""
+"Summer also kept us incredibly busy with a process of hiring Awesomeness "
+"Ambassador -- our first paid staff member! We spent literally hundreds of "
+"hours to recruit the best applicant: Lucie Daeye. Totally paid off. If you "
+"want to learn more about the recruitment process, <a href=\"http://blog."
+"djangogirls.org/post/129169522198/django-girls-is-hiring-lessons-learned-"
+"from-our\">we shared it in detail on our blog</a>."
 msgstr ""
 
 #: templates/core/2015.html:310
-msgid "After the very busy summer, the time came to rest and recharge batteries a little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few weeks, and she did an amazing job. This is also when we realized how many of us were so close to burnout, and the decision of hiring our first paid staff member came at such a perfect time."
+msgid ""
+"After the very busy summer, the time came to rest and recharge batteries a "
+"little bit. We let Lucie (the Awesomeness Ambassador) run the show for a few "
+"weeks, and she did an amazing job. This is also when we realized how many of "
+"us were so close to burnout, and the decision of hiring our first paid staff "
+"member came at such a perfect time."
 msgstr ""
 
 #: templates/core/2015.html:316
-msgid "Lucie focused some of her efforts on fundraising activities, and traveled to Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered with Elastic and after the event they made an amazing donation of $17,000! That's the biggest donation we've seen yet, and completely unexpected. Thank you again!"
+#, python-brace-format
+msgid ""
+"Lucie focused some of her efforts on fundraising activities, and traveled to "
+"Munich for Elastic{ON} Tour event to run Django Girls booth. We partnered "
+"with Elastic and after the event they made an amazing donation of $17,000! "
+"That's the biggest donation we've seen yet, and completely unexpected. Thank "
+"you again!"
 msgstr ""
 
 #: templates/core/2015.html:322
-msgid "In October, Ania Warzecha decided to step down from Support Team, and wrote a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/overcommitment-and-burnout\">overcommitment and burnout</a>. This made us more aware of the need to practice excellent self-care while doing volunteer and open-source work."
+msgid ""
+"In October, Ania Warzecha decided to step down from Support Team, and wrote "
+"a valuable post on <a href=\"http://blog.djangogirls.org/post/131283812099/"
+"overcommitment-and-burnout\">overcommitment and burnout</a>. This made us "
+"more aware of the need to practice excellent self-care while doing volunteer "
+"and open-source work."
 msgstr ""
 
 #: templates/core/2015.html:329
-msgid "We made a jump from hosting our emails on a VPS provided generously by Megiteam to Google Apps, which became free to us once we officially registered as charity. This turned out to be quite a project: moving 100+ email accounts and tens of thousands of emails without interrupting anyone's organization! This wouldn't have happened so smoothly if it wasn't for Adria Richards, who volunteered and offered us her knowledge and experience free of charge. Thank you, Adria!"
+msgid ""
+"We made a jump from hosting our emails on a VPS provided generously by "
+"Megiteam to Google Apps, which became free to us once we officially "
+"registered as charity. This turned out to be quite a project: moving 100+ "
+"email accounts and tens of thousands of emails without interrupting anyone's "
+"organization! This wouldn't have happened so smoothly if it wasn't for Adria "
+"Richards, who volunteered and offered us her knowledge and experience free "
+"of charge. Thank you, Adria!"
 msgstr ""
 
 #: templates/core/2015.html:337
-msgid "Since Lucie joined the team, we've also vastly improved our communication: the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can find all the Dispatches we sent so far."
+msgid ""
+"Since Lucie joined the team, we've also vastly improved our communication: "
+"the Django Girls Dispatch goes out regularly every two weeks to almost 1,100 "
+"people! <a href=\"https://djangogirls.org/newsletter/\">Here</a> you can "
+"find all the Dispatches we sent so far."
 msgstr ""
 
 #: templates/core/2015.html:351
@@ -1426,39 +1870,95 @@ msgid "Success stories 💖"
 msgstr ""
 
 #: templates/core/2015.html:353
-msgid "We don't have information on the number of people who became developers after Django Girls, and that information is difficult to gather. But it's an important metric. In this section, we're featuring interviews with some Django Girls attendees who've become professional developers since taking our workshop. We hope these anecdotes give you an idea of how powerful and life-changing attending a Django Girls workshop can be."
+msgid ""
+"We don't have information on the number of people who became developers "
+"after Django Girls, and that information is difficult to gather. But it's an "
+"important metric. In this section, we're featuring interviews with some "
+"Django Girls attendees who've become professional developers since taking "
+"our workshop. We hope these anecdotes give you an idea of how powerful and "
+"life-changing attending a Django Girls workshop can be."
 msgstr ""
 
 #: templates/core/2015.html:364
-msgid "Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever Django Girls event at EuroPython, and started to work as Python Developer shortly after. She now also studies Computer Science and co-organizes local meetup for Python developers in her city."
+msgid ""
+"Agata Grdal is 23 and lives in Wrocław, Poland. She attended first ever "
+"Django Girls event at EuroPython, and started to work as Python Developer "
+"shortly after. She now also studies Computer Science and co-organizes local "
+"meetup for Python developers in her city."
 msgstr ""
 
 #: templates/core/2015.html:370
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I've created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of crazy, positive people!"
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I've created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of crazy, "
+"positive people!"
 msgstr ""
 
 #: templates/core/2015.html:386
-msgid "Catherine is 25 years old and lives in France. After attending Django Girls event organized in Paris, she decided to switch career and is now studying computer programming fulltime."
+msgid ""
+"Catherine is 25 years old and lives in France. After attending Django Girls "
+"event organized in Paris, she decided to switch career and is now studying "
+"computer programming fulltime."
 msgstr ""
 
 #: templates/core/2015.html:392
-msgid "I was looking for a professional reconversion when I came across Django Girls, and it was my very first immersion into the programming world. It was wonderful! The learning pace was intense and thrilling, and the community, built around strong values, very welcoming. It encouraged me to keep looking into this field and I am now studying it full time!"
+msgid ""
+"I was looking for a professional reconversion when I came across Django "
+"Girls, and it was my very first immersion into the programming world. It was "
+"wonderful! The learning pace was intense and thrilling, and the community, "
+"built around strong values, very welcoming. It encouraged me to keep looking "
+"into this field and I am now studying it full time!"
 msgstr ""
 
 #: templates/core/2015.html:409
-msgid "Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since December 2015 she can proudly add \"Junior Django Developer\" as her new job title. She also co-organized Django Girls Kraków 2014 and was a coach at Django Girls Kraków 2015. Last Spring with a group of people, she organized a two-month weekly workshops for beginners to practise resolving simple programming problems in Python. Most recently she also got involved in the organization of the Krakow Python User Group and DjangoCon Europe 2016."
+msgid ""
+"Maria Lowas-Rzechonek is 32 years old and lives in Kraków, Poland. Since "
+"December 2015 she can proudly add \"Junior Django Developer\" as her new job "
+"title. She also co-organized Django Girls Kraków 2014 and was a coach at "
+"Django Girls Kraków 2015. Last Spring with a group of people, she organized "
+"a two-month weekly workshops for beginners to practise resolving simple "
+"programming problems in Python. Most recently she also got involved in the "
+"organization of the Krakow Python User Group and DjangoCon Europe 2016."
 msgstr ""
 
 #: templates/core/2015.html:417
-msgid "I wouldn't be where I am now if not Django Girls. I wouldn't have been so motivated to carry on learning programming if I hadn't participated in Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience of Django/Python community, and probably I wouldn't get involved in local meetups because of that. I wouldn't have that great opportunity to practise and get my code public, if not Django Girls Winter of Code. Lastly, if not Django Girls, I wouldn't meet all those wonderful people, who actually get me in touch with people looking for junior developers. Learning how to program is a dangerous journey to go alone."
+msgid ""
+"I wouldn't be where I am now if not Django Girls. I wouldn't have been so "
+"motivated to carry on learning programming if I hadn't participated in "
+"Django Girls at EuroPython 2014. I wouldn't have such a wonderful experience "
+"of Django/Python community, and probably I wouldn't get involved in local "
+"meetups because of that. I wouldn't have that great opportunity to practise "
+"and get my code public, if not Django Girls Winter of Code. Lastly, if not "
+"Django Girls, I wouldn't meet all those wonderful people, who actually get "
+"me in touch with people looking for junior developers. Learning how to "
+"program is a dangerous journey to go alone."
 msgstr ""
 
 #: templates/core/2015.html:437
-msgid "Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending Django Girls London 2015, she got a job as a Junior Full-Stack Developer and now she works with Django, Python, C# and JavaScript on daily basis! In Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is about to run Django Girls Sheffield, which will take place in Feburary 2016. She’s also been involved with <a href=\"http://microworldtour.github.io/about.html\">microbit worldtour project</a> about writing Python for BBC Micro:Bit and enjoyed that a lot."
+msgid ""
+"Päivi Suomela is 30 years old and lives in Sheffield, UK. After attending "
+"Django Girls London 2015, she got a job as a Junior Full-Stack Developer and "
+"now she works with Django, Python, C# and JavaScript on daily basis! In "
+"Autumn, she organized Django Girls Coventry at PyCon UK 2015 and she is "
+"about to run Django Girls Sheffield, which will take place in Feburary 2016. "
+"She’s also been involved with <a href=\"http://microworldtour.github.io/"
+"about.html\">microbit worldtour project</a> about writing Python for BBC "
+"Micro:Bit and enjoyed that a lot."
 msgstr ""
 
 #: templates/core/2015.html:445
-msgid "I first heard of Django Girls when it was just starting out and I applied to the first workshop but wasn’t selected at the time. I applied again when the workshop was in London in March 2015 and this time I got in. I had been learning to program on my own, but the workshop gave me the push I needed to get more serious about it and actually try to get work as a developer. It was great to hear stories of other women who had become developers despite not having studied CS at university and having already spent time working in other careers. It made me realise that I could do it too! I’ve also met lots of nice people through Django Girls and heard about different opportunities that I might not have been aware of otherwise."
+msgid ""
+"I first heard of Django Girls when it was just starting out and I applied to "
+"the first workshop but wasn’t selected at the time. I applied again when the "
+"workshop was in London in March 2015 and this time I got in. I had been "
+"learning to program on my own, but the workshop gave me the push I needed to "
+"get more serious about it and actually try to get work as a developer. It "
+"was great to hear stories of other women who had become developers despite "
+"not having studied CS at university and having already spent time working in "
+"other careers. It made me realise that I could do it too! I’ve also met lots "
+"of nice people through Django Girls and heard about different opportunities "
+"that I might not have been aware of otherwise."
 msgstr ""
 
 #: templates/core/2015.html:461
@@ -1470,15 +1970,31 @@ msgid "2015 was an incredibly busy year for Django Girls."
 msgstr ""
 
 #: templates/core/2015.html:464
-msgid "From a tiny and loosely defined organization in 2014, we grew to develop the Django Girls Foundation and hired one person to work exclusively on Django Girls."
+msgid ""
+"From a tiny and loosely defined organization in 2014, we grew to develop the "
+"Django Girls Foundation and hired one person to work exclusively on Django "
+"Girls."
 msgstr ""
 
 #: templates/core/2015.html:466
-msgid "We are incredibly proud of how much the Django Girls community achieved in the past year, and we hope that 2016 will be even better and more exciting!"
+msgid ""
+"We are incredibly proud of how much the Django Girls community achieved in "
+"the past year, and we hope that 2016 will be even better and more exciting!"
 msgstr ""
 
 #: templates/core/2015.html:469
-msgid "To make Django Girls sustainable and allow further growth, <span><b>we need your help</b></span>. One of our goals for 2016 is to secure the position of Awesomeness Ambassador for the future and increase the revenue from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the expenses associated with it. We hope that in the next months, with the help of the amazing community around Django Girls,we will be able to continue spreading love for programming around the world. To help us further our goal, please consider becoming a monthly contributor to <a href=\"https://www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We promise you won't regret it!"
+msgid ""
+"To make Django Girls sustainable and allow further growth, <span><b>we need "
+"your help</b></span>. One of our goals for 2016 is to secure the position of "
+"Awesomeness Ambassador for the future and increase the revenue from <a "
+"href=\"https://www.patreon.com/djangogirls\">Patreon</a> to cover the "
+"expenses associated with it. We hope that in the next months, with the help "
+"of the amazing community around Django Girls,we will be able to continue "
+"spreading love for programming around the world. To help us further our "
+"goal, please consider becoming a monthly contributor to <a href=\"https://"
+"www.patreon.com/djangogirls\">our Patreon campaign</a>, or <a href=\"https://"
+"djangogirls.org/contact/\">email us</a> to discuss corporate sponsorship. We "
+"promise you won't regret it!"
 msgstr ""
 
 #: templates/core/2015.html:479
@@ -1490,43 +2006,77 @@ msgid "Sponsors 📢️"
 msgstr ""
 
 #: templates/core/2015.html:488 templates/core/2016-2017.html:424
-msgid "Again, we would like to thank amazing sponsors of Django Girls and of the individual Django Girls workshops all over the world. They help us make Django Girls sustainable and more importantly, they help local organizers keep their events free. We want Django Girls to be accessible to many people as possible, and that couldn't happen without them."
+msgid ""
+"Again, we would like to thank amazing sponsors of Django Girls and of the "
+"individual Django Girls workshops all over the world. They help us make "
+"Django Girls sustainable and more importantly, they help local organizers "
+"keep their events free. We want Django Girls to be accessible to many people "
+"as possible, and that couldn't happen without them."
 msgstr ""
 
 #: templates/core/2015.html:496 templates/core/2016-2017.html:432
-msgid "Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates products to to search, analyze, and visualize your data, allowing you to get actionable insight in real time. Before becoming one of our biggest sponsors, they also sponsored several local events. Thanks <3"
+msgid ""
+"Known for Elasticsearch, Kibana, Beats, and Logstash, Elastic creates "
+"products to to search, analyze, and visualize your data, allowing you to get "
+"actionable insight in real time. Before becoming one of our biggest "
+"sponsors, they also sponsored several local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:503 templates/core/2016-2017.html:439
-msgid "The Django Software Foundation (DSF) is a non-profit organization created to promote, support, and advance the development of Django. They've helped many Django Girls events that had problems finding local sponsors. Thanks <3"
+msgid ""
+"The Django Software Foundation (DSF) is a non-profit organization created to "
+"promote, support, and advance the development of Django. They've helped many "
+"Django Girls events that had problems finding local sponsors. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:509 templates/core/2016-2017.html:446
-msgid "The Python Software Foundation (PSF) is a non-profit organization that holds the intellectual property rights behind the Python programming language. They are one of the biggest sponsors for local events. Thanks <3"
+msgid ""
+"The Python Software Foundation (PSF) is a non-profit organization that holds "
+"the intellectual property rights behind the Python programming language. "
+"They are one of the biggest sponsors for local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:515 templates/core/2016-2017.html:453
-msgid "GitHub is a Git repository hosting service. They have sponsored many Django Girls events, and they provide useful materials for new learners like cheat-sheets. Thanks <3"
+msgid ""
+"GitHub is a Git repository hosting service. They have sponsored many Django "
+"Girls events, and they provide useful materials for new learners like cheat-"
+"sheets. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:521 templates/core/2016-2017.html:460
-msgid "Divio, that created Django CMS and Aldryn, uses Python and Django to provide support for website installation, maintenance, troubleshooting, and development. They sponsored many local events and joined as Patreon supporters in June 2015. Thanks <3"
+msgid ""
+"Divio, that created Django CMS and Aldryn, uses Python and Django to provide "
+"support for website installation, maintenance, troubleshooting, and "
+"development. They sponsored many local events and joined as Patreon "
+"supporters in June 2015. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:527 templates/core/2016-2017.html:467
-msgid "Lincoln Loop is a full service web studio offering user experience and development based on the Django Web Framework. They joined our Patreon campaign in April 2015, and have contributed to local events. Thanks <3"
+msgid ""
+"Lincoln Loop is a full service web studio offering user experience and "
+"development based on the Django Web Framework. They joined our Patreon "
+"campaign in April 2015, and have contributed to local events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:533 templates/core/2016-2017.html:474
-msgid "Since May, Django Girls has been hosted on PythonAnywhere! They host, run, and code Python in the cloud, and have made the lives of our attendees much easier by being really simple and pleasant to use. Thanks <3"
+msgid ""
+"Since May, Django Girls has been hosted on PythonAnywhere! They host, run, "
+"and code Python in the cloud, and have made the lives of our attendees much "
+"easier by being really simple and pleasant to use. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:539 templates/core/2016-2017.html:481
-msgid "Mandrill is a transactional email platform from MailChimp. They'vebeen supporting our emails since September 2015 and have also sponsored local events. Thanks <3"
+msgid ""
+"Mandrill is a transactional email platform from MailChimp. They'vebeen "
+"supporting our emails since September 2015 and have also sponsored local "
+"events. Thanks <3"
 msgstr ""
 
 #: templates/core/2015.html:545 templates/core/2016-2017.html:488
-msgid "We would also like to thank our regular donors from <a href=\"https://www.patreon.com/djangogirls\">Patreon</a>: your commitment to help us every month is amazing. Thanks <3"
+msgid ""
+"We would also like to thank our regular donors from <a href=\"https://www."
+"patreon.com/djangogirls\">Patreon</a>: your commitment to help us every "
+"month is amazing. Thanks <3"
 msgstr ""
 
 #: templates/core/2016-2017.html:5 templates/core/2016-2017.html:7
@@ -1534,7 +2084,10 @@ msgid "Django Girls Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:6 templates/core/2016-2017.html:8
-msgid "Thanks to the organizers, coaches, and volunteers in countries all over the world, 2016-2017 was an absolutely incredible year for Django Girls. Read all about our challenges and achievements from 2016-2017."
+msgid ""
+"Thanks to the organizers, coaches, and volunteers in countries all over the "
+"world, 2016-2017 was an absolutely incredible year for Django Girls. Read "
+"all about our challenges and achievements from 2016-2017."
 msgstr ""
 
 #: templates/core/2016-2017.html:26
@@ -1542,11 +2095,25 @@ msgid "Impact Report 2016-2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:29
-msgid "Django Girls Foundation is an initiative that aims to introduce women and girls who never coded before to the world of technology and increase the diversity of the tech industry. We achieve this by organising one-day workshops and inviting women to come and learn how to build the internet using HTML, CSS, Python and Django. Django Girls is a volunteer run organisation with volunteers all over the world. Django Girls has two part-time paid staff members and the support team (six awesome ladies who are also volunteers) to help provide support to all other volunteers."
+msgid ""
+"Django Girls Foundation is an initiative that aims to introduce women and "
+"girls who never coded before to the world of technology and increase the "
+"diversity of the tech industry. We achieve this by organising one-day "
+"workshops and inviting women to come and learn how to build the internet "
+"using HTML, CSS, Python and Django. Django Girls is a volunteer run "
+"organisation with volunteers all over the world. Django Girls has two part-"
+"time paid staff members and the support team (six awesome ladies who are "
+"also volunteers) to help provide support to all other volunteers."
 msgstr ""
 
 #: templates/core/2016-2017.html:38
-msgid "This Impact Report aims to celebrate achievements of the Django Girls community in the past two years, and showcase the incredible growth of the organization. For the first time ever, we're also presenting results of a survey we conducted with almost 600 past Django Girls attendees to see if Django Girls Foundation actually achieves the goal of our mission: to bring more women into tech industry!"
+msgid ""
+"This Impact Report aims to celebrate achievements of the Django Girls "
+"community in the past two years, and showcase the incredible growth of the "
+"organization. For the first time ever, we're also presenting results of a "
+"survey we conducted with almost 600 past Django Girls attendees to see if "
+"Django Girls Foundation actually achieves the goal of our mission: to bring "
+"more women into tech industry!"
 msgstr ""
 
 #: templates/core/2016-2017.html:50
@@ -1554,35 +2121,55 @@ msgid "✨ Highlights ✨"
 msgstr ""
 
 #: templates/core/2016-2017.html:52
-msgid "👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have organised <span>377 free workshops</span> with <span>102 more</span> being currently planned. That's more than 3000 hours of happy coding!"
+msgid ""
+"👭👫👬 Django Girls community grew to <span>1069 volunteers</span> who have "
+"organised <span>377 free workshops</span> with <span>102 more</span> being "
+"currently planned. That's more than 3000 hours of happy coding!"
 msgstr ""
 
 #: templates/core/2016-2017.html:57
-msgid "👩‍💻 <span>21%%</span> of participants in our survey <span>started working in tech</span> after attending Django Girls workshop. <a href=\"#employment-stats\">👉</a>"
+#, python-format
+msgid ""
+"👩‍💻 <span>21%%</span> of participants in our survey <span>started working "
+"in tech</span> after attending Django Girls workshop. <a href=\"#employment-"
+"stats\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:62
-msgid "💯 In the last 2 years we improved our tools to support the growth of the organisation, maintended our free online resources (our tutorial is now in <span>14 languages!</span>), started Django Girls Store as a fundraising effort, shipped <span>146 organizer kits</span> and more.  <a href=\"#tutorial\">👉</a>"
+msgid ""
+"💯 In the last 2 years we improved our tools to support the growth of the "
+"organisation, maintended our free online resources (our tutorial is now in "
+"<span>14 languages!</span>), started Django Girls Store as a fundraising "
+"effort, shipped <span>146 organizer kits</span> and more.  <a "
+"href=\"#tutorial\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:67
-msgid "📈🎉 In July 2017, on our 3rd birthday, we also celebrated our <span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
+msgid ""
+"📈🎉 In July 2017, on our 3rd birthday, we also celebrated our "
+"<span>10,000th workshop attendee</span> <a href=\"#growth\">👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:72
-msgid "🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still learning programming</span> after the workshop. <a href=\"#learning-stats\">👉</a>"
+#, python-format
+msgid ""
+"🎓 We learned that <span>79%%</span> of Django Girls alumnis are <span>still "
+"learning programming</span> after the workshop. <a href=\"#learning-stats\">"
+"👉</a>"
 msgstr ""
 
 #: templates/core/2016-2017.html:77
-msgid "📚 <span>693,524 people</span> used our free online <a href=\"https://tutorial.djangogirls.org\">tutorial</a> in the last year"
+msgid ""
+"📚 <span>693,524 people</span> used our free online <a href=\"https://"
+"tutorial.djangogirls.org\">tutorial</a> in the last year"
 msgstr ""
 
 #: templates/core/2016-2017.html:86
 msgid "Growth 📈"
 msgstr ""
 
-#: templates/core/2016-2017.html:81
-msgid "Map of Django Girls event from July 2014 to July 2017"
+#: templates/core/2016-2017.html:88
+msgid "Map of Django Girls events from January 2016 to July 2017"
 msgstr ""
 
 #: templates/core/2016-2017.html:94
@@ -1638,11 +2225,23 @@ msgid "🌎 Maintenance & translation of our free online resources"
 msgstr ""
 
 #: templates/core/2016-2017.html:122
-msgid "The curriculum we developed Django Girls Tutorial is used in our workshops to introduce attendees to web development using Python and Django. The tutorial has been published online for free to allow everyone to learn without the need to attend an in-person workshop.<br /> We are proud that the <span>tutorial has been now translated into 14 languages</span> We are thankful to all the volunteers who have made this possible."
+msgid ""
+"The curriculum we developed Django Girls Tutorial is used in our workshops "
+"to introduce attendees to web development using Python and Django. The "
+"tutorial has been published online for free to allow everyone to learn "
+"without the need to attend an in-person workshop.<br /> We are proud that "
+"the <span>tutorial has been now translated into 14 languages</span> We are "
+"thankful to all the volunteers who have made this possible."
 msgstr ""
 
 #: templates/core/2016-2017.html:130
-msgid "The popularity of the online tutorial keeps growing significantly faster than our in-person workshops. In the second year it gained a 328.95%% increase in the number of unique users who used the tutorial, and 121.53%% increase in the last year. Since the tutorial as been published, it's been <span>read by 1,068,995 of people!</span>"
+#, python-format
+msgid ""
+"The popularity of the online tutorial keeps growing significantly faster "
+"than our in-person workshops. In the second year it gained a 328.95%% "
+"increase in the number of unique users who used the tutorial, and 121.53%% "
+"increase in the last year. Since the tutorial as been published, it's been "
+"<span>read by 1,068,995 of people!</span>"
 msgstr ""
 
 #: templates/core/2016-2017.html:144 templates/core/workshop_box.html:20
@@ -1654,11 +2253,22 @@ msgid "🎁 Organiser Starter Kits"
 msgstr ""
 
 #: templates/core/2016-2017.html:150
-msgid "We realised that there are certain things such as room decorations and swag (stickers, buttons and tattoos) that are needed by all event organisers. We lowered the costs of decorations and swag for each event by ordering them in bulk from suppliers and stock them in the Django Girls shop. Organisers then order the Organizer Starter Kit from our shop for a small donation, and we donated a number of them to events organised in developing countries. We are super excited that we managed to introduce the Django Girls Starter Kit in 2016."
+msgid ""
+"We realised that there are certain things such as room decorations and swag "
+"(stickers, buttons and tattoos) that are needed by all event organisers. We "
+"lowered the costs of decorations and swag for each event by ordering them in "
+"bulk from suppliers and stock them in the Django Girls shop. Organisers then "
+"order the Organizer Starter Kit from our shop for a small donation, and we "
+"donated a number of them to events organised in developing countries. We are "
+"super excited that we managed to introduce the Django Girls Starter Kit in "
+"2016."
 msgstr ""
 
 #: templates/core/2016-2017.html:160
-msgid "Since the introduction, <span>146 events have received their starter kits</span> which has helped them make their events awesome! Out of those, 28 were donated for free for events in need."
+msgid ""
+"Since the introduction, <span>146 events have received their starter kits</"
+"span> which has helped them make their events awesome! Out of those, 28 were "
+"donated for free for events in need."
 msgstr ""
 
 #: templates/core/2016-2017.html:169
@@ -1666,7 +2276,12 @@ msgid "💰 Fundraising"
 msgstr ""
 
 #: templates/core/2016-2017.html:171
-msgid "Most of our funds were generated through corporate and individual donations through Patreon, an online donation management system. In 2016, we also managed to introduce Django Girls shop where we sell swag such as t-shirts, socks and tote bags as a way of making the charity sustainable. Details of how much was raised in 2016 are shown in the table below:"
+msgid ""
+"Most of our funds were generated through corporate and individual donations "
+"through Patreon, an online donation management system. In 2016, we also "
+"managed to introduce Django Girls shop where we sell swag such as t-shirts, "
+"socks and tote bags as a way of making the charity sustainable. Details of "
+"how much was raised in 2016 are shown in the table below:"
 msgstr ""
 
 #: templates/core/2016-2017.html:183
@@ -1698,11 +2313,31 @@ msgid "Participants Survey"
 msgstr ""
 
 #: templates/core/2016-2017.html:204
-msgid "We have celebrated reaching our milestone of 10,000 workshop participants by conducting a survey to see how Django Girls alumni are doing after attending the workshop in their city. We reached out to our former attendees and received an overwhelming <span>response from 519 awesome women</span> who shared with us their experiences with Django Girls and how attending the workshop changed their lives."
+msgid ""
+"We have celebrated reaching our milestone of 10,000 workshop participants by "
+"conducting a survey to see how Django Girls alumni are doing after attending "
+"the workshop in their city. We reached out to our former attendees and "
+"received an overwhelming <span>response from 519 awesome women</span> who "
+"shared with us their experiences with Django Girls and how attending the "
+"workshop changed their lives."
 msgstr ""
 
 #: templates/core/2016-2017.html:212
-msgid "The ages of the <span>respondents ranged from 14 to 65 years</span>, with 71%% being under the age of 30. This shows that Django Girls workshops are open and welcoming to women and girls irrespective of their age, as long they have an interest in technology and learning programming"
+#, python-format
+msgid ""
+"The ages of the <span>respondents ranged from 14 to 65 years</span>, with "
+"71%% being under the age of 30. This shows that Django Girls workshops are "
+"open and welcoming to women and girls irrespective of their age, as long "
+"they have an interest in technology and learning programming"
+msgstr ""
+
+#: templates/core/2016-2017.html:219
+msgid ""
+"We'd like to acknowledge that even though the total number of responses "
+"received is a significant representative sample of the Django Girls alumni, "
+"it is likely that most of the women who responded to our survey stayed "
+"active in the tech industry after attending our workshops and hence the "
+"results could be positively skewed."
 msgstr ""
 
 #: templates/core/2016-2017.html:227
@@ -1710,15 +2345,29 @@ msgid "Participants’ Involvement in Tech Activities"
 msgstr ""
 
 #: templates/core/2016-2017.html:231
-msgid "We asked the respondents if they were involved in tech-related activities after the workshop. The tech activities included attending tech events, organising Django Girls and similar tech events, coaching at Django Girls workshops, teaching or working in tech, working on coding projects and enrolling for programming courses."
+msgid ""
+"We asked the respondents if they were involved in tech-related activities "
+"after the workshop. The tech activities included attending tech events, "
+"organising Django Girls and similar tech events, coaching at Django Girls "
+"workshops, teaching or working in tech, working on coding projects and "
+"enrolling for programming courses."
 msgstr ""
 
 #: templates/core/2016-2017.html:239
-msgid "We were excited to learn that <b>73%% of the respondents are still involved tech-related activities</b> after the event."
+#, python-format
+msgid ""
+"We were excited to learn that <b>73%% of the respondents are still involved "
+"tech-related activities</b> after the event."
 msgstr ""
 
 #: templates/core/2016-2017.html:247
-msgid "These statistics show that our workshops are generating interest in technology and programming in the participants who attends them. This interest then results in them organising other workshops and tech events as well as attending tech events for some of the women. These findings <b>prove that Django Girls workshops have been a successful intervention</b> to increase the number of women involved in engineering and programming."
+msgid ""
+"These statistics show that our workshops are generating interest in "
+"technology and programming in the participants who attends them. This "
+"interest then results in them organising other workshops and tech events as "
+"well as attending tech events for some of the women. These findings <b>prove "
+"that Django Girls workshops have been a successful intervention</b> to "
+"increase the number of women involved in engineering and programming."
 msgstr ""
 
 #: templates/core/2016-2017.html:258
@@ -1726,19 +2375,33 @@ msgid "Participants’ learning to code after the workshop"
 msgstr ""
 
 #: templates/core/2016-2017.html:265
-msgid "We were also interested in finding out whether our former participants continued learning programming after attending the workshop."
+msgid ""
+"We were also interested in finding out whether our former participants "
+"continued learning programming after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:268
-msgid "79%% of women attending Django Girls workshop continued learning programming after and 7%% were planning to continue learning"
+#, python-format
+msgid ""
+"79%% of women attending Django Girls workshop continued learning programming "
+"after and 7%% were planning to continue learning"
 msgstr ""
 
 #: templates/core/2016-2017.html:273
-msgid "1%% of participants had tried and given up while 13%% had not continued learning programming after the workshop."
+#, python-format
+msgid ""
+"1%% of participants had tried and given up while 13%% had not continued "
+"learning programming after the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:280
-msgid "The findings showed that the majority of the women who attend Django Girls workshops continue learning to code after. The women continued learning in various ways; some on their own, enrolling for online coding courses or enrolling into universities. These findings show that Django Girls is indeed increasing the number of women in the programming field, who will one day be employed as programmers after they have developed their programming skills."
+msgid ""
+"The findings showed that the majority of the women who attend Django Girls "
+"workshops continue learning to code after. The women continued learning in "
+"various ways; some on their own, enrolling for online coding courses or "
+"enrolling into universities. These findings show that Django Girls is indeed "
+"increasing the number of women in the programming field, who will one day be "
+"employed as programmers after they have developed their programming skills."
 msgstr ""
 
 #: templates/core/2016-2017.html:291
@@ -1746,19 +2409,35 @@ msgid "Participants’ Employment in Tech after attending workshops"
 msgstr ""
 
 #: templates/core/2016-2017.html:298
-msgid "The biggest question we were interested to answer was to know how many of the women started working in tech as developers after attending the workshop."
+msgid ""
+"The biggest question we were interested to answer was to know how many of "
+"the women started working in tech as developers after attending the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:304
-msgid "We were impressed to learn that <b>21%% of Django Girls' former attendees are now hired as developers</b> after attending the workshop!"
+#, python-format
+msgid ""
+"We were impressed to learn that <b>21%% of Django Girls' former attendees "
+"are now hired as developers</b> after attending the workshop!"
 msgstr ""
 
 #: templates/core/2016-2017.html:307
-msgid "It was also interesting to note that 15%% of the attendees of were already working in tech and hence their newly acquired skills made their jobs better. About 23%% had not yet got jobs as developers but were still developing their skills so they could get jobs in the future while the remaining 40%% had not got tech jobs and did not indicate their future plans."
+#, python-format
+msgid ""
+"It was also interesting to note that 15%% of the attendees of were already "
+"working in tech and hence their newly acquired skills made their jobs "
+"better. About 23%% had not yet got jobs as developers but were still "
+"developing their skills so they could get jobs in the future while the "
+"remaining 40%% had not got tech jobs and did not indicate their future plans."
 msgstr ""
 
 #: templates/core/2016-2017.html:317
-msgid "This further affirmed that our work has had positive results in the lives of women we introduced to coding as well as the tech industry that hires these women. <strong>We are proud that at least <span>109 women now work as developers</span> after attending the workshop. This is a big achievement which we are happy about!</strong>"
+msgid ""
+"This further affirmed that our work has had positive results in the lives of "
+"women we introduced to coding as well as the tech industry that hires these "
+"women. <strong>We are proud that at least <span>109 women now work as "
+"developers</span> after attending the workshop. This is a big achievement "
+"which we are happy about!</strong>"
 msgstr ""
 
 #: templates/core/2016-2017.html:326
@@ -1766,19 +2445,39 @@ msgid "Impact of Django Girls workshops on Participants’ lives"
 msgstr ""
 
 #: templates/core/2016-2017.html:333
-msgid "We were also interested in learning other ways the participants had been impacted by attending a Django Girls workshop."
+msgid ""
+"We were also interested in learning other ways the participants had been "
+"impacted by attending a Django Girls workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:338
-msgid "The survey showed that 93%% of the participants had been impacted positively in different ways."
+#, python-format
+msgid ""
+"The survey showed that 93%% of the participants had been impacted positively "
+"in different ways."
 msgstr ""
 
 #: templates/core/2016-2017.html:341
-msgid "The survey showed that about 43%% had been inspired by meeting other women in tech resulting in them becoming more involved in tech by organising tech events and attending other tech events. Many of these women were so inspired to learn that the tech industry and programming are for women as well."
+#, python-format
+msgid ""
+"The survey showed that about 43%% had been inspired by meeting other women "
+"in tech resulting in them becoming more involved in tech by organising tech "
+"events and attending other tech events. Many of these women were so inspired "
+"to learn that the tech industry and programming are for women as well."
 msgstr ""
 
 #: templates/core/2016-2017.html:350
-msgid "About 25%% had been excited that learnt new knowledge about technology, programming and web development; gained experienced and experienced personal growth. About 14%% of the participants had been happy to have been able to meet new friends and new connections within the tech industry whom they have kept in touch with since the workshop. About 11%% of the participants had changed their career path and became interested in a career in the tech industry prompting them to continue learning to code so they could one day become developers. Only 7%% said there was no remarkable impact on their lives due to participation in the workshop."
+#, python-format
+msgid ""
+"About 25%% had been excited that learnt new knowledge about technology, "
+"programming and web development; gained experienced and experienced personal "
+"growth. About 14%% of the participants had been happy to have been able to "
+"meet new friends and new connections within the tech industry whom they have "
+"kept in touch with since the workshop. About 11%% of the participants had "
+"changed their career path and became interested in a career in the tech "
+"industry prompting them to continue learning to code so they could one day "
+"become developers. Only 7%% said there was no remarkable impact on their "
+"lives due to participation in the workshop."
 msgstr ""
 
 #: templates/core/2016-2017.html:362
@@ -1786,15 +2485,152 @@ msgid "Summary"
 msgstr ""
 
 #: templates/core/2016-2017.html:364
-msgid "<b>The findings show that Django Girls has been successful in inspiring women to fall in love with programming as participants are exposed to women who are in the programming discipline within their own communities.</b> The friendly environment that Django Girls workshops provide enables women who have never programmed before to learn to code and thereby arousing interest in tech and <b>causing many of these women to work towards a career change and aim to be employed in the tech industry</b>. The friendly environment also creates an atmosphere for making new friends and creating new network connections, fostering the beauty of the Django community which strives to be welcoming and diverse."
+msgid ""
+"<b>The findings show that Django Girls has been successful in inspiring "
+"women to fall in love with programming as participants are exposed to women "
+"who are in the programming discipline within their own communities.</b> The "
+"friendly environment that Django Girls workshops provide enables women who "
+"have never programmed before to learn to code and thereby arousing interest "
+"in tech and <b>causing many of these women to work towards a career change "
+"and aim to be employed in the tech industry</b>. The friendly environment "
+"also creates an atmosphere for making new friends and creating new network "
+"connections, fostering the beauty of the Django community which strives to "
+"be welcoming and diverse."
 msgstr ""
 
 #: templates/core/2016-2017.html:382
-msgid "On our third birthday, we asked our Twitter community to tell us about the ways Django Girls impacted their lives. The response we received was overwhelmingly positive:"
+msgid ""
+"On our third birthday, we asked our Twitter community to tell us about the "
+"ways Django Girls impacted their lives. The response we received was "
+"overwhelmingly positive:"
 msgstr ""
 
 #: templates/core/2016-2017.html:413
 msgid "See more success stories"
+msgstr ""
+
+#: templates/core/coc.html:4
+msgid "Django Girls Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:10 templates/global/footer.html:13
+msgid "Code of Conduct"
+msgstr ""
+
+#: templates/core/coc.html:13
+msgid "This document is also available in:"
+msgstr ""
+
+#: templates/core/coc.html:42
+msgid ""
+"Django Girls aims to be a welcoming event, where people meet in a friendly "
+"environment. Accordingly, we expect that all participants are expected to "
+"show respect and courtesy to other participants throughout the workshop."
+msgstr ""
+
+#: templates/core/coc.html:50
+msgid ""
+"To make clear what is expected, all delegates/attendees, speakers, "
+"exhibitors, organizers and volunteers at any Django Girls event are required "
+"to conform to the following Code of Conduct. Organizers will enforce this "
+"code before and throughout the event."
+msgstr ""
+
+#: templates/core/coc.html:57
+msgid "In short"
+msgstr ""
+
+#: templates/core/coc.html:61
+msgid ""
+"Django Girls is dedicated to providing a harassment-free workshop experience "
+"for everyone, regardless of gender, sexual orientation, disability, physical "
+"appearance, body size, race, or religion."
+msgstr ""
+
+#: templates/core/coc.html:66
+msgid "We do not tolerate harassment of workshop participants in any form."
+msgstr ""
+
+#: templates/core/coc.html:67
+msgid ""
+"Sexual language and imagery is not appropriate for any workshop venue, "
+"including talks."
+msgstr ""
+
+#: templates/core/coc.html:69
+msgid ""
+"Be kind to others. Do not insult or put down other attendees. Behave "
+"professionally. Don't publish photographs of people without their consent. "
+"Remember that harassment and sexist, racist, or exclusionary jokes are not "
+"appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:76
+msgid ""
+"Conference participants violating these rules may be sanctioned or expelled "
+"from the workshop without a refund at the discretion of the workshop "
+"organizers."
+msgstr ""
+
+#: templates/core/coc.html:83
+msgid "Longer version"
+msgstr ""
+
+#: templates/core/coc.html:86
+msgid ""
+"Harassment includes offensive verbal comments related to gender, sexual "
+"orientation, disability, physical appearance, body size, race, religion, "
+"sexual images in public spaces, deliberate intimidation, stalking, "
+"following, harassing photography or recording, sustained disruption of talks "
+"or other events, inappropriate physical contact, and unwelcome sexual "
+"attention."
+msgstr ""
+
+#: templates/core/coc.html:94
+msgid ""
+"Participants asked to stop any harassing behavior are expected to comply "
+"immediately."
+msgstr ""
+
+#: templates/core/coc.html:97
+msgid ""
+"Be careful in the words that you choose. Remember that sexist, racist, and "
+"other exclusionary jokes can be offensive to those around you. Excessive "
+"swearing and offensive jokes are not appropriate for Django Girls."
+msgstr ""
+
+#: templates/core/coc.html:104
+msgid ""
+"If a participant engages in harassing behavior, the workshop organizers may "
+"take any action they deem appropriate, including warning the offender or "
+"expulsion from the workshop with no refund."
+msgstr ""
+
+#: templates/core/coc.html:110
+msgid ""
+"We expect participants to follow these rules at all workshop venues and "
+"workshop-related social events."
+msgstr ""
+
+#: templates/core/coc.html:112
+msgid "Reporting harassment"
+msgstr ""
+
+#: templates/core/coc.html:115
+msgid ""
+"If you are being harassed, notice that someone else is being harassed, or "
+"have any other concerns, please contact your coach or one of the organizers "
+"immediately. If your concern is with the organizing team, please email "
+"details to coc@djangogirls.org."
+msgstr ""
+
+#: templates/core/coc.html:122
+msgid ""
+"The staff is well informed on how to deal with the incident and how to "
+"further proceed with the situation. Conference staff will be happy to help "
+"participants contact hotel/venue security or local law enforcement, provide "
+"escorts, or otherwise assist those experiencing harassment to feel safe for "
+"the duration of the conference. We value your attendance."
 msgstr ""
 
 #: templates/core/contribute.html:9 templates/global/footer.html:24
@@ -1803,7 +2639,12 @@ msgid "Contribute"
 msgstr ""
 
 #: templates/core/contribute.html:11
-msgid "There are many ways to contribute to Django Girls: you can organize an event, coach, work on the tutorial and help on Gitter. If you'd rather help us financially, you can always support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
+msgid ""
+"There are many ways to contribute to Django Girls: you can organize an "
+"event, coach, work on the tutorial and help on Gitter. If you'd rather help "
+"us financially, you can always support us on <a href=\"https://www.patreon."
+"com/djangogirls\">Patreon</a> or <a href=\"https://www.paypal.com/uk/webapps/"
+"mpp/search-cause?charityId=129929&s=3\">PayPal Giving Funds</a>."
 msgstr ""
 
 #: templates/core/contribute.html:22
@@ -1811,11 +2652,22 @@ msgid "Support us!"
 msgstr ""
 
 #: templates/core/contribute.html:31
-msgid "Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/RegisterOfCharities/CharityFramework.aspx?RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> and is volunteer run. If you're an individual or a company and want to support us, you can make a <a href=\"https://www.patreon.com/djangogirls\">monthly donation</a>. You can send one-time donations to our <a href=\"%(donation_url)s\">PayPal account</a> or <a href=\"%(donation_url)s\">donate via credit card</a>."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"http://apps.charitycommission.gov.uk/Showcharity/"
+"RegisterOfCharities/CharityFramework.aspx?"
+"RegisteredCharityNumber=1163260&SubsidiaryNumber=0\">Registered Charity</a> "
+"and is volunteer run. If you're an individual or a company and want to "
+"support us, you can make a <a href=\"https://www.patreon.com/"
+"djangogirls\">monthly donation</a>. You can send one-time donations to our "
+"<a href=\"%(donation_url)s\">PayPal account</a> or <a "
+"href=\"%(donation_url)s\">donate via credit card</a>."
 msgstr ""
 
 #: templates/core/contribute.html:39
-msgid "If you want to help an <a href=\"http://djangogirls.org/events\">event</a> in particular, you can contact the local organization team to sponsor them."
+msgid ""
+"If you want to help an <a href=\"http://djangogirls.org/events\">event</a> "
+"in particular, you can contact the local organization team to sponsor them."
 msgstr ""
 
 #: templates/core/contribute.html:46
@@ -1823,11 +2675,17 @@ msgid "Organize!"
 msgstr ""
 
 #: templates/core/contribute.html:54
-msgid "Each Django Girls event is a free, one-day workshop for 30-60 people on HTML, CSS, Python and Django. A typical workshop takes 8 hours and people work in small, 3-person groups with a coach dedicated to each group."
+msgid ""
+"Each Django Girls event is a free, one-day workshop for 30-60 people on "
+"HTML, CSS, Python and Django. A typical workshop takes 8 hours and people "
+"work in small, 3-person groups with a coach dedicated to each group."
 msgstr ""
 
 #: templates/core/contribute.html:61
-msgid "Want to get started? Check our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/\">bring Django Girls to your city!</a>"
+msgid ""
+"Want to get started? Check our <a href=\"https://organize.djangogirls.org/"
+"\">Organizer's Manual</a> and <a href=\"https://djangogirls.org/organize/"
+"\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:72
@@ -1835,15 +2693,23 @@ msgid "Coach!"
 msgstr ""
 
 #: templates/core/contribute.html:80
-msgid "Have you heard about an event happening in your city and you want to help? Contact the local <a href=\"http://djangogirls.org/events\">organizing team</a> and ask if they need more coaches!"
+msgid ""
+"Have you heard about an event happening in your city and you want to help? "
+"Contact the local <a href=\"http://djangogirls.org/events\">organizing team</"
+"a> and ask if they need more coaches!"
 msgstr ""
 
 #: templates/core/contribute.html:86
-msgid "You will be helping a group of 3 people to install what they need for the event and guide them through our <a href=\"https://tutorial.djangogirls.org/\">tutorial</a>."
+msgid ""
+"You will be helping a group of 3 people to install what they need for the "
+"event and guide them through our <a href=\"https://tutorial.djangogirls.org/"
+"\">tutorial</a>."
 msgstr ""
 
 #: templates/core/contribute.html:92
-msgid "Don't forget to check our <a href=\"https://coach.djangogirls.org/\">Coaching Manual</a>!"
+msgid ""
+"Don't forget to check our <a href=\"https://coach.djangogirls.org/"
+"\">Coaching Manual</a>!"
 msgstr ""
 
 #: templates/core/contribute.html:99
@@ -1855,11 +2721,15 @@ msgid "Computer screen with a console and a webpage."
 msgstr ""
 
 #: templates/core/contribute.html:107
-msgid "There is always something to do to make our website better. You can report (or fix!) bugs and typos, or work on new features."
+msgid ""
+"There is always something to do to make our website better. You can report "
+"(or fix!) bugs and typos, or work on new features."
 msgstr ""
 
 #: templates/core/contribute.html:113
-msgid "We are waiting for your <a href=\"https://github.com/DjangoGirls/djangogirls\">pull requests!</a>"
+msgid ""
+"We are waiting for your <a href=\"https://github.com/DjangoGirls/"
+"djangogirls\">pull requests!</a>"
 msgstr ""
 
 #: templates/core/contribute.html:123
@@ -1871,11 +2741,16 @@ msgid "A note book and a pen."
 msgstr ""
 
 #: templates/core/contribute.html:131
-msgid "Is something in the tutorial not clear, or is there a typo? You can improve the tutorial by making a pull request to our <a href=\"https://github.com/DjangoGirls/tutorial\">GitHub repository</a>."
+msgid ""
+"Is something in the tutorial not clear, or is there a typo? You can improve "
+"the tutorial by making a pull request to our <a href=\"https://github.com/"
+"DjangoGirls/tutorial\">GitHub repository</a>."
 msgstr ""
 
 #: templates/core/contribute.html:136
-msgid "You just finished our tutorial and want to help? Making pull requests to fix typo is a great way to use your new Git skills!"
+msgid ""
+"You just finished our tutorial and want to help? Making pull requests to fix "
+"typo is a great way to use your new Git skills!"
 msgstr ""
 
 #: templates/core/contribute.html:140
@@ -1887,11 +2762,18 @@ msgid "A computer screen saying hello and golden balloons saying yay!."
 msgstr ""
 
 #: templates/core/contribute.html:148
-msgid "Our tutorial has already been translated into <a href=\"https://tutorial.djangogirls.org/\">19 languages</a>, but we always need helping maintaining those translations. Or you can help us translating the tutorial into a new language!"
+msgid ""
+"Our tutorial has already been translated into <a href=\"https://tutorial."
+"djangogirls.org/\">19 languages</a>, but we always need helping maintaining "
+"those translations. Or you can help us translating the tutorial into a new "
+"language!"
 msgstr ""
 
 #: templates/core/contribute.html:155
-msgid "If you want to join an existing <a href=\"https://crowdin.com/project/django-girls-tutorial\">translation team</a> or launch a new translation, <a href=\"mailto:translations@djangogirls.org\">contact us</a>."
+msgid ""
+"If you want to join an existing <a href=\"https://crowdin.com/project/django-"
+"girls-tutorial\">translation team</a> or launch a new translation, <a "
+"href=\"mailto:translations@djangogirls.org\">contact us</a>."
 msgstr ""
 
 #: templates/core/contribute.html:166
@@ -1903,11 +2785,17 @@ msgid "A web page opened on a computer."
 msgstr ""
 
 #: templates/core/contribute.html:174
-msgid "Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?"
+msgid ""
+"Many people are doing our tutorial outside of a workshop. Sometimes, they "
+"get stuck and need help. How about spending a few hours a week helping them?"
 msgstr ""
 
 #: templates/core/contribute.html:180
-msgid "This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is designed to be a friendly space, especially for beginners. Remember that our <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also applies there."
+msgid ""
+"This <a href=\"https://gitter.im/DjangoGirls/tutorial\">Gitter room</a> is "
+"designed to be a friendly space, especially for beginners. Remember that our "
+"<a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a> also "
+"applies there."
 msgstr ""
 
 #: templates/core/contribute.html:188
@@ -1919,11 +2807,16 @@ msgid "A pile a tattoo."
 msgstr ""
 
 #: templates/core/contribute.html:196
-msgid "Want to help out in a way that isn't listed here? You can look at our <a href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and propose new projects to work on."
+msgid ""
+"Want to help out in a way that isn't listed here? You can look at our <a "
+"href=\"https://trello.com/b/q7p6jcfg/django-girls\">Trello board</a> and "
+"propose new projects to work on."
 msgstr ""
 
 #: templates/core/contribute.html:201
-msgid "Don't forget to read the rules described in the first column before adding a new card! ❤"
+msgid ""
+"Don't forget to read the rules described in the first column before adding a "
+"new card! ❤"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:11
@@ -1931,7 +2824,13 @@ msgid "💖 Special thanks to all our amazing supporters! 💖"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:15
-msgid "This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity website from the 29th January to the 29th of March with the aim of raising US $10,000. We are truly grateful to all our awesome supporters who helped reach our target goal. We managed to raise a total of $13,314 - 133%% of our goal!"
+#, python-format
+msgid ""
+"This year (2018) we ran a crowdfunding campaign on Indiegogo's generosity "
+"website from the 29th January to the 29th of March with the aim of raising "
+"US $10,000. We are truly grateful to all our awesome supporters who helped "
+"reach our target goal. We managed to raise a total of $13,314 - 133%% of our "
+"goal!"
 msgstr ""
 
 #: templates/core/crowdfunding_donors.html:31
@@ -1939,14 +2838,22 @@ msgid "Our awesome supporters ✨"
 msgstr ""
 
 #: templates/core/event.html:23
-msgid "Hi there! You can see this page because you're logged in admin. When you want to make it public, go to <a href=\"%(event_url)s\">your website section in the admin</a> and click on 'Website is ready'."
+#, python-format
+msgid ""
+"Hi there! You can see this page because you're logged in admin. When you "
+"want to make it public, go to <a href=\"%(event_url)s\">your website section "
+"in the admin</a> and click on 'Website is ready'."
 msgstr ""
 
 #: templates/core/event.html:48
-msgid "Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a>."
+#, python-format
+msgid ""
+"Participants need to follow the <a href=\"%(coc_url)s\">Django Girls Code of "
+"Conduct</a>."
 msgstr ""
 
 #: templates/core/event.html:55
+#, python-format
 msgid "Contact organizers: <a href=\"mailto:%(email)s\">%(email)s</a>"
 msgstr ""
 
@@ -1975,7 +2882,11 @@ msgid "FAQ: Frequently Asked Questions"
 msgstr ""
 
 #: templates/core/faq.html:14
-msgid "Django Girls events have been happening all over the world for a while now, and we get some repeat questions. If you need more help: <a href=\"%(contact_url)s\">contact us</a>!"
+#, python-format
+msgid ""
+"Django Girls events have been happening all over the world for a while now, "
+"and we get some repeat questions. If you need more help: <a "
+"href=\"%(contact_url)s\">contact us</a>!"
 msgstr ""
 
 #: templates/core/faq.html:20
@@ -1991,27 +2902,67 @@ msgid "Q: Isn't Django Girls sexist?"
 msgstr ""
 
 #: templates/core/faq.html:35
-msgid "A: It really isn't, but we can understand why people might feel that way. We've found that by having a women-only space for learning Python and Django, women are more comfortable participating. See <a href=\"http://jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia.com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails Girls to see what we mean. If you're having the knee-jerk reaction that reaching out specifically to women hurts men, or hurts diversity efforts in other areas, we encourage you to read <a href=\"https://hynek.me/articles/how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One particularly relevant quote is this:"
+msgid ""
+"A: It really isn't, but we can understand why people might feel that way. "
+"We've found that by having a women-only space for learning Python and "
+"Django, women are more comfortable participating. See <a href=\"http://"
+"jennifermann.ghost.io/minority-groups-in-tech-is-it-just-reverse-sexism/\" "
+"target=\"_blank\">this essay</a> on \"<a href=\"http://geekfeminism.wikia."
+"com/wiki/Reverse_sexism\" target=\"_blank\">reverse sexism</a>\" and Rails "
+"Girls to see what we mean. If you're having the knee-jerk reaction that "
+"reaching out specifically to women hurts men, or hurts diversity efforts in "
+"other areas, we encourage you to read <a href=\"https://hynek.me/articles/"
+"how-i-stopped-worrying-and-started-loving-pyladies/\" target=\"_blank\">How "
+"I Stopped Worrying and Started Loving Pyladies</a> by Hynek Schlawack. One "
+"particularly relevant quote is this:"
 msgstr ""
 
 #: templates/core/faq.html:52
-msgid "Outreach programs don't divide our community. They incubate people which aren't comfortable to cope with us from the beginning on and grow our community in the long term."
+msgid ""
+"Outreach programs don't divide our community. They incubate people which "
+"aren't comfortable to cope with us from the beginning on and grow our "
+"community in the long term."
 msgstr ""
 
 #: templates/core/faq.html:60
-msgid "It doesn't really matter whose fault the initial discomfort is. Whether they're being over-sensitive (hint: <a href=\"http://therealkatie.net/blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether we're a bunch of a**holes (I know you aren't). The facts are these: if we want underrepresented people to enrich our community, we have to look for pragmatic ways to get them in. Even if the methods don't seem sound to us on the first sight to us."
+msgid ""
+"It doesn't really matter whose fault the initial discomfort is. Whether "
+"they're being over-sensitive (hint: <a href=\"http://therealkatie.net/"
+"blog/2012/mar/21/lighten-up/\" target=\"_blank\">they aren't</a>) or whether "
+"we're a bunch of a**holes (I know you aren't). The facts are these: if we "
+"want underrepresented people to enrich our community, we have to look for "
+"pragmatic ways to get them in. Even if the methods don't seem sound to us on "
+"the first sight to us."
 msgstr ""
 
 #: templates/core/faq.html:71
-msgid "\"Yes, but...\" discussion don't help. PyLadies – and similar outreach groups – found a way that works. So be thankful to their organizers for doing this! And again: if you know of a better way, stop sh*tting on their approach and go for it! The world isn't binary; the more approaches, the more diversity, the better."
+msgid ""
+"\"Yes, but...\" discussion don't help. PyLadies – and similar outreach "
+"groups – found a way that works. So be thankful to their organizers for "
+"doing this! And again: if you know of a better way, stop sh*tting on their "
+"approach and go for it! The world isn't binary; the more approaches, the "
+"more diversity, the better."
 msgstr ""
 
 #: templates/core/faq.html:81
-msgid "Also, not all Django Girls events are exclusive to women. Our organizer's manual encourages organizers to use our materials to put on workshops for women <em>and</em> for mixed-gender groups. We've also open-sourced all of our content, so if you like our tutorial but don't want to put on a Django Girls event with it, feel free to fork it, credit us for the content, but rebrand it into something that works for your goals."
+msgid ""
+"Also, not all Django Girls events are exclusive to women. Our organizer's "
+"manual encourages organizers to use our materials to put on workshops for "
+"women <em>and</em> for mixed-gender groups. We've also open-sourced all of "
+"our content, so if you like our tutorial but don't want to put on a Django "
+"Girls event with it, feel free to fork it, credit us for the content, but "
+"rebrand it into something that works for your goals."
 msgstr ""
 
 #: templates/core/faq.html:92
-msgid "We don't want to get men <em>out</em> of programming; we just want to bring more women <em>in</em>. There are already a lot of other bootcamps, workshops, meetups, and groups that are \"mixed gender,\" but are really mostly men. We've found that by limiting our workshop to a majority of women participants, women are more comfortable signing up, asking questions, getting involved, and even staying involved later on. And that's a good thing!"
+msgid ""
+"We don't want to get men <em>out</em> of programming; we just want to bring "
+"more women <em>in</em>. There are already a lot of other bootcamps, "
+"workshops, meetups, and groups that are \"mixed gender,\" but are really "
+"mostly men. We've found that by limiting our workshop to a majority of women "
+"participants, women are more comfortable signing up, asking questions, "
+"getting involved, and even staying involved later on. And that's a good "
+"thing!"
 msgstr ""
 
 #: templates/core/faq.html:109
@@ -2019,7 +2970,9 @@ msgid "Q: Are Django Girls events trans-inclusive?"
 msgstr ""
 
 #: templates/core/faq.html:114
-msgid "A: Yes! We encourage you to make this explicit on your website. Some events have used this wording:"
+msgid ""
+"A: Yes! We encourage you to make this explicit on your website. Some events "
+"have used this wording:"
 msgstr ""
 
 #: templates/core/faq.html:117
@@ -2027,11 +2980,29 @@ msgid "We are trans-inclusive and welcome applications from all women."
 msgstr ""
 
 #: templates/core/faq.html:121
-msgid "You can add this to your FAQ, or to your event description on your event website. If you'd like to learn more about trans people, you might want to take a look at <a href=\"http://www.thegenderbook.com/\" target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://www.roostertailscomic.com/comic/queer-101-third-edition/\" target=\"_blank\">this comic</a>, or any of the many other introductions to trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies.com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us to these excellent resources."
+msgid ""
+"You can add this to your FAQ, or to your event description on your event "
+"website. If you'd like to learn more about trans people, you might want to "
+"take a look at <a href=\"http://www.thegenderbook.com/\" "
+"target=\"_blank\">this illustrated book about gender</a>, <a href=\"http://"
+"www.roostertailscomic.com/comic/queer-101-third-edition/\" "
+"target=\"_blank\">this comic</a>, or any of the many other introductions to "
+"trans issues on the internet. Thanks to the <a href=\"http://kit.pyladies."
+"com/en/latest/faqs.html\" target=\"_blank\">PyLadies FAQ</a> for pointing us "
+"to these excellent resources."
 msgstr ""
 
 #: templates/core/faq.html:142
-msgid "A: There doesn't seem to be a need for Django Boys at the moment. But all of our content, including our tutorial and this manual, is open sourced, so if you'd like to start a workshop aimed at another audience, we encourage you to do so! We support you starting an organization that reaches an audience you care about. All the resources we've created, including the tutorial and this manual, are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"A: There doesn't seem to be a need for Django Boys at the moment. But all of "
+"our content, including our tutorial and this manual, is open sourced, so if "
+"you'd like to start a workshop aimed at another audience, we encourage you "
+"to do so! We support you starting an organization that reaches an audience "
+"you care about. All the resources we've created, including the tutorial and "
+"this manual, are open sourced under Creative Commons Attribution 4.0 "
+"International (CC BY 4). This means that you can modify, distribute and use "
+"commercially, but you cannot sublicense and you have to give us credit and "
+"include copyright."
 msgstr ""
 
 #: templates/core/foundation.html:4 templates/core/foundation.html:10
@@ -2048,7 +3019,9 @@ msgid "We inspire women to fall in love with programming."
 msgstr ""
 
 #: templates/core/index.html:17
-msgid "Django Girls organize free Python and Django workshops, create open sourced online tutorials and curate amazing first experiences with technology."
+msgid ""
+"Django Girls organize free Python and Django workshops, create open sourced "
+"online tutorials and curate amazing first experiences with technology."
 msgstr ""
 
 #: templates/core/index.html:29
@@ -2056,11 +3029,20 @@ msgid "What is Django Girls?"
 msgstr ""
 
 #: templates/core/index.html:32
-msgid "Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> and a community that empowers and helps women to organize free, one-day programming workshops by providing tools, resources and support. We are a volunteer run organization with hundreds of people contributing to bring more amazing women into the world of technology. We are making technology more approachable by creating resources designed with empathy."
+#, python-format
+msgid ""
+"Django Girls is a <a href=\"%(foundation_url)s\">non-profit organization</a> "
+"and a community that empowers and helps women to organize free, one-day "
+"programming workshops by providing tools, resources and support. We are a "
+"volunteer run organization with hundreds of people contributing to bring "
+"more amazing women into the world of technology. We are making technology "
+"more approachable by creating resources designed with empathy."
 msgstr ""
 
 #: templates/core/index.html:40
-msgid "During each of our events, 30-60 women build their first web application using HTML, CSS, Python and Django."
+msgid ""
+"During each of our events, 30-60 women build their first web application "
+"using HTML, CSS, Python and Django."
 msgstr ""
 
 #: templates/core/index.html:53
@@ -2068,11 +3050,22 @@ msgid "Django Girls impact"
 msgstr ""
 
 #: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count|default_if_none:'0')s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count|default_if_none:'0')s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count|default_if_none:'0')s cities</span> in <span class=\"highlighted-number\">%(country_count|default_if_none:'0')s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#, python-format
+msgid ""
+"Since 2014, an army of <span class=\"highlighted-"
+"number\">%(organizers_count)s volunteers</span> in the Django Girls "
+"community organized <span class=\"highlighted-number\">%(all_events_count)s "
+"events.</span> We've been to <span class=\"highlighted-"
+"number\">%(cities_count)s cities</span> in <span class=\"highlighted-"
+"number\">%(country_count)s countries</span> (<a "
+"href=\"%(event_map_url)s\">see them all on a map</a>)."
 msgstr ""
 
 #: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum|default_if_none:'0')s incredible women attended</span> events organized by members of our community."
+#, python-format
+msgid ""
+"A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible "
+"women attended</span> events organized by members of our community."
 msgstr ""
 
 #: templates/core/index.html:69
@@ -2084,11 +3077,18 @@ msgid "Bring Django Girls to your city!"
 msgstr ""
 
 #: templates/core/index.html:74
-msgid "Is there no Django Girls event in your city? You can help make it happen!"
+msgid ""
+"Is there no Django Girls event in your city? You can help make it happen!"
 msgstr ""
 
 #: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count|default_if_none:'0')s organizers all over the world!"
+#, python-format
+msgid ""
+"We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer "
+"Manual</a> that provides you with all information required to organize "
+"Django Girls workshop. By volunteering to organize, you're joining a vibrant "
+"and supportive community of %(organizers_count)s organizers all over the "
+"world!"
 msgstr ""
 
 #: templates/core/index.html:82 templates/organize/index.html:89
@@ -2096,6 +3096,7 @@ msgid "Apply to organize a workshop"
 msgstr ""
 
 #: templates/core/index.html:108
+#, python-format
 msgid "Show all %(future_events_count)s upcoming events"
 msgstr ""
 
@@ -2104,7 +3105,9 @@ msgid "Badass Django Ladies"
 msgstr ""
 
 #: templates/core/index.html:117
-msgid "Each week we try to introduce one badass lady who uses Python or Django and highlight her work:"
+msgid ""
+"Each week we try to introduce one badass lady who uses Python or Django and "
+"highlight her work:"
 msgstr ""
 
 #: templates/core/index.html:125
@@ -2124,7 +3127,15 @@ msgid "Support our work"
 msgstr ""
 
 #: templates/core/index.html:141
-msgid "Django Girls is a volunteer run organization, and we depend on your support to make it happen."
+msgid ""
+"Django Girls is a volunteer run organization, and we depend on your support "
+"to make it happen."
+msgstr ""
+
+#: templates/core/index.html:143
+msgid ""
+"<span class=\"highlighted-number\">$1,060</span> of <span "
+"class=\"highlighted-number\">$2,500</span> monthly goal pledged"
 msgstr ""
 
 #: templates/core/index.html:150 templates/donations/donate.html:99
@@ -2132,7 +3143,11 @@ msgid "Make a recurring donation on Patreon"
 msgstr ""
 
 #: templates/core/index.html:154
-msgid "You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. If you would like to discuss a bigger partnership, <a href=\"%(contact_url)s\">please get in touch</a>."
+#, python-format
+msgid ""
+"You can also send us a one <a href=\"%(donations_url)s\">time donation</a>. "
+"If you would like to discuss a bigger partnership, <a "
+"href=\"%(contact_url)s\">please get in touch</a>."
 msgstr ""
 
 #: templates/core/index.html:162
@@ -2140,7 +3155,9 @@ msgid "Stay up to date!"
 msgstr ""
 
 #: templates/core/index.html:164
-msgid "Subscribe to Django Girls Dispatch to receive the latest and greatest from our community every two weeks, straight to your inbox!"
+msgid ""
+"Subscribe to Django Girls Dispatch to receive the latest and greatest from "
+"our community every two weeks, straight to your inbox!"
 msgstr ""
 
 #: templates/core/index.html:171 templates/core/newsletter.html:35
@@ -2156,12 +3173,51 @@ msgstr ""
 msgid "See the Django Girls Dispatch archives"
 msgstr ""
 
+#: templates/core/index.html:183
+msgid "Check out our podcast!"
+msgstr ""
+
+#: templates/core/index.html:185
+msgid ""
+"We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is "
+"being hosted by trustees <a href=\"http://blog.djangogirls.org/"
+"post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/"
+"post/172001842084\">Leona</a> where they talk with many awesome people from "
+"our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/"
+"rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/"
+"djangogirls\">podcast</a> which is available on multiple platforms such as "
+"<a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/"
+"id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/"
+"aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</"
+"a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-"
+"bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?"
+"ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a "
+"href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+msgstr ""
+
+#: templates/core/index.html:203
+msgid "They already sponsor us! 💕"
+msgstr ""
+
+#: templates/core/index.html:205
+#, python-format
+msgid ""
+"These incredible companies made a pledge to diversity and are actively "
+"helping us to change the ratio in the tech industry. <br /> If you wish to "
+"join them, support us on <a href=\"https://www.patreon.com/"
+"djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+msgstr ""
+
 #: templates/core/index.html:220
 msgid "They already support us! 💕"
 msgstr ""
 
-#: templates/core/index.html:205
-msgid "These incredible companies made a pledge to diversity and are actively helping us to change the ratio in the tech industry. <br /> If you wish to join them, support us on <a href=\"https://www.patreon.com/djangogirls\">Patreon</a> or <a href=\"%(contact_url)s\">drop us a line</a>."
+#: templates/core/index.html:222
+#, python-format
+msgid ""
+"These incredible companies are actively helping us to change the ratio in "
+"the tech industry by supporting us in other ways. <br /> If you wish to join "
+"them, <a href=\"%(contact_url)s\">drop us a line</a>."
 msgstr ""
 
 #: templates/core/newsletter.html:4
@@ -2173,11 +3229,16 @@ msgid "Django Girls Dispatch"
 msgstr ""
 
 #: templates/core/newsletter.html:13
-msgid "We're sending a biweekly newsletter to friends and strangers who support us and are curious how we're doing."
+msgid ""
+"We're sending a biweekly newsletter to friends and strangers who support us "
+"and are curious how we're doing."
 msgstr ""
 
 #: templates/core/newsletter.html:25
-msgid "We don't send advertisements or spam, and we won't share your email with anyone. <br /> We just send a biweekly dispatch and awesome announcements about things we're proud of."
+msgid ""
+"We don't send advertisements or spam, and we won't share your email with "
+"anyone. <br /> We just send a biweekly dispatch and awesome announcements "
+"about things we're proud of."
 msgstr ""
 
 #: templates/core/newsletter.html:49
@@ -2189,11 +3250,15 @@ msgid "Cookie and Privacy Policies of Django Girls Website"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:5 templates/core/privacy_cookies.html:25
-msgid "This Policy applies to our use of any and all Data collected by us in relation to your use of the Site."
+msgid ""
+"This Policy applies to our use of any and all Data collected by us in "
+"relation to your use of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:14
-msgid "<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We, Us, Our</b> Django Girls Foundation, Registered Charity Number "
+"1163260 whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:20
@@ -2213,19 +3278,31 @@ msgid "In this Policy the following terms shall have the following meanings:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:33
-msgid "<b>Data</b> means all the information you submit to us via the Site. This definition, where appropriate, incorporates the definitions provided in the Data Protection Act 1998."
+msgid ""
+"<b>Data</b> means all the information you submit to us via the Site. This "
+"definition, where appropriate, incorporates the definitions provided in the "
+"Data Protection Act 1998."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:38
-msgid "<b>Cookie</b> means a small text file placed on your computer by this Site when you visit certain parts of the Site and/or when you use certain features of the Site."
+msgid ""
+"<b>Cookie</b> means a small text file placed on your computer by this Site "
+"when you visit certain parts of the Site and/or when you use certain "
+"features of the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:43
-msgid "<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications (EC Directive) Regulations 2003 as amended by the Privacy and Electronic Communications (EC Directive) (Amendment) Regulations 2011."
+msgid ""
+"<b>UK and EU Cookie law</b> means the Privacy and Electronic Communications "
+"(EC Directive) Regulations 2003 as amended by the Privacy and Electronic "
+"Communications (EC Directive) (Amendment) Regulations 2011."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:48
-msgid "<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, a regulation in EU law on data protection and privacy for all individuals within the European Union and the European Economic Area."
+msgid ""
+"<b>EU GDPR, GDPR</b> means The General Data Protection Regulation 2016/679, "
+"a regulation in EU law on data protection and privacy for all individuals "
+"within the European Union and the European Economic Area."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:53
@@ -2237,15 +3314,25 @@ msgid "Scope of this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:61
-msgid "This Policy applies only to the actions of you and us when using the Site. It does not extend to:"
+msgid ""
+"This Policy applies only to the actions of you and us when using the Site. "
+"It does not extend to:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:64
-msgid "any Event which you may attend as the organisers of those events are responsible for complying with the data protection legislation which applies in their jurisdiction. Despite this, the organisers of all events are required to follow the policies laid out below as part of their agreement with us and we hereby grant you the right to pursue them for any breach of these policies; or"
+msgid ""
+"any Event which you may attend as the organisers of those events are "
+"responsible for complying with the data protection legislation which applies "
+"in their jurisdiction. Despite this, the organisers of all events are "
+"required to follow the policies laid out below as part of their agreement "
+"with us and we hereby grant you the right to pursue them for any breach of "
+"these policies; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:71
-msgid "any websites that can be accessed from this Site including, but not limited to, any links we might provide."
+msgid ""
+"any websites that can be accessed from this Site including, but not limited "
+"to, any links we might provide."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:74
@@ -2253,7 +3340,9 @@ msgid "Data Collected"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:76
-msgid "Without limitation, all or any of the following Data may be collected by the Site from time to time:"
+msgid ""
+"Without limitation, all or any of the following Data may be collected by the "
+"Site from time to time:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:79
@@ -2289,7 +3378,9 @@ msgid "operating system (automatically collected); and"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:87
-msgid "a list of URLs starting with a referring site, your activity on the Site, and the site you exit to (automatically collected)."
+msgid ""
+"a list of URLs starting with a referring site, your activity on the Site, "
+"and the site you exit to (automatically collected)."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:90
@@ -2301,15 +3392,22 @@ msgid "We will keep any personal Data you submit for 60 months."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:95
-msgid "Unless we are obliged or allowed by law, and subject to “Third Party Sites and Services” below, we will not disclose your Data to third parties.  This does not include the companies which form part of our group."
+msgid ""
+"Unless we are obliged or allowed by law, and subject to “Third Party Sites "
+"and Services” below, we will not disclose your Data to third parties.  This "
+"does not include the companies which form part of our group."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:101
-msgid "All personal Data is stored securely in accordance with the principles of the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"All personal Data is stored securely in accordance with the principles of "
+"the Data Protection Act 1998 and the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:106
-msgid "We use your Data so as to give you the best possible service and experience when using the Site."
+msgid ""
+"We use your Data so as to give you the best possible service and experience "
+"when using the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:108
@@ -2325,15 +3423,21 @@ msgid "improvement of our products / services;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:112
-msgid "transmission by email of promotional materials that may be of interest to you;"
+msgid ""
+"transmission by email of promotional materials that may be of interest to "
+"you;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:113
-msgid "contact for market research purposes which may be done using email, telephone, fax or mail;"
+msgid ""
+"contact for market research purposes which may be done using email, "
+"telephone, fax or mail;"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:114
-msgid "the organisation of an Event for which you have applied or in which you have expressed interest; or"
+msgid ""
+"the organisation of an Event for which you have applied or in which you have "
+"expressed interest; or"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:115
@@ -2345,15 +3449,25 @@ msgid "Third Party Sites and Services"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:121
-msgid "We may, from time to time, use other parties for dealing with matters that may include, but are not limited to, payment processing, delivery of purchased items, search engine facilities, advertising and marketing. The providers of such services have access to some of your Data."
+msgid ""
+"We may, from time to time, use other parties for dealing with matters that "
+"may include, but are not limited to, payment processing, delivery of "
+"purchased items, search engine facilities, advertising and marketing. The "
+"providers of such services have access to some of your Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:129
-msgid "Any Data used by such parties is used only to the extent required by them to perform the services that we’ve requested. Any use for other purposes is strictly prohibited."
+msgid ""
+"Any Data used by such parties is used only to the extent required by them to "
+"perform the services that we’ve requested. Any use for other purposes is "
+"strictly prohibited."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:136
-msgid "Any Data that is processed by third parties will be processed within the terms of this Policy and in accordance with the Data Protection Act 1998 and the EU GDPR."
+msgid ""
+"Any Data that is processed by third parties will be processed within the "
+"terms of this Policy and in accordance with the Data Protection Act 1998 and "
+"the EU GDPR."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:142
@@ -2361,7 +3475,11 @@ msgid "Links to Other Websites"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:145
-msgid "We may, from time to time, provide links to other websites. We have no control over such websites and can’t be responsible for their content. This Policy does not extend to those websites and we suggest that you read the privacy policy or statement on those websites before using them."
+msgid ""
+"We may, from time to time, provide links to other websites. We have no "
+"control over such websites and can’t be responsible for their content. This "
+"Policy does not extend to those websites and we suggest that you read the "
+"privacy policy or statement on those websites before using them."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:151
@@ -2369,7 +3487,12 @@ msgid "Changes of Business Ownership and Control"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:154
-msgid "We may, from time to time, expand or reduce our business and that may mean that the people who control our business change. If we do that your Data will, if relevant, be transferred to the people who then control the business. They will have the same rights and obligations as we have under the terms of this Policy."
+msgid ""
+"We may, from time to time, expand or reduce our business and that may mean "
+"that the people who control our business change. If we do that your Data "
+"will, if relevant, be transferred to the people who then control the "
+"business. They will have the same rights and obligations as we have under "
+"the terms of this Policy."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:161
@@ -2381,7 +3504,9 @@ msgid "Controlling Use of Your Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:164
-msgid "If we ask for Data from you, you will be given options to restrict our use of that Data.  This may include the following:"
+msgid ""
+"If we ask for Data from you, you will be given options to restrict our use "
+"of that Data.  This may include the following:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:167
@@ -2401,11 +3526,17 @@ msgid "Your Right to Withhold Information"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:174
-msgid "You may access certain areas of the Site without providing any Data at all but to use all features and functions available on the Site you may be required to submit certain Data."
+msgid ""
+"You may access certain areas of the Site without providing any Data at all "
+"but to use all features and functions available on the Site you may be "
+"required to submit certain Data."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:176
-msgid "You may restrict your internet browser’s use of Cookies – we suggest that you look at the “Tools” setting for your internet browser.  See below under “Cookies” for more information."
+msgid ""
+"You may restrict your internet browser’s use of Cookies – we suggest that "
+"you look at the “Tools” setting for your internet browser.  See below under "
+"“Cookies” for more information."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:178
@@ -2413,7 +3544,9 @@ msgid "Accessing Your Own Data"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:180
-msgid "You have the right to ask for a copy of any of your personal Data which we hold on payment of a small fee which will not exceed £10."
+msgid ""
+"You have the right to ask for a copy of any of your personal Data which we "
+"hold on payment of a small fee which will not exceed £10."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:182
@@ -2421,7 +3554,10 @@ msgid "Security"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:184
-msgid "Data security is of great importance to us and to protect your Data we have put in place various physical, electronic and managerial procedures to safeguard and secure Data collected via the Site."
+msgid ""
+"Data security is of great importance to us and to protect your Data we have "
+"put in place various physical, electronic and managerial procedures to "
+"safeguard and secure Data collected via the Site."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:186
@@ -2429,27 +3565,49 @@ msgid "Cookies"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:188
-msgid "The Site may place and access certain Cookies on your computer.  These are first party Cookies and we place them via the Site and only we use them.  We use Cookies to improve your experience of using the Site and to improve our range of products and/or services.  We choose the Cookies we use carefully and have taken steps to make sure that your privacy is always protected and respected."
+msgid ""
+"The Site may place and access certain Cookies on your computer.  These are "
+"first party Cookies and we place them via the Site and only we use them.  We "
+"use Cookies to improve your experience of using the Site and to improve our "
+"range of products and/or services.  We choose the Cookies we use carefully "
+"and have taken steps to make sure that your privacy is always protected and "
+"respected."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:190
-msgid "All Cookies used by the Site are used in accordance with current UK and EU Cookie Law."
+msgid ""
+"All Cookies used by the Site are used in accordance with current UK and EU "
+"Cookie Law."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:192
-msgid "Certain features of the Site need Cookies for those features to work.  UK and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those cases, we don’t ask for your consent to place them but you can still block these Cookies by changing your internet browser’s settings as detailed below."
+msgid ""
+"Certain features of the Site need Cookies for those features to work.  UK "
+"and EU Cookie Law deems these Cookies to be “strictly necessary”.  In those "
+"cases, we don’t ask for your consent to place them but you can still block "
+"these Cookies by changing your internet browser’s settings as detailed below."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:194
-msgid "The Site uses analytics services provided by Google and others.  “Analytics” is a set of tools used to collect and analyse how the Site is used which then helps us understand the needs of our Users.  This, in turn, means that we can improve the Site and the products and/or services offered through it."
+msgid ""
+"The Site uses analytics services provided by Google and others.  “Analytics” "
+"is a set of tools used to collect and analyse how the Site is used which "
+"then helps us understand the needs of our Users.  This, in turn, means that "
+"we can improve the Site and the products and/or services offered through it."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:196
-msgid "You don’t have to let us use these analytic Cookies but when we use them your privacy and safe use of the Site are not at risk."
+msgid ""
+"You don’t have to let us use these analytic Cookies but when we use them "
+"your privacy and safe use of the Site are not at risk."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:198
-msgid "The analytics service may place Cookies on your device immediately you visit the Site and it may not be possible to obtain your consent before it does.  You can remove these Cookies and prevent future use of them by following the steps set out below:"
+msgid ""
+"The analytics service may place Cookies on your device immediately you visit "
+"the Site and it may not be possible to obtain your consent before it does.  "
+"You can remove these Cookies and prevent future use of them by following the "
+"steps set out below:"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:201
@@ -2457,19 +3615,29 @@ msgid "You can choose to enable or disable Cookies in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:202
-msgid "Most internet browsers enable you to choose whether you wish to disable all Cookies or only third party Cookies."
+msgid ""
+"Most internet browsers enable you to choose whether you wish to disable all "
+"Cookies or only third party Cookies."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:203
-msgid "By default, most internet browsers accept Cookies but this can be changed. For further details, please consult the help menu in your internet browser."
+msgid ""
+"By default, most internet browsers accept Cookies but this can be changed. "
+"For further details, please consult the help menu in your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:204
-msgid "You can choose to delete Cookies at any time but if you do you may lose any information that enables you to access the Site quickly and efficiently and you may lose your personal settings."
+msgid ""
+"You can choose to delete Cookies at any time but if you do you may lose any "
+"information that enables you to access the Site quickly and efficiently and "
+"you may lose your personal settings."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:208
-msgid "We recommend that you make sure that your internet browser is up-to-date and that if you are not sure about anything you look at the help and guidance provided by your internet browser."
+msgid ""
+"We recommend that you make sure that your internet browser is up-to-date and "
+"that if you are not sure about anything you look at the help and guidance "
+"provided by your internet browser."
 msgstr ""
 
 #: templates/core/privacy_cookies.html:214
@@ -2477,7 +3645,11 @@ msgid "Changes to this Policy"
 msgstr ""
 
 #: templates/core/privacy_cookies.html:217
-msgid "We have the right to change this Policy as and when we decide from time to time or as may be required by law. Any changes will be immediately posted on the Site and you are deemed to have accepted the terms of this Policy on your first use of the Site following those changes."
+msgid ""
+"We have the right to change this Policy as and when we decide from time to "
+"time or as may be required by law. Any changes will be immediately posted on "
+"the Site and you are deemed to have accepted the terms of this Policy on "
+"your first use of the Site following those changes."
 msgstr ""
 
 #: templates/core/resources.html:9 templates/global/footer.html:39
@@ -2486,7 +3658,11 @@ msgid "Resources"
 msgstr ""
 
 #: templates/core/resources.html:11
-msgid "All the resources we've created are open sourced under Creative Commons Attribution 4.0 International (CC BY 4). This means that you can modify, distribute and use commercially, but you cannot sublicense and you have to give us credit and include copyright."
+msgid ""
+"All the resources we've created are open sourced under Creative Commons "
+"Attribution 4.0 International (CC BY 4). This means that you can modify, "
+"distribute and use commercially, but you cannot sublicense and you have to "
+"give us credit and include copyright."
 msgstr ""
 
 #: templates/core/resources.html:22
@@ -2498,7 +3674,10 @@ msgid "Tutorial Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:30
-msgid "The tutorial we're using for all of our workshops. It's a very beginner-friendly tutorial with introductions to the command line, Python, Django, HTML and CSS."
+msgid ""
+"The tutorial we're using for all of our workshops. It's a very beginner-"
+"friendly tutorial with introductions to the command line, Python, Django, "
+"HTML and CSS."
 msgstr ""
 
 #: templates/core/resources.html:35 templates/core/resources.html:55
@@ -2515,7 +3694,10 @@ msgid "Organize Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:50
-msgid "We have written down everything we know about organizing workshops like Django Girls. It's a handbook for organizers of local events, but can be used to organize any kind of workshop."
+msgid ""
+"We have written down everything we know about organizing workshops like "
+"Django Girls. It's a handbook for organizers of local events, but can be "
+"used to organize any kind of workshop."
 msgstr ""
 
 #: templates/core/resources.html:67
@@ -2523,7 +3705,10 @@ msgid "Coaching Guide Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:72
-msgid "A good coaching approach is the most important part of Django Girls events. Learn how to be a good coach, what the rules are and what we believe in. This can be used for coaching any event -- not only Django Girls workshops."
+msgid ""
+"A good coaching approach is the most important part of Django Girls events. "
+"Learn how to be a good coach, what the rules are and what we believe in. "
+"This can be used for coaching any event -- not only Django Girls workshops."
 msgstr ""
 
 #: templates/core/resources.html:84 templates/global/footer.html:44
@@ -2535,7 +3720,10 @@ msgid "Tutorial Extensions Django Girls"
 msgstr ""
 
 #: templates/core/resources.html:92
-msgid "This book contains additional tasks and tutorials that can be accomplished after finishing our main tutorial. Our main tutorial fits into one day of work and we want it to stay this way."
+msgid ""
+"This book contains additional tasks and tutorials that can be accomplished "
+"after finishing our main tutorial. Our main tutorial fits into one day of "
+"work and we want it to stay this way."
 msgstr ""
 
 #: templates/core/terms_conditions.html:4
@@ -2545,11 +3733,17 @@ msgstr ""
 
 #: templates/core/terms_conditions.html:5
 #: templates/core/terms_conditions.html:22
-msgid "Welcome to our terms and conditions page. We’ve tried to make it easy to follow so that you know exactly where you stand when you order from us. Please read it through and, if there is anything you don’t understand, get in touch and we’ll do our best to explain."
+msgid ""
+"Welcome to our terms and conditions page. We’ve tried to make it easy to "
+"follow so that you know exactly where you stand when you order from us. "
+"Please read it through and, if there is anything you don’t understand, get "
+"in touch and we’ll do our best to explain."
 msgstr ""
 
 #: templates/core/terms_conditions.html:14
-msgid "<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 whose address is United House, North Road, London N7 9DP"
+msgid ""
+"<b>We</b> are Django Girls Foundation, Registered Charity Number 1163260 "
+"whose address is United House, North Road, London N7 9DP"
 msgstr ""
 
 #: templates/core/terms_conditions.html:18
@@ -2565,7 +3759,10 @@ msgid "By entering our site you are accepting these T&Cs"
 msgstr ""
 
 #: templates/core/terms_conditions.html:33
-msgid "One other thing we need to say is that we do change these T&Cs from time to time and so you <b>must</b> always visit this page to see what changes we’ve made – we’ll assume that you have each time you contact us."
+msgid ""
+"One other thing we need to say is that we do change these T&Cs from time to "
+"time and so you <b>must</b> always visit this page to see what changes we’ve "
+"made – we’ll assume that you have each time you contact us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:39
@@ -2573,7 +3770,9 @@ msgid "Agreement"
 msgstr ""
 
 #: templates/core/terms_conditions.html:41
-msgid "This page is meant to form the basis of the relationship between us and both you and we agree to be bound by what it says."
+msgid ""
+"This page is meant to form the basis of the relationship between us and both "
+"you and we agree to be bound by what it says."
 msgstr ""
 
 #: templates/core/terms_conditions.html:44
@@ -2589,19 +3788,26 @@ msgid "You promise us:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:49
-msgid "That you have the right to agree these T&Cs with us and that you are over the age of 18 years."
+msgid ""
+"That you have the right to agree these T&Cs with us and that you are over "
+"the age of 18 years."
 msgstr ""
 
 #: templates/core/terms_conditions.html:50
-msgid "That if you follow any links we have on the Site, you will read the terms and conditions on the sites we link you to."
+msgid ""
+"That if you follow any links we have on the Site, you will read the terms "
+"and conditions on the sites we link you to."
 msgstr ""
 
 #: templates/core/terms_conditions.html:51
-msgid "That you won’t use robots, spiders, scrapers or similar things on the Site."
+msgid ""
+"That you won’t use robots, spiders, scrapers or similar things on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:52
-msgid "That you won’t try to get around any things we put on the Site to stop or limit access to parts of it."
+msgid ""
+"That you won’t try to get around any things we put on the Site to stop or "
+"limit access to parts of it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:53
@@ -2609,15 +3815,25 @@ msgid "That you won’t do anything that might cause our systems to crash."
 msgstr ""
 
 #: templates/core/terms_conditions.html:54
-msgid "That you won’t steal, borrow, copy or otherwise obtain the Site or any part of it for use in any other site or application for any use which conflicts with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t steal, borrow, copy or otherwise obtain the Site or any part "
+"of it for use in any other site or application for any use which conflicts "
+"with the aims and ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:55
-msgid "That you won’t try to modify, translate, adapt, edit, decompile, disassemble or reverse engineer any programs we use in connection with the Site or the services it offers for any purpose which is inconsistent with the aims and ideals which we publish from time to time on the Site."
+msgid ""
+"That you won’t try to modify, translate, adapt, edit, decompile, disassemble "
+"or reverse engineer any programs we use in connection with the Site or the "
+"services it offers for any purpose which is inconsistent with the aims and "
+"ideals which we publish from time to time on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:56
-msgid "That you won’t copy, imitate or use the trademarks and/or designs and/or layout or anything else which would usually amount to intellectual property and which we own."
+msgid ""
+"That you won’t copy, imitate or use the trademarks and/or designs and/or "
+"layout or anything else which would usually amount to intellectual property "
+"and which we own."
 msgstr ""
 
 #: templates/core/terms_conditions.html:59
@@ -2625,11 +3841,20 @@ msgid "Intellectual property"
 msgstr ""
 
 #: templates/core/terms_conditions.html:60
-msgid "Either we or third parties own all of the information and intellectual property on the Site."
+msgid ""
+"Either we or third parties own all of the information and intellectual "
+"property on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:63
-msgid "We’re quite happy for you to use information or intellectual property on the Site which belongs to us provided that you ask for our permission (in writing) first.  We may impose conditions on your use of that information or intellectual property. If you want to use any of our information or intellectual property as an Organiser then you must comply with our Organiser terms and conditions which you can view <a href=\"http://organize.djangogirls.org/\">here</a>."
+msgid ""
+"We’re quite happy for you to use information or intellectual property on the "
+"Site which belongs to us provided that you ask for our permission (in "
+"writing) first.  We may impose conditions on your use of that information or "
+"intellectual property. If you want to use any of our information or "
+"intellectual property as an Organiser then you must comply with our "
+"Organiser terms and conditions which you can view <a href=\"http://organize."
+"djangogirls.org/\">here</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:71
@@ -2637,11 +3862,17 @@ msgid "Price and payment"
 msgstr ""
 
 #: templates/core/terms_conditions.html:73
-msgid "We make no charge for the service we offer to individuals through the Site and most other services we offer are free of charge."
+msgid ""
+"We make no charge for the service we offer to individuals through the Site "
+"and most other services we offer are free of charge."
 msgstr ""
 
 #: templates/core/terms_conditions.html:80
-msgid "If you wish to make a donation for the use of any of our services, go to our <a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a href=\"%(donations_url)s\">our donate page</a>."
+#, python-format
+msgid ""
+"If you wish to make a donation for the use of any of our services, go to our "
+"<a href=\"https://www.patreon.com/djangogirls\">Patreon page</a> or <a "
+"href=\"%(donations_url)s\">our donate page</a>."
 msgstr ""
 
 #: templates/core/terms_conditions.html:86
@@ -2649,7 +3880,11 @@ msgid "Use of communications facilities"
 msgstr ""
 
 #: templates/core/terms_conditions.html:88
-msgid "When submitting content for us to publish on the Site or using any forums or chat rooms on the Site and/or any other similar system on the Site and when using Facebook, Wordpress or any other external communication system to contact us, you must do so in accordance with the following rules:"
+msgid ""
+"When submitting content for us to publish on the Site or using any forums or "
+"chat rooms on the Site and/or any other similar system on the Site and when "
+"using Facebook, Wordpress or any other external communication system to "
+"contact us, you must do so in accordance with the following rules:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:90
@@ -2657,51 +3892,79 @@ msgid "you must not use language that may be offensive to other Users;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:91
-msgid "you must not submit Content that is unlawful or otherwise objectionable.  This includes, but is not limited to, Content that is abusive, threatening, harassing, defamatory, ageist, sexist or racist;"
+msgid ""
+"you must not submit Content that is unlawful or otherwise objectionable.  "
+"This includes, but is not limited to, Content that is abusive, threatening, "
+"harassing, defamatory, ageist, sexist or racist;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:92
-msgid "you must submit no Content that is intended to promote or incite violence;"
+msgid ""
+"you must submit no Content that is intended to promote or incite violence;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:93
-msgid "Content must be posted, and communications with us must be made, using the English language;"
+msgid ""
+"Content must be posted, and communications with us must be made, using the "
+"English language;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:94
-msgid "you must not post links to other sites containing any of the above types of Content;"
+msgid ""
+"you must not post links to other sites containing any of the above types of "
+"Content;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:95
-msgid "the means by which you identify yourself must not violate these T&Cs or any applicable laws;"
+msgid ""
+"the means by which you identify yourself must not violate these T&Cs or any "
+"applicable laws;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:96
-msgid "you must not engage in any form of commercial advertising. This does not prohibit references to businesses for non-promotional purposes including references where advertising may be incidental;"
+msgid ""
+"you must not engage in any form of commercial advertising. This does not "
+"prohibit references to businesses for non-promotional purposes including "
+"references where advertising may be incidental;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:97
-msgid "you give us the right to publish the material you have submitted to us anywhere and for whatever reason we choose and we don’t have to pay you a fee or acknowledge you as the author;"
+msgid ""
+"you give us the right to publish the material you have submitted to us "
+"anywhere and for whatever reason we choose and we don’t have to pay you a "
+"fee or acknowledge you as the author;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:98
-msgid "you must not impersonate other people, particularly our employees and representatives and those of our affiliates; and"
+msgid ""
+"you must not impersonate other people, particularly our employees and "
+"representatives and those of our affiliates; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:99
-msgid "you must not use our System for unauthorised mass communication such as “spam” or “junk mail”."
+msgid ""
+"you must not use our System for unauthorised mass communication such as "
+"“spam” or “junk mail”."
 msgstr ""
 
 #: templates/core/terms_conditions.html:102
-msgid "You acknowledge that we have the right to monitor any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we have the right to monitor any and all communications "
+"made to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:104
-msgid "You acknowledge that we may retain copies of any and all communications made to us or using our System."
+msgid ""
+"You acknowledge that we may retain copies of any and all communications made "
+"to us or using our System."
 msgstr ""
 
 #: templates/core/terms_conditions.html:107
-msgid "You agree that we can modify any information you send to us in any way and you agree that you have no moral right to be identified as the author of that information. Unless we have agreed them with you in advance, we don’t have to comply with any restrictions you put on our use of that information."
+msgid ""
+"You agree that we can modify any information you send to us in any way and "
+"you agree that you have no moral right to be identified as the author of "
+"that information. Unless we have agreed them with you in advance, we don’t "
+"have to comply with any restrictions you put on our use of that information."
 msgstr ""
 
 #: templates/core/terms_conditions.html:114
@@ -2709,7 +3972,10 @@ msgid "Privacy and cookies"
 msgstr ""
 
 #: templates/core/terms_conditions.html:118
-msgid "We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and Cookie Policy</a> forms part of these T&Cs."
+#, python-format
+msgid ""
+"We and you both agree that <a href=\"%(cookies_url)s\">our Privacy and "
+"Cookie Policy</a> forms part of these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:123
@@ -2725,7 +3991,9 @@ msgid "that the Site will meet your needs;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:129
-msgid "that all the information we publish is correct, up to date and not misleading;"
+msgid ""
+"that all the information we publish is correct, up to date and not "
+"misleading;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:130
@@ -2749,19 +4017,35 @@ msgid "that the Site is secure,"
 msgstr ""
 
 #: templates/core/terms_conditions.html:137
-msgid "but we can’t guarantee those things and, by agreeing to these T&Cs you are confirming that you accept that situation."
+msgid ""
+"but we can’t guarantee those things and, by agreeing to these T&Cs you are "
+"confirming that you accept that situation."
 msgstr ""
 
 #: templates/core/terms_conditions.html:140
-msgid "We take all reasonable effort to test material before placing it on the Site. In the very unlikely event of any loss, disruption or damage caused by material on the Site, we cannot be held responsible for any loss, disruption or damage to your data or computer system which may occur."
+msgid ""
+"We take all reasonable effort to test material before placing it on the "
+"Site. In the very unlikely event of any loss, disruption or damage caused by "
+"material on the Site, we cannot be held responsible for any loss, disruption "
+"or damage to your data or computer system which may occur."
 msgstr ""
 
 #: templates/core/terms_conditions.html:147
-msgid "The only rights you have under these T&Cs are those mentioned within them. If a right is not mentioned (unless it is a right given to you under the laws of England and Wales) then it does not exist."
+msgid ""
+"The only rights you have under these T&Cs are those mentioned within them. "
+"If a right is not mentioned (unless it is a right given to you under the "
+"laws of England and Wales) then it does not exist."
 msgstr ""
 
 #: templates/core/terms_conditions.html:150
-msgid "If you find an error, problem or bug when using any of the services or facilities we provide on the Site you agree either to notify us by submitting a pull request to the following <a href=\"https://github.com/DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the Site facilities. Whilst we will always endeavour to resolve any of the issues referred to in this paragraph we do not make any warranty that we will be able to achieve any specific outcome."
+msgid ""
+"If you find an error, problem or bug when using any of the services or "
+"facilities we provide on the Site you agree either to notify us by "
+"submitting a pull request to the following <a href=\"https://github.com/"
+"DjangoGirls/djangogirls/\">address</a> or to open an issue with us using the "
+"Site facilities. Whilst we will always endeavour to resolve any of the "
+"issues referred to in this paragraph we do not make any warranty that we "
+"will be able to achieve any specific outcome."
 msgstr ""
 
 #: templates/core/terms_conditions.html:158 templates/global/menu.html:20
@@ -2769,11 +4053,20 @@ msgid "Events"
 msgstr ""
 
 #: templates/core/terms_conditions.html:160
-msgid "Events organised through the Site are usually organised by third parties and not by us. Although we set out guidelines for all organisers to follow we have no control over whether those guidelines are followed or not. For this reason and to the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your booking or attendance at an Event or from anything arising from it."
+msgid ""
+"Events organised through the Site are usually organised by third parties and "
+"not by us. Although we set out guidelines for all organisers to follow we "
+"have no control over whether those guidelines are followed or not. For this "
+"reason and to the maximum extent permitted by law, we accept no liability "
+"for any direct or indirect loss or damage, foreseeable or otherwise, "
+"including any indirect, consequential, special or exemplary damages arising "
+"from your booking or attendance at an Event or from anything arising from it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:162
-msgid "You accept that all issues arising relating to an Event must be addressed to the Event Organiser."
+msgid ""
+"You accept that all issues arising relating to an Event must be addressed to "
+"the Event Organiser."
 msgstr ""
 
 #: templates/core/terms_conditions.html:164
@@ -2781,11 +4074,15 @@ msgid "Problems"
 msgstr ""
 
 #: templates/core/terms_conditions.html:166
-msgid "We do our very best to make sure that you do not experience any problems when using the Site but if you do, you must tell us straight away."
+msgid ""
+"We do our very best to make sure that you do not experience any problems "
+"when using the Site but if you do, you must tell us straight away."
 msgstr ""
 
 #: templates/core/terms_conditions.html:168
-msgid "We will do what we can to resolve the problem as quickly as we can and without charge to you if we agree that you have a problem."
+msgid ""
+"We will do what we can to resolve the problem as quickly as we can and "
+"without charge to you if we agree that you have a problem."
 msgstr ""
 
 #: templates/core/terms_conditions.html:170
@@ -2793,11 +4090,16 @@ msgid "Availability of the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:172
-msgid "We never guarantee that the Site will be available all the time and if it’s not available for any reason we cannot be held responsible for anything you lose as a result."
+msgid ""
+"We never guarantee that the Site will be available all the time and if it’s "
+"not available for any reason we cannot be held responsible for anything you "
+"lose as a result."
 msgstr ""
 
 #: templates/core/terms_conditions.html:174
-msgid "We have the right to change the Site and the services it offers, suspend it or stop it at any time."
+msgid ""
+"We have the right to change the Site and the services it offers, suspend it "
+"or stop it at any time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:176
@@ -2805,7 +4107,11 @@ msgid "Limitation of liability"
 msgstr ""
 
 #: templates/core/terms_conditions.html:178
-msgid "To the maximum extent permitted by law, we accept no liability for any direct or indirect loss or damage, foreseeable or otherwise, including any indirect, consequential, special or exemplary damages arising from your use of the Site or any information contained in it."
+msgid ""
+"To the maximum extent permitted by law, we accept no liability for any "
+"direct or indirect loss or damage, foreseeable or otherwise, including any "
+"indirect, consequential, special or exemplary damages arising from your use "
+"of the Site or any information contained in it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:180
@@ -2813,7 +4119,9 @@ msgid "You use the Site and its Content at your own risk."
 msgstr ""
 
 #: templates/core/terms_conditions.html:182
-msgid "Nothing in these T&Cs excludes or restricts our liability for death or personal injury resulting from any negligence or fraud on our part."
+msgid ""
+"Nothing in these T&Cs excludes or restricts our liability for death or "
+"personal injury resulting from any negligence or fraud on our part."
 msgstr ""
 
 #: templates/core/terms_conditions.html:184
@@ -2821,11 +4129,16 @@ msgid "Linking"
 msgstr ""
 
 #: templates/core/terms_conditions.html:186
-msgid "We don’t control any of the websites we link to and so we can’t be responsible for the content of such websites and we disclaim liability for any losses which come out of you using them."
+msgid ""
+"We don’t control any of the websites we link to and so we can’t be "
+"responsible for the content of such websites and we disclaim liability for "
+"any losses which come out of you using them."
 msgstr ""
 
 #: templates/core/terms_conditions.html:188
-msgid "Just because we link to a site does not mean that we endorse or recommend that site."
+msgid ""
+"Just because we link to a site does not mean that we endorse or recommend "
+"that site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:190
@@ -2833,15 +4146,23 @@ msgid "We can never guarantee that a link will work."
 msgstr ""
 
 #: templates/core/terms_conditions.html:192
-msgid "If you find any link we offer to be offensive, please let us know and we will consider removing it."
+msgid ""
+"If you find any link we offer to be offensive, please let us know and we "
+"will consider removing it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:194
-msgid "If you link to any other site using the Site then you understand that separate conditions will apply to those sites and that we have no control over those conditions – so you agree that you will read and understand them before using those sites."
+msgid ""
+"If you link to any other site using the Site then you understand that "
+"separate conditions will apply to those sites and that we have no control "
+"over those conditions – so you agree that you will read and understand them "
+"before using those sites."
 msgstr ""
 
 #: templates/core/terms_conditions.html:196
-msgid "If you wish to link to the Site you may link to our Home page on the following conditions:"
+msgid ""
+"If you wish to link to the Site you may link to our Home page on the "
+"following conditions:"
 msgstr ""
 
 #: templates/core/terms_conditions.html:199
@@ -2857,7 +4178,9 @@ msgid "you can only link from a site that you own;"
 msgstr ""
 
 #: templates/core/terms_conditions.html:202
-msgid "you can’t suggest that we are associated with you, endorse you and approve of you in any way; and"
+msgid ""
+"you can’t suggest that we are associated with you, endorse you and approve "
+"of you in any way; and"
 msgstr ""
 
 #: templates/core/terms_conditions.html:203
@@ -2865,7 +4188,9 @@ msgid "you mustn’t frame our Site on any other site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:206
-msgid "We always have the right to break any link you make even if we can’t give a reason for our decision."
+msgid ""
+"We always have the right to break any link you make even if we can’t give a "
+"reason for our decision."
 msgstr ""
 
 #: templates/core/terms_conditions.html:208
@@ -2873,11 +4198,18 @@ msgid "Modifications to these T&Cs & the site"
 msgstr ""
 
 #: templates/core/terms_conditions.html:211
-msgid "We’ve already said this, but we need to make it clear that these T&Cs will change from time to time and we don’t have the resources to let all our visitors know about the changes. As a result you MUST come back to this page to make sure that we haven’t changed these T&Cs and whenever you access the Site, you are confirming to us that you are aware of any changes."
+msgid ""
+"We’ve already said this, but we need to make it clear that these T&Cs will "
+"change from time to time and we don’t have the resources to let all our "
+"visitors know about the changes. As a result you MUST come back to this page "
+"to make sure that we haven’t changed these T&Cs and whenever you access the "
+"Site, you are confirming to us that you are aware of any changes."
 msgstr ""
 
 #: templates/core/terms_conditions.html:219
-msgid "We’ve also got the right to change the Site as and when we want to, but these T&Cs will still apply to any changes we make."
+msgid ""
+"We’ve also got the right to change the Site as and when we want to, but "
+"these T&Cs will still apply to any changes we make."
 msgstr ""
 
 #: templates/core/terms_conditions.html:221
@@ -2885,39 +4217,66 @@ msgid "General stuff"
 msgstr ""
 
 #: templates/core/terms_conditions.html:224
-msgid "<i>Operative Law</i> – these T&Cs are made under the laws of England and Wales and that is the only jurisdiction which can govern it."
+msgid ""
+"<i>Operative Law</i> – these T&Cs are made under the laws of England and "
+"Wales and that is the only jurisdiction which can govern it."
 msgstr ""
 
 #: templates/core/terms_conditions.html:225
-msgid "<i>Partnership/Joint Ventures</i> – we and you agree that the agreement between us does not form the basis of any partnership or co-venture."
+msgid ""
+"<i>Partnership/Joint Ventures</i> – we and you agree that the agreement "
+"between us does not form the basis of any partnership or co-venture."
 msgstr ""
 
 #: templates/core/terms_conditions.html:226
-msgid "<i>Effect of Agreement</i> – the current agreement between us and you supersedes any previous agreement in relation to the matters dealt with and represents the entire understanding between us and you"
+msgid ""
+"<i>Effect of Agreement</i> – the current agreement between us and you "
+"supersedes any previous agreement in relation to the matters dealt with and "
+"represents the entire understanding between us and you"
 msgstr ""
 
 #: templates/core/terms_conditions.html:227
-msgid "<i>Time of the Essence</i> – time will not be of the essence in any part of the agreement between us and you."
+msgid ""
+"<i>Time of the Essence</i> – time will not be of the essence in any part of "
+"the agreement between us and you."
 msgstr ""
 
 #: templates/core/terms_conditions.html:228
-msgid "<i>Warranties</i> – all parties acknowledge and agree that they have not entered into thie agreement between us and you in reliance on anything said or promised by the other which is not in these T&Cs."
+msgid ""
+"<i>Warranties</i> – all parties acknowledge and agree that they have not "
+"entered into thie agreement between us and you in reliance on anything said "
+"or promised by the other which is not in these T&Cs."
 msgstr ""
 
 #: templates/core/terms_conditions.html:229
-msgid "<i>Force Majeure</i> – if something outside our control happens and that prevents us from performing our services then you accept that we are not liable for the consequences of that failure (this includes such things as strikes, riots, fires, explosions, war, floods and so on). If such an event does happen we will tell you as soon as we are able and resume the service as soon as we can. If we cannot perform the service within a reasonable time, we can cancel it and if we do we will refund to you a fair and reasonable proportion of any payment you have made to us."
+msgid ""
+"<i>Force Majeure</i> – if something outside our control happens and that "
+"prevents us from performing our services then you accept that we are not "
+"liable for the consequences of that failure (this includes such things as "
+"strikes, riots, fires, explosions, war, floods and so on). If such an event "
+"does happen we will tell you as soon as we are able and resume the service "
+"as soon as we can. If we cannot perform the service within a reasonable "
+"time, we can cancel it and if we do we will refund to you a fair and "
+"reasonable proportion of any payment you have made to us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:230
-msgid "<i>Unenforceability</i> – if a Court or other body says that any part of these T&Cs is unenforceable, the rest of them will stand."
+msgid ""
+"<i>Unenforceability</i> – if a Court or other body says that any part of "
+"these T&Cs is unenforceable, the rest of them will stand."
 msgstr ""
 
 #: templates/core/terms_conditions.html:231
-msgid "<i>Notices</i> – if either you or we need to give formal notice to the other it must be done by email to the address that each of us gives to the other from time to time."
+msgid ""
+"<i>Notices</i> – if either you or we need to give formal notice to the other "
+"it must be done by email to the address that each of us gives to the other "
+"from time to time."
 msgstr ""
 
 #: templates/core/terms_conditions.html:232
-msgid "<i>Entire Agreement</i> – these T&Cs contain the entire understanding between us."
+msgid ""
+"<i>Entire Agreement</i> – these T&Cs contain the entire understanding "
+"between us."
 msgstr ""
 
 #: templates/core/terms_conditions.html:235
@@ -2929,15 +4288,22 @@ msgid "Definitions"
 msgstr ""
 
 #: templates/core/terms_conditions.html:239
-msgid "<b>Consumer legislation</b> means the Consumer Contracts (Information, Cancellation and Additional Charges) Regulations 2013."
+msgid ""
+"<b>Consumer legislation</b> means the Consumer Contracts (Information, "
+"Cancellation and Additional Charges) Regulations 2013."
 msgstr ""
 
 #: templates/core/terms_conditions.html:240
-msgid "<b>Content</b> means any text, graphics, images, audio, video, software, data compilations and any other form of information capable of being stored in a computer that appears on or forms part of the Site."
+msgid ""
+"<b>Content</b> means any text, graphics, images, audio, video, software, "
+"data compilations and any other form of information capable of being stored "
+"in a computer that appears on or forms part of the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:242
-msgid "<b>Event</b> means any event organised by an Organiser using the material we offer on the Site."
+msgid ""
+"<b>Event</b> means any event organised by an Organiser using the material we "
+"offer on the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:244
@@ -2945,7 +4311,10 @@ msgid "<b>Organiser</b> means the organiser or promoter of an Event."
 msgstr ""
 
 #: templates/core/terms_conditions.html:247
-msgid "<b>System</b> means the communications and other system or systems we use in connection with the Site. means the communications and other system or systems we use in connection with the Site."
+msgid ""
+"<b>System</b> means the communications and other system or systems we use in "
+"connection with the Site. means the communications and other system or "
+"systems we use in connection with the Site."
 msgstr ""
 
 #: templates/core/terms_conditions.html:253
@@ -2953,7 +4322,8 @@ msgid "<b>T&Cs</b> means these terms and conditions."
 msgstr ""
 
 #: templates/core/terms_conditions.html:255
-msgid "<b>User</b> means any person, firm or company using the Site for any purpose."
+msgid ""
+"<b>User</b> means any person, firm or company using the Site for any purpose."
 msgstr ""
 
 #: templates/core/workshop_box.html:9
@@ -2961,7 +4331,10 @@ msgid "Order Django Girls Workshop Box for your event!"
 msgstr ""
 
 #: templates/core/workshop_box.html:11
-msgid "Get a golden envelope full of Django Girls stickers, gold letter balloons, stickers of our partners, and buttons. <br /> Everything you need to make your workshop DjangoGirlsy! 🌸✨"
+msgid ""
+"Get a golden envelope full of Django Girls stickers, gold letter balloons, "
+"stickers of our partners, and buttons. <br /> Everything you need to make "
+"your workshop DjangoGirlsy! 🌸✨"
 msgstr ""
 
 #: templates/core/workshop_box.html:27
@@ -2969,11 +4342,19 @@ msgid "How it works?"
 msgstr ""
 
 #: templates/core/workshop_box.html:29
-msgid "We purchased Django Girls goodies in bulk quantity, which massively lowered their price. It will save everyone time and money and you will be able to focus on more awesome things. The box can be sent to Django Girls workshops from all over the world: small goodies and swag won't drain your sponsor money anymore! YAY! ✨💰"
+msgid ""
+"We purchased Django Girls goodies in bulk quantity, which massively lowered "
+"their price. It will save everyone time and money and you will be able to "
+"focus on more awesome things. The box can be sent to Django Girls workshops "
+"from all over the world: small goodies and swag won't drain your sponsor "
+"money anymore! YAY! ✨💰"
 msgstr ""
 
 #: templates/core/workshop_box.html:37
-msgid "We calculated that one event of 30 people would need to pay around £150 GBP for all of those things, and sometimes they're hard to get. We're able to buy and ship them all for around $50."
+msgid ""
+"We calculated that one event of 30 people would need to pay around £150 GBP "
+"for all of those things, and sometimes they're hard to get. We're able to "
+"buy and ship them all for around $50."
 msgstr ""
 
 #: templates/core/workshop_box.html:44
@@ -3037,7 +4418,11 @@ msgid "You will also need to add shipping costs. 📮"
 msgstr ""
 
 #: templates/core/workshop_box.html:71
-msgid "If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/Developing_country#List_of_developing_economies\">developing country</a> or if you tried but can't find sponsors, you'll be able to apply for a free box (you'll need to pay for shipping)."
+msgid ""
+"If your event is happening in a <a href=\"https://en.wikipedia.org/wiki/"
+"Developing_country#List_of_developing_economies\">developing country</a> or "
+"if you tried but can't find sponsors, you'll be able to apply for a free box "
+"(you'll need to pay for shipping)."
 msgstr ""
 
 #: templates/core/workshop_box.html:78
@@ -3045,7 +4430,12 @@ msgid "How to get one?"
 msgstr ""
 
 #: templates/core/workshop_box.html:80
-msgid "Yay, that's great that you want to order one! To do that, <a href=\"https://store.djangogirls.org/products/django-girls-workshop-box\">go to our store</a>. <b>We strongly recommend you to buy it at least 6 weeks before your event</b>: if you don't do it, we can't guarantee that your box will be delivered on time for your event."
+msgid ""
+"Yay, that's great that you want to order one! To do that, <a href=\"https://"
+"store.djangogirls.org/products/django-girls-workshop-box\">go to our store</"
+"a>. <b>We strongly recommend you to buy it at least 6 weeks before your "
+"event</b>: if you don't do it, we can't guarantee that your box will be "
+"delivered on time for your event."
 msgstr ""
 
 #: templates/core/workshop_box.html:86
@@ -3053,7 +4443,9 @@ msgid "Requirements to apply for a free box:"
 msgstr ""
 
 #: templates/core/workshop_box.html:88
-msgid "Your event must happen in a developing country or you tried but can't find any sponsor."
+msgid ""
+"Your event must happen in a developing country or you tried but can't find "
+"any sponsor."
 msgstr ""
 
 #: templates/core/workshop_box.html:89
@@ -3065,11 +4457,16 @@ msgid "Application process for your event needs to be open"
 msgstr ""
 
 #: templates/core/workshop_box.html:91
-msgid "You need to order it at least 6 weeks before workshop to allow for shipping time"
+msgid ""
+"You need to order it at least 6 weeks before workshop to allow for shipping "
+"time"
 msgstr ""
 
 #: templates/core/workshop_box.html:94
-msgid "<b>If you check all those requirements</b>, <a href=\"mailto:hello@djangogirls.org\">send us an email</a> describing your situation: we will review your application and contact you soon. 💕"
+msgid ""
+"<b>If you check all those requirements</b>, <a href=\"mailto:"
+"hello@djangogirls.org\">send us an email</a> describing your situation: we "
+"will review your application and contact you soon. 💕"
 msgstr ""
 
 #: templates/default/about.html:4
@@ -3089,7 +4486,9 @@ msgid "Applications are now open!"
 msgstr ""
 
 #: templates/default/apply.html:7
-msgid "Application process closes on July 23rd and you'll be informed about acceptance or rejection by July 28th (or sooner)!"
+msgid ""
+"Application process closes on July 23rd and you'll be informed about "
+"acceptance or rejection by July 28th (or sooner)!"
 msgstr ""
 
 #: templates/default/apply.html:10
@@ -3101,7 +4500,10 @@ msgid "Be a Mentor!"
 msgstr ""
 
 #: templates/default/coach.html:8
-msgid "We would be delighted if you would like to join us as a mentor! <a href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
+#, python-format
+msgid ""
+"We would be delighted if you would like to join us as a mentor! <a "
+"href=\"%(contact_url)s\">Contact us</a> if you're interested ❤️"
 msgstr ""
 
 #: templates/default/coach.html:16 templates/default/values.html:5
@@ -3109,15 +4511,23 @@ msgid "Django Girls"
 msgstr ""
 
 #: templates/default/coach.html:18
-msgid "This workshop is a part of bigger initiative: <a href=\"https://djangogirls.org/\">Django Girls</a>. It is a non-profit organization and events are organized by volunteers in different places of the world."
+msgid ""
+"This workshop is a part of bigger initiative: <a href=\"https://djangogirls."
+"org/\">Django Girls</a>. It is a non-profit organization and events are "
+"organized by volunteers in different places of the world."
 msgstr ""
 
 #: templates/default/coach.html:24
-msgid "To see the source for the program find us on Github: <a href=\"https://github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
+msgid ""
+"To see the source for the program find us on Github: <a href=\"https://"
+"github.com/DjangoGirls/\">github.com/DjangoGirls</a>."
 msgstr ""
 
 #: templates/default/coach.html:30
-msgid "If you want to bring Django Girls to your city, <a href=\"%(contact_url)s\">drop us a line</a>"
+#, python-format
+msgid ""
+"If you want to bring Django Girls to your city, <a "
+"href=\"%(contact_url)s\">drop us a line</a>"
 msgstr ""
 
 #: templates/default/faq.html:6
@@ -3125,7 +4535,10 @@ msgid "Do I need to know anything about websites or programming?"
 msgstr ""
 
 #: templates/default/faq.html:9
-msgid "No! Workshops are for beginners. You don’t need to know anything about it. However, if you have a little bit of technical knowledge (i.e. you know what HTML or CSS are) you still can apply!"
+msgid ""
+"No! Workshops are for beginners. You don’t need to know anything about it. "
+"However, if you have a little bit of technical knowledge (i.e. you know what "
+"HTML or CSS are) you still can apply!"
 msgstr ""
 
 #: templates/default/faq.html:18
@@ -3133,7 +4546,11 @@ msgid "I am not living in Germany, can I attend?"
 msgstr ""
 
 #: templates/default/faq.html:21
-msgid "Of course! Workshops will be in English, so if you have no troubles with speaking and understanding English - you should apply. If you need financial aid to get to Berlin or you need assistance with booking flights or hotel in Berlin - let us know. We are willing to help you!"
+msgid ""
+"Of course! Workshops will be in English, so if you have no troubles with "
+"speaking and understanding English - you should apply. If you need financial "
+"aid to get to Berlin or you need assistance with booking flights or hotel in "
+"Berlin - let us know. We are willing to help you!"
 msgstr ""
 
 #: templates/default/faq.html:31
@@ -3141,7 +4558,10 @@ msgid "Should I bring my own laptop?"
 msgstr ""
 
 #: templates/default/faq.html:34
-msgid "Yes. We have no hardware, so we expect you to bring your computer with you. It is also important for us that you will take home everything you’ll write and create during workshops."
+msgid ""
+"Yes. We have no hardware, so we expect you to bring your computer with you. "
+"It is also important for us that you will take home everything you’ll write "
+"and create during workshops."
 msgstr ""
 
 #: templates/default/faq.html:45
@@ -3149,7 +4569,10 @@ msgid "Do I need to have something installed on my laptop?"
 msgstr ""
 
 #: templates/default/faq.html:48
-msgid "It would be helpful to have Django installed before workshops, but wouldn't expect you to install anything on your own.We will make sure that one of our coaches will help you out with this task."
+msgid ""
+"It would be helpful to have Django installed before workshops, but wouldn't "
+"expect you to install anything on your own.We will make sure that one of our "
+"coaches will help you out with this task."
 msgstr ""
 
 #: templates/default/faq.html:58
@@ -3157,7 +4580,11 @@ msgid "Is EuroPython conference good for a total beginner?"
 msgstr ""
 
 #: templates/default/faq.html:61
-msgid "As a workshop attendee you will get a free ticket to EuroPython - conference for Python programmers. Even though you are new to programming,conference is a good place to meet many interesting people in the industry and find inspiration."
+msgid ""
+"As a workshop attendee you will get a free ticket to EuroPython - conference "
+"for Python programmers. Even though you are new to programming,conference is "
+"a good place to meet many interesting people in the industry and find "
+"inspiration."
 msgstr ""
 
 #: templates/default/faq.html:70
@@ -3165,11 +4592,17 @@ msgid "Is food provided?"
 msgstr ""
 
 #: templates/default/faq.html:71
-msgid "Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
+msgid ""
+"Yes. Thanks to EuroPython, snacks and lunch will be served during workshops."
 msgstr ""
 
 #: templates/default/footer.html:39
-msgid "♥ Django Girls Europe is organized by <a href=\"http://twitter.com/olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/asednecka\">Ola Sendecka</a> with the support from <a href=\"http://europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of <a href=\"/\">Django Girls</a>."
+msgid ""
+"♥ Django Girls Europe is organized by <a href=\"http://twitter.com/"
+"olasitarska\">Ola Sitarska</a> and <a href=\"http://twitter.com/"
+"asednecka\">Ola Sendecka</a> with the support from <a href=\"http://"
+"europython.eu/\">EuroPython 2014</a>.<br> Django Girls Europe is a part of "
+"<a href=\"/\">Django Girls</a>."
 msgstr ""
 
 #: templates/default/partners.html:3
@@ -3177,23 +4610,40 @@ msgid "Sponsors"
 msgstr ""
 
 #: templates/default/partners.html:7
-msgid "We couldn't be here without the support from amazing people and organizations who donated money, knowledge and time to help us make this a reality. If you want to contribute and support our goal, <a href=\"%(contact_url)s\">please get it touch</a>"
+#, python-format
+msgid ""
+"We couldn't be here without the support from amazing people and "
+"organizations who donated money, knowledge and time to help us make this a "
+"reality. If you want to contribute and support our goal, <a "
+"href=\"%(contact_url)s\">please get it touch</a>"
 msgstr ""
 
 #: templates/default/values.html:7
-msgid "If you are a woman and want to learn how to make websites, we have good news for you: we are holding a one-day workshop for beginners!"
+msgid ""
+"If you are a woman and want to learn how to make websites, we have good news "
+"for you: we are holding a one-day workshop for beginners!"
 msgstr ""
 
 #: templates/default/values.html:11
-msgid "It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</strong> in <strong>CITY</strong>."
+msgid ""
+"It will take place on <strong>DAY, MONTH, YEAR</strong> at <strong>VENUE</"
+"strong> in <strong>CITY</strong>."
 msgstr ""
 
 #: templates/default/values.html:15
-msgid "We believe the IT industry will greatly benefit from bringing more women into technology. We want to give you an opportunity to learn how to program and become one of us &ndash; women programmers!"
+msgid ""
+"We believe the IT industry will greatly benefit from bringing more women "
+"into technology. We want to give you an opportunity to learn how to program "
+"and become one of us &ndash; women programmers!"
 msgstr ""
 
 #: templates/default/values.html:22
-msgid "Workshops are free of charge and if you cannot afford coming to CITY but are very motivated to learn and then share your knowledge with others, we may have some funds to help you out with your travel costs and accommodation. Don't wait too long: you can apply for the workshop only until <strong>DATE</strong>!"
+msgid ""
+"Workshops are free of charge and if you cannot afford coming to CITY but are "
+"very motivated to learn and then share your knowledge with others, we may "
+"have some funds to help you out with your travel costs and accommodation. "
+"Don't wait too long: you can apply for the workshop only until <strong>DATE</"
+"strong>!"
 msgstr ""
 
 #: templates/default/values.html:33
@@ -3201,7 +4651,10 @@ msgid "Apply for the workshop!"
 msgstr ""
 
 #: templates/default/values.html:35
-msgid "If you are a woman, know English and have a laptop, you can apply for our event! You don't need to know any technical stuff &ndash; our workshop is for people who are new to programming."
+msgid ""
+"If you are a woman, know English and have a laptop, you can apply for our "
+"event! You don't need to know any technical stuff &ndash; our workshop is "
+"for people who are new to programming."
 msgstr ""
 
 #: templates/default/values.html:43
@@ -3209,7 +4662,9 @@ msgid "As a workshop attendee you will:"
 msgstr ""
 
 #: templates/default/values.html:46
-msgid "attend a one-day Django workshop during which you will create your first website"
+msgid ""
+"attend a one-day Django workshop during which you will create your first "
+"website"
 msgstr ""
 
 #: templates/default/values.html:48
@@ -3217,7 +4672,9 @@ msgid "be fed by us: during our event, food is provided"
 msgstr ""
 
 #: templates/default/values.html:53
-msgid "We have space only for XX people, so make sure to fill out the form very carefully!"
+msgid ""
+"We have space only for XX people, so make sure to fill out the form very "
+"carefully!"
 msgstr ""
 
 #: templates/donations/donate.html:13
@@ -3229,19 +4686,37 @@ msgid "Our mission:"
 msgstr ""
 
 #: templates/donations/donate.html:22
-msgid "Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered charity</a>. We use your generous donations to teach thousands of women to build websites using Python and Django by providing resources and tools volunteer organizers all over the world."
+#, python-format
+msgid ""
+"Django Girls is a volunteer-run <a href=\"%(foundation_url)s\">registered "
+"charity</a>. We use your generous donations to teach thousands of women to "
+"build websites using Python and Django by providing resources and tools "
+"volunteer organizers all over the world."
 msgstr ""
 
 #: templates/donations/donate.html:30
-msgid "Since July 2014, our workshops have reached %(attendees_sum|default_if_none:'0')s women in %(countries_count|default_if_none:'0')s countries and our <a href=\"https://tutorial.djangogirls.org/\">online tutorial</a> has been read by more than 3,958,285 people."
+#, python-format
+msgid ""
+"Since July 2014, our workshops have reached "
+"%(attendees_sum|default_if_none:'0')s women in "
+"%(countries_count|default_if_none:'0')s countries and our <a href=\"https://"
+"tutorial.djangogirls.org/\">online tutorial</a> has been read by more than "
+"3,958,285 people."
 msgstr ""
 
 #: templates/donations/donate.html:38
-msgid "Our focus and mission for this year is in improving diversity and inclusion in Django Girls, ensuring our workshops are accessible to all, specifically including those from marginalised groups."
+msgid ""
+"Our focus and mission for this year is in improving diversity and inclusion "
+"in Django Girls, ensuring our workshops are accessible to all, specifically "
+"including those from marginalised groups."
 msgstr ""
 
 #: templates/donations/donate.html:47
-msgid "We're transparent about our finances. See our <a href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see how we spend donations and what impact they made."
+#, python-format
+msgid ""
+"We're transparent about our finances. See our <a "
+"href=\"%(sixteen_seventeen_url)s\">Annual Report for 2016-2017</a> to see "
+"how we spend donations and what impact they made."
 msgstr ""
 
 #: templates/donations/donate.html:54
@@ -3257,11 +4732,19 @@ msgid "Monthly donations"
 msgstr ""
 
 #: templates/donations/donate.html:75
-msgid "If you would like to setup a recurring donation, we encourage you to do so via our <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
+msgid ""
+"If you would like to setup a recurring donation, we encourage you to do so "
+"via our <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon page</a>. Our pledges start at 5 USD per month."
 msgstr ""
 
 #: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1QVS4_eWu-cZyvbK5-G0x4sXkDg9Xx6eY/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#, python-format
+msgid ""
+"Are you a company interested in sponsoring us? Our <a href=\"https://drive."
+"google.com/file/d/1fAmyAiEyLGiE0s6_z3PzgLByHNKzEVHB/view?"
+"usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
 msgstr ""
 
 #: templates/donations/donate.html:105
@@ -3269,11 +4752,16 @@ msgid "One-time donations"
 msgstr ""
 
 #: templates/donations/donate.html:107
-msgid "You can send us a one-time donation via PayPal to <a href=\"mailto:hello@djangogirls.org\">hello@djangogirls.org</a>"
+msgid ""
+"You can send us a one-time donation via PayPal to <a href=\"mailto:"
+"hello@djangogirls.org\">hello@djangogirls.org</a>"
 msgstr ""
 
 #: templates/donations/donate.html:114
-msgid "If you would like to discuss a bigger partnership or a corporate sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
+#, python-format
+msgid ""
+"If you would like to discuss a bigger partnership or a corporate "
+"sponsorship, <a href=\"%(contact_url)s\">please get in touch.</a>"
 msgstr ""
 
 #: templates/donations/donate.html:121
@@ -3293,15 +4781,10 @@ msgid "Humble Bundle Store"
 msgstr ""
 
 #: templates/donations/donate.html:149
-msgid "If you like video games, you can choose Django Girls as your designated charity in the <a href=\"https://www.humblebundle.com/store?charity=129929\">Humble Bundle Store</a>! 🎮"
-msgstr ""
-
-#: templates/donations/donate.html:155
-msgid "Amazon Smile"
-msgstr ""
-
-#: templates/donations/donate.html:157
-msgid "When you shop at <a href=\"https://smile.amazon.co.uk/ch/1163260-0\">AmazonSmile</a>, Amazon will make a donation to the Django Girls Foundation on your behalf if you select us as your chosen charity! Please help support our work by choosing us today. 🛒"
+msgid ""
+"If you like video games, you can choose Django Girls as your designated "
+"charity in the <a href=\"https://www.humblebundle.com/store?"
+"charity=129929\">Humble Bundle Store</a>! 🎮"
 msgstr ""
 
 #: templates/donations/donate.html:161
@@ -3317,11 +4800,26 @@ msgid "Django Girls Awesomeness Ambassador:"
 msgstr ""
 
 #: templates/donations/donate.html:174
-msgid "In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time contractor</a> to help with the daily operations of the organization. After year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at Mapbox."
+msgid ""
+"In September 2015, <a href=\"http://blog.djangogirls.org/post/127160095788/"
+"meet-our-awesomeness-ambassador-lucie\">the Foundation hired a part-time "
+"contractor</a> to help with the daily operations of the organization. After "
+"year and a half, Django Girls’ 1st Awesomeness Ambassador <a href=\"http://"
+"blog.djangogirls.org/post/128559723068/your-django-story-meet-lucie-daeye\"> "
+"Lucie Daeye</a> resigned to start her new adventure as Systems Engineer at "
+"Mapbox."
 msgstr ""
 
 #: templates/donations/donate.html:182
-msgid "In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined us as our Awesomeness Ambassador to take over from where Lucie left. <a href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness Ambassador, is in charge of responding to organizer's requests, handling our mail, improving our processes, doing administrative tasks, updating the blog and newsletter, and maintaining the website and resources."
+msgid ""
+"In June 2017, <a href=\"https://blog.djangogirls.org/post/161441111423/"
+"claire-wicher-joins-django-girls-as-awesomeness\"> Claire Wicher</a> joined "
+"us as our Awesomeness Ambassador to take over from where Lucie left. <a "
+"href=\"https://blog.djangogirls.org/post/161441111423/claire-wicher-joins-"
+"django-girls-as-awesomeness\">Claire Wicher</a> as our Awesomeness "
+"Ambassador, is in charge of responding to organizer's requests, handling our "
+"mail, improving our processes, doing administrative tasks, updating the blog "
+"and newsletter, and maintaining the website and resources."
 msgstr ""
 
 #: templates/donations/donate.html:191 templates/donations/donate.html:211
@@ -3333,11 +4831,20 @@ msgid "Django Girls Fundraising Coordinator:"
 msgstr ""
 
 #: templates/donations/donate.html:196
-msgid "In June 2017, we introduced the role of <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> Fundraising Coordinator</a> to help with coordinating the fundraising activities of the organization. <a href=\"https://blog.djangogirls.org/post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</a> as our Fundraising Coordinator engages sponsors and the community to get funding to ensure the organization remains sustainable."
+msgid ""
+"In June 2017, we introduced the role of <a href=\"https://blog.djangogirls."
+"org/post/162673547790/anna-makarudze-joins-as-the-django-girls\"> "
+"Fundraising Coordinator</a> to help with coordinating the fundraising "
+"activities of the organization. <a href=\"https://blog.djangogirls.org/"
+"post/162673547790/anna-makarudze-joins-as-the-django-girls\">Anna Makarudze</"
+"a> as our Fundraising Coordinator engages sponsors and the community to get "
+"funding to ensure the organization remains sustainable."
 msgstr ""
 
 #: templates/donations/donate.html:205
-msgid "In August 2020, we also asked her to help us by providing technical support for our website, and help maintain and keep our website up-to-date."
+msgid ""
+"In August 2020, we also asked her to help us by providing technical support "
+"for our website, and help maintain and keep our website up-to-date."
 msgstr ""
 
 #: templates/donations/donate.html:213
@@ -3345,11 +4852,15 @@ msgid "Django Girls Summit:"
 msgstr ""
 
 #: templates/donations/donate.html:216
-msgid "Django Girls Summit is a two days unconference where organizers will meet and share their experiences about Django Girls workshops."
+msgid ""
+"Django Girls Summit is a two days unconference where organizers will meet "
+"and share their experiences about Django Girls workshops."
 msgstr ""
 
 #: templates/donations/donate.html:223
-msgid "Your donations will help us organize this event and give financial assistance to conference's attendees who need it."
+msgid ""
+"Your donations will help us organize this event and give financial "
+"assistance to conference's attendees who need it."
 msgstr ""
 
 #: templates/donations/error.html:7
@@ -3364,16 +4875,52 @@ msgstr ""
 msgid "Back to donation page"
 msgstr ""
 
+#: templates/donations/sponsors.html:8
+msgid "Our Global Partners"
+msgstr ""
+
+#: templates/donations/sponsors.html:11
+#, python-format
+msgid ""
+"Our global partners are companies who are supporting our work by donating to "
+"us either monthly through <a href=\"https://www.patreon.com/djangogirls\" "
+"target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join "
+"these amazing companies in sponsoring us? Our <a href=\"https://drive.google."
+"com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate "
+"sponsorships</a> start at 100 USD per month. <a "
+"href=\"%(contact_url)s\">Contact us!</a> 📨"
+msgstr ""
+
+#: templates/donations/sponsors.html:21
+msgid "Diamond - $10,000+ per year 💞✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:40
+msgid "Platinum - $5,000+ per year 💝✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:59
+msgid "Gold - $2,500+ per year 💖✨"
+msgstr ""
+
+#: templates/donations/sponsors.html:78
+msgid "Silver - $1,000+ per year 💗✨"
+msgstr ""
+
 #: templates/donations/success.html:8
+#, python-format
 msgid "Thank you for your contribution of %(currency)s%(amount)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:3
+#, python-format
 msgid "Hello team %(city)s!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:5
-msgid "Congratulations on running your own Django Girls event! We're super proud and so so so happy for you :)"
+msgid ""
+"Congratulations on running your own Django Girls event! We're super proud "
+"and so so so happy for you :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:8
@@ -3381,7 +4928,12 @@ msgid "Numbers"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:10
-msgid "Whenever you have a little bit of time, we would be super grateful if you could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Whenever you have a little bit of time, we would be super grateful if you "
+"could <a href=\"%(base_url)s%(event_url)s\">fill out this form</a> to "
+"provide information how many people attended your workshop. This will help "
+"us show the global impact that Django Girls is having on the world! :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:17
@@ -3389,7 +4941,10 @@ msgid "Tell us how it went!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:18
-msgid "We’d love to hear from you more about the workshop: how it went? Have you enjoyed it? What was your favourite moment of it? We wanna hear *everything* :)"
+msgid ""
+"We’d love to hear from you more about the workshop: how it went? Have you "
+"enjoyed it? What was your favourite moment of it? We wanna hear "
+"*everything* :)"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:22
@@ -3397,7 +4952,12 @@ msgid "Share your experiences"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:23
-msgid "If you want to write on your experience as an organizer or share with the community all the awesome things that happened during your event, you can write a post on our blog. You did something cool: don't be shy and brag about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here.</a>"
+msgid ""
+"If you want to write on your experience as an organizer or share with the "
+"community all the awesome things that happened during your event, you can "
+"write a post on our blog. You did something cool: don't be shy and brag "
+"about it! <a href=\"http://blog.djangogirls.org/submit\">You can do it here."
+"</a>"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:27
@@ -3405,7 +4965,10 @@ msgid "Upload your photos"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:28
-msgid "If you would like to add photos from your event to our <a href=\"https://www.flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we will provide you with information how to do it."
+msgid ""
+"If you would like to add photos from your event to our <a href=\"https://www."
+"flickr.com/photos/djangogirls/\">Flickr account</a>, just let us know and we "
+"will provide you with information how to do it."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:32
@@ -3413,7 +4976,11 @@ msgid "Donation"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:34
-msgid "If you have any money leftover from your workshop, consider <a href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls Foundation</a>, a non-profit that supports organizers all over the world."
+#, python-format
+msgid ""
+"If you have any money leftover from your workshop, consider <a "
+"href=\"%(base_url)s%(donations_url)s\">donating it to Django Girls "
+"Foundation</a>, a non-profit that supports organizers all over the world."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:41
@@ -3421,11 +4988,19 @@ msgid "Discount in our store"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:42
-msgid "Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a href=\"https://store.djangogirls.org\">in our store</a>. You can share this code with your coaches and attendees. All proceeds will go to Django Girls Foundation (non-profit organization)."
+#, python-format
+msgid ""
+"Use the code \"%(discount_code)s\" to get a 15%% discount on your order <a "
+"href=\"https://store.djangogirls.org\">in our store</a>. You can share this "
+"code with your coaches and attendees. All proceeds will go to Django Girls "
+"Foundation (non-profit organization)."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:49
-msgid "If you want to plan another event someday, don't hesitate to fill out the <a href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
+#, python-format
+msgid ""
+"If you want to plan another event someday, don't hesitate to fill out the <a "
+"href=\"%(base_url)s%(organize_url)s\">organizing form again</a>."
 msgstr ""
 
 #: templates/emails/event_thank_you.html:55
@@ -3433,9 +5008,9 @@ msgid "Thanks and congrats yet again, you're awesome!"
 msgstr ""
 
 #: templates/emails/event_thank_you.html:58
-#: templates/emails/existing_user.html:43 templates/emails/new_user.html:45
+#: templates/emails/existing_user.html:39 templates/emails/new_user.html:46
 #: templates/emails/organize/application_confirmation.html:36
-#: templates/emails/organize/event_deployed.html:95
+#: templates/emails/organize/event_deployed.html:94
 #: templates/emails/submit_information_email.html:16
 msgid "Hugs, rainbows and sunshines!"
 msgstr ""
@@ -3446,10 +5021,12 @@ msgid "Hi there!"
 msgstr ""
 
 #: templates/emails/existing_user.html:5
+#, python-format
 msgid "Congrats! You can now manage %(event)s event!"
 msgstr ""
 
 #: templates/emails/existing_user.html:7
+#, python-format
 msgid "The website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3458,29 +5035,39 @@ msgid "To manage it, login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/existing_user.html:17
+#, python-format
 msgid "Email: %(email)s<br /> Use your existing password."
 msgstr ""
 
 #: templates/emails/existing_user.html:23 templates/emails/new_user.html:23
-msgid "Here you can find instructions on editing website: https://organize.djangogirls.org/website/"
+msgid ""
+"Here you can find instructions on editing website: https://organize."
+"djangogirls.org/website/"
 msgstr ""
 
 #: templates/emails/existing_user.html:26
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "    Your event's email is %(email)s. Ask the main organizer of you event\n"
 "    for password and instructions to access it.\n"
-""
 msgstr ""
 
-#: templates/emails/existing_user.html:33 templates/emails/new_user.html:35
-msgid "You can contact hello@ if you need assistance but it’s usually faster to check our <a href=\"https://faq-organizers.djangogirls.org/\">FAQ</a> or to post questions to the <a href=\"https://groups.google.com/forum/#!forum/django-girls-organizers\"> Google Group of Django Girls Organizers</a> or <a href=\"https://djangogirls.slack.com/messages/general/\"> Slack channel</a> - there are more people that can help you! :)"
+#: templates/emails/existing_user.html:33
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)"
 msgstr ""
 
 #: templates/emails/new_user.html:5
-msgid "Congrats! You're now a Django Girls organizer, so awesome! Here is access to your website:"
+msgid ""
+"Congrats! You're now a Django Girls organizer, so awesome! Here is access to "
+"your website:"
 msgstr ""
 
 #: templates/emails/new_user.html:7
+#, python-format
 msgid "Your website address is https://djangogirls.org/%(page_url)s"
 msgstr ""
 
@@ -3489,21 +5076,37 @@ msgid "Login here:<br /> https://djangogirls.org/admin/"
 msgstr ""
 
 #: templates/emails/new_user.html:17
-msgid "\n"
+#, python-format
+msgid ""
+"\n"
 "  Email: %(email)s<br />\n"
 "  Password: %(password)s\n"
-""
 msgstr ""
 
 #: templates/emails/new_user.html:26
-msgid "Your event's email is %(email)s. Ask the main organizer of you event for password and instructions to access it."
+#, python-format
+msgid ""
+"Your event's email is %(email)s. Ask the main organizer of you event for "
+"password and instructions to access it."
 msgstr ""
 
-#: templates/emails/new_user.html:32
-msgid "We also invited you to Django Girls Slack, where we chat, communicate and meet each other!"
+#: templates/emails/new_user.html:33
+#, python-format
+msgid ""
+"Click <a href=\"%(slack_invite_link)s\">this link</a> to join <a "
+"href=\"%(slack_invite_link)s\">Django Girls Slack</a>, where we chat, "
+"communicate and meet each other!"
+msgstr ""
+
+#: templates/emails/new_user.html:40
+msgid ""
+"You can contact hello@ if you need assistance but it's usually faster to "
+"check <a href=\"https://djangogirls.slack.com/messages/general/\">Slack "
+"channel</a> - there are more people that can help you! :)*"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:3
+#, python-format
 msgid "Hi team %(event)s!"
 msgstr ""
 
@@ -3512,11 +5115,17 @@ msgid "How are you? We hope you are doing fantastic! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:8
-msgid "We've noticed that the Django Girls %(event.city)s event has no live website or isn’t open for applications yet. Is everything going well with preparations?"
+#, python-format
+msgid ""
+"We've noticed that the Django Girls %(event.city)s event has no live website "
+"or isn’t open for applications yet. Is everything going well with "
+"preparations?"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:14
-msgid "Let us know how it goes. If you're stuck on something, we can definitely help! :)"
+msgid ""
+"Let us know how it goes. If you're stuck on something, we can definitely "
+"help! :)"
 msgstr ""
 
 #: templates/emails/offer_help_email.html:17
@@ -3527,8 +5136,19 @@ msgstr ""
 msgid "Hello,"
 msgstr ""
 
+#: templates/emails/organize/application_confirmation.html:6
+#, python-format
+msgid ""
+"Thank you for submitting the application to organize Django Girls in "
+"%(city)s! Yay!"
+msgstr ""
+
 #: templates/emails/organize/application_confirmation.html:10
-msgid "We’re now going to review your application and get back to you in around a week. Django Girls is a volunteer-run charity, and we’re doing our best to respond in timely fashion. In the meantime, you can familiarise yourself with our free resources for organizers."
+msgid ""
+"We’re now going to review your application and get back to you in around a "
+"week. Django Girls is a volunteer-run charity, and we’re doing our best to "
+"respond in timely fashion. In the meantime, you can familiarise yourself "
+"with our free resources for organizers."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:16
@@ -3540,11 +5160,36 @@ msgid "Being an awesome person - already done! :)"
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:20
-msgid "The event should be <b>free for participants</b>, and <b>women should have a preference</b> in the application process (but men can apply, too). You should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial we've prepared for workshops</a>, and ideally work in small groups of attendees and coaches (each group working at their own pace)."
+msgid ""
+"The event should be <b>free for participants</b>, and <b>women should have a "
+"preference</b> in the application process (but men can apply, too). You "
+"should also use the <a href=\"http://tutorial.djangogirls.org/\">tutorial "
+"we've prepared for workshops</a>, and ideally work in small groups of "
+"attendees and coaches (each group working at their own pace)."
 msgstr ""
 
 #: templates/emails/organize/application_confirmation.html:25
-msgid "Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> and provide <b>safe</b> environments that follow an enforced <a href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember that Django Girls events are not only aimed to teach people about programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgid ""
+"Share our values: Django Girls events are <b>inclusive</b>, <b>friendly</b> "
+"and provide <b>safe</b> environments that follow an enforced <a "
+"href=\"https://djangogirls.org/pages/coc/\">Code of Conduct</a>. Remember "
+"that Django Girls events are not only aimed to teach people about "
+"programming, but to do it in a <b>friendly</b> and <b>positive</b> way."
+msgstr ""
+
+#: templates/emails/organize/application_confirmation.html:33
+#, python-format
+msgid ""
+"Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> "
+"describes quite well the process of organizing a workshop. You can also read "
+"experiences of other organizers on our blog: <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a>."
 msgstr ""
 
 #: templates/emails/organize/application_notification.html:3
@@ -3621,7 +5266,9 @@ msgid "Do you have potential coaches in mind?"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:6
-msgid "Congratulations! Your application to organize Django Girls workshop in your city has been accepted. We’re delighted to have you with us!"
+msgid ""
+"Congratulations! Your application to organize Django Girls workshop in your "
+"city has been accepted. We’re delighted to have you with us!"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:9
@@ -3633,14 +5280,17 @@ msgid "1) Email address"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:13
+#, python-format
 msgid "Your e-mail is %(email)s."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:16
-msgid "\n"
-"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail.djangogirls.org/</a><br/>\n"
+#, python-format
+msgid ""
+"\n"
+"    You can login here: <a href=\"http://mail.djangogirls.org/\">http://mail."
+"djangogirls.org/</a><br/>\n"
 "    Username: %(email)s (@djangogirls.com works too!)<br/>\n"
-""
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:22
@@ -3648,7 +5298,9 @@ msgid "Password:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:24
-msgid "Previous organizers should have password to this account. Let us know if you need to reset it."
+msgid ""
+"Previous organizers should have password to this account. Let us know if you "
+"need to reset it."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:30
@@ -3656,7 +5308,9 @@ msgid "You can also add this inbox to your email client:"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:36
-msgid "Or you can forward incoming mail to your private email account by following these instructions."
+msgid ""
+"Or you can forward incoming mail to your private email account by following "
+"these instructions."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:39
@@ -3664,19 +5318,29 @@ msgid "2) Website"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:42
-msgid "Your website address is <a href=\"https://djangogirls.org/%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
+#, python-format
+msgid ""
+"Your website address is <a href=\"https://djangogirls.org/"
+"%(page_url)s\">https://djangogirls.org/%(page_url)s</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:48
-msgid "You should receive a separate email with auto generated password and instructions to login."
+msgid ""
+"You should receive a separate email with auto generated password and "
+"instructions to login."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:52
-msgid "Your website is currently hidden for public, you can only see it if you’re logged in. If you want to make it available for everyone, go here and edit your website changing the “is live” option."
+msgid ""
+"Your website is currently hidden for public, you can only see it if you’re "
+"logged in. If you want to make it available for everyone, go here and edit "
+"your website changing the “is live” option."
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:59
-msgid "More instructions on editing your website: <a href=\"https://organize.djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
+msgid ""
+"More instructions on editing your website: <a href=\"https://organize."
+"djangogirls.org/website/\">https://organize.djangogirls.org/website/</a>"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:65
@@ -3684,30 +5348,40 @@ msgid "3) Organizers community"
 msgstr ""
 
 #: templates/emails/organize/event_deployed.html:67
-msgid "Django Girls has a growing community of more than 300 organizers. You should receive an invitation to join a private group on Google Groups and Slack -- this is where you can chat with other organisers, ask for their help or advice. Use it wisely and plenty!"
+msgid ""
+"Django Girls has a growing community of more than 2346 organizers. If you "
+"are a new organizer and not already Django Girls Slack, please reach out to "
+"hello@djangogirls.org and we will invite you to join -- this is where you "
+"can chat with other organisers, ask for their help or advice. Use it wisely "
+"and plenty!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:74
+#: templates/emails/organize/event_deployed.html:73
 msgid "4) Postponing or canceling"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:77
-msgid "If you need to cancel or postpone your event, it’s not a problem at all! Please let us know by sending an email and we’ll help."
+#: templates/emails/organize/event_deployed.html:76
+msgid ""
+"If you need to cancel or postpone your event, it’s not a problem at all! "
+"Please let us know by sending an email and we’ll help."
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:83
+#: templates/emails/organize/event_deployed.html:82
 msgid "5) Need more help?"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:86
-msgid "Don’t forget about Organiser’s FAQ, Manual or to post questions to our Google Group of Django Girls Organizers or Slack channel - there are always more people there that can help you! :)"
+#: templates/emails/organize/event_deployed.html:85
+msgid ""
+"Don’t forget about Organiser’s FAQ, Manual or to post questions to our "
+"Google Group of Django Girls Organizers or Slack channel - there are always "
+"more people there that can help you! :)"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:92
+#: templates/emails/organize/event_deployed.html:91
 msgid "Good luck!"
 msgstr ""
 
-#: templates/emails/organize/event_deployed.html:96
+#: templates/emails/organize/event_deployed.html:95
 msgid "Django Girls team"
 msgstr ""
 
@@ -3716,55 +5390,91 @@ msgid "Hello there,"
 msgstr ""
 
 #: templates/emails/organize/rejection.html:6
-msgid "Thank you so much for taking the time to submit an application to organize Django Girls %(city)s workshop."
+#, python-format
+msgid ""
+"Thank you so much for taking the time to submit an application to organize "
+"Django Girls %(city)s workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:12
-msgid "We reviewed your application and we think that you need to do a little bit more planning before we can give you a positive answer. Please read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure you meet all the requirements to host a workshop carefully, and then read experiences of other organizers on our blog: <a href=\"https://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a> to see how much work is required to organize the workshop."
+#, python-format
+msgid ""
+"We reviewed your application and we think that you need to do a little bit "
+"more planning before we can give you a positive answer. Please read our <a "
+"href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a> and ensure "
+"you meet all the requirements to host a workshop carefully, and then read "
+"experiences of other organizers on our blog: <a href=\"https://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"https://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"https://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> or <a href=\"https://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a> to see how much work is required to organize the workshop."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:25
-msgid "When you have more things planned (like potential date, venue, coaches or sponsors), get back to us by filling out the form again."
+msgid ""
+"When you have more things planned (like potential date, venue, coaches or "
+"sponsors), get back to us by filling out the form again."
 msgstr ""
 
 #: templates/emails/organize/rejection.html:29
-msgid "Have a lovely day and thank you again for reaching out to us!<br /> Django Girls team"
+msgid ""
+"Have a lovely day and thank you again for reaching out to us!<br /> Django "
+"Girls team"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:3
+#, python-format
 msgid "Hello team %(event)s!"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:5
-msgid "Hope you’re all doing fantastic and took some well deserved rest after organizing your Django Girls workshop :)"
+msgid ""
+"Hope you’re all doing fantastic and took some well deserved rest after "
+"organizing your Django Girls workshop :)"
 msgstr ""
 
 #: templates/emails/submit_information_email.html:9
-msgid "Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this form</a> to provide information how many people attended your workshop. This will help us show the global impact that Django Girls is having on the world! :)"
+#, python-format
+msgid ""
+"Just a friendly reminder to <a href=\"%(base)s%(event_url)s\">fill out this "
+"form</a> to provide information how many people attended your workshop. This "
+"will help us show the global impact that Django Girls is having on the "
+"world! :)"
 msgstr ""
 
-#: templates/event/base.html:7 templates/global/base.html:7
+#: templates/event/base.html:15 templates/global/base.html:15
 msgid "Django Girls - start your journey with programming"
 msgstr ""
 
-#: templates/event/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django tailored for women."
+#: templates/event/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"tailored for women."
 msgstr ""
 
 #: templates/event/menu.html:7 templates/global/menu.html:7
 msgid "Toggle navigation"
 msgstr ""
 
-#: templates/global/base.html:8
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women."
+#: templates/global/base.html:16
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women."
 msgstr ""
 
-#: templates/global/base.html:12
-msgid "Django Girls is a one-day workshop about programming in Python and Django for women"
+#: templates/global/base.html:20
+msgid ""
+"Django Girls is a one-day workshop about programming in Python and Django "
+"for women"
 msgstr ""
 
-#: templates/global/base.html:14
-msgid "Join us and become a female developer! Build your first website in Python and Django in a friendly, safe environment."
+#: templates/global/base.html:22
+msgid ""
+"Join us and become a female developer! Build your first website in Python "
+"and Django in a friendly, safe environment."
 msgstr ""
 
 #: templates/global/footer.html:10
@@ -3779,12 +5489,12 @@ msgstr ""
 msgid "Chat with us!"
 msgstr ""
 
-#: templates/core/coc.html:10 templates/global/footer.html:13
-msgid "Code of Conduct"
-msgstr ""
-
 #: templates/global/footer.html:14
 msgid "Contact"
+msgstr ""
+
+#: templates/global/footer.html:15 templates/jobboard/index.html:7
+msgid "Job Board"
 msgstr ""
 
 #: templates/global/footer.html:20
@@ -3801,6 +5511,10 @@ msgstr ""
 
 #: templates/global/footer.html:25
 msgid "Sponsor us"
+msgstr ""
+
+#: templates/global/footer.html:26 templates/global/menu.html:33
+msgid "Our Sponsors"
 msgstr ""
 
 #: templates/global/footer.html:30
@@ -3828,22 +5542,27 @@ msgid "Privacy & Cookies"
 msgstr ""
 
 #: templates/global/footer.html:60
+#, python-format
 msgid "<b>%(future_events_count)s</b> upcoming events"
 msgstr ""
 
 #: templates/global/footer.html:61
+#, python-format
 msgid "<b>%(past_events_count)s</b> past events"
 msgstr ""
 
-#: templates/global/footer.html:60
-msgid "<b>%(applicants_sum|default_if_none:'0')s</b> applicants"
+#: templates/global/footer.html:62
+#, python-format
+msgid "<b>%(applicants_sum)s</b> applicants"
 msgstr ""
 
-#: templates/global/footer.html:61
-msgid "<b>%(attendees_sum|default_if_none:'0')s</b> attendees"
+#: templates/global/footer.html:63
+#, python-format
+msgid "<b>%(attendees_sum)s</b> attendees"
 msgstr ""
 
 #: templates/global/footer.html:64
+#, python-format
 msgid "<b>%(countries_count)s</b> countries"
 msgstr ""
 
@@ -3855,8 +5574,12 @@ msgstr ""
 msgid "Blog"
 msgstr ""
 
-#: templates/global/menu.html:28
-msgid "Support us 💕"
+#: templates/global/menu.html:25
+msgid "Jobs"
+msgstr ""
+
+#: templates/global/menu.html:29
+msgid "Donate to us 💕"
 msgstr ""
 
 #: templates/global/menu.html:31
@@ -3876,7 +5599,11 @@ msgid "Q: How can I register?"
 msgstr ""
 
 #: templates/includes/_faq.html:11
-msgid "A: You want to attend a workshop happening in your city? So cool! You can register on the event's website. If there is no website, it means that registrations are not opened yet. Come back in a few days to check or send an email to the local organizers of the workshop you want to attend."
+msgid ""
+"A: You want to attend a workshop happening in your city? So cool! You can "
+"register on the event's website. If there is no website, it means that "
+"registrations are not opened yet. Come back in a few days to check or send "
+"an email to the local organizers of the workshop you want to attend."
 msgstr ""
 
 #: templates/includes/_faq.html:23
@@ -3884,7 +5611,12 @@ msgid "Q: I missed the deadline! Can I still apply to a workshop?"
 msgstr ""
 
 #: templates/includes/_faq.html:29
-msgid "A: Sadly, you won't be able to apply: events receive many applications and already have a waiting list in case an attendee has to cancel. You can subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where the next events are planed."
+#, python-format
+msgid ""
+"A: Sadly, you won't be able to apply: events receive many applications and "
+"already have a waiting list in case an attendee has to cancel. You can "
+"subscribe to our <a href=\"%(newsletter_url)s\">newsletter</a> to know where "
+"the next events are planed."
 msgstr ""
 
 #: templates/includes/_faq.html:41
@@ -3892,15 +5624,23 @@ msgid "Q: I want to coach or sponsor an event!"
 msgstr ""
 
 #: templates/includes/_faq.html:45
-msgid "A: You rock! Just send an email to the local organizers of the workshop!"
+msgid ""
+"A: You rock! Just send an email to the local organizers of the workshop!"
 msgstr ""
 
 #: templates/includes/_faq.html:52
-msgid "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?"
+msgid ""
+"Q: I'm following Django Girls tutorial and something is not working in my "
+"code: can you help me debug it?"
 msgstr ""
 
 #: templates/includes/_faq.html:57
-msgid "A: Sadly, Django Girls Support Team won't be able to help you: our work is to help other organizers plan their workshop. If you need assistance while doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/\">Django Girls Gitter room</a>: a group of volunteers is waiting for you there and will be happy to answer all your questions ;)"
+msgid ""
+"A: Sadly, Django Girls Support Team won't be able to help you: our work is "
+"to help other organizers plan their workshop. If you need assistance while "
+"doing the tutorial, go to <a href=\"https://gitter.im/DjangoGirls/tutorial/"
+"\">Django Girls Gitter room</a>: a group of volunteers is waiting for you "
+"there and will be happy to answer all your questions ;)"
 msgstr ""
 
 #: templates/includes/_no_event.html:5
@@ -3912,7 +5652,8 @@ msgid "Sign up for our newsletter"
 msgstr ""
 
 #: templates/includes/_no_event.html:13
-msgid "Stay up to date with everything that's happening in Django Girls valley:"
+msgid ""
+"Stay up to date with everything that's happening in Django Girls valley:"
 msgstr ""
 
 #: templates/includes/_no_event.html:16
@@ -3924,11 +5665,38 @@ msgid "Your city"
 msgstr ""
 
 #: templates/includes/_no_event.html:27
-msgid "Everyone can organize their own Django Girls event and share it with their community."
+msgid ""
+"Everyone can organize their own Django Girls event and share it with their "
+"community."
 msgstr ""
 
 #: templates/includes/_no_event.html:29
 msgid "Find out more"
+msgstr ""
+
+#: templates/jobboard/index.html:11
+msgid ""
+" Django Girls global partners are hiring! Want to see your job posted "
+"here? \n"
+"            <a href=\"/contact/\">Contact us</a> about becoming a global "
+"partner for Django Girls \n"
+"            and recruit the best talent for your organization. "
+msgstr ""
+
+#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
+msgid "Apply here"
+msgstr ""
+
+#: templates/jobboard/index.html:43
+msgid "More information"
+msgstr ""
+
+#: templates/jobboard/index.html:57
+msgid "Sorry, no job openings at the moment."
+msgstr ""
+
+#: templates/jobboard/job.html:26
+msgid "Sorry the job listing does not exist."
 msgstr ""
 
 #: templates/organize/commitment.html:20
@@ -3936,23 +5704,36 @@ msgid "Django Girls Organizer Commitement"
 msgstr ""
 
 #: templates/organize/commitment.html:23
-msgid "Django Girls is an initiative aimed at introducing women who have never coded before to the world of technology and increasing the diversity within the tech industry. We do that by organizing workshops and inviting women to join us to learn how to build the internet using HTML, CSS, Python and Django <strong>in a safe, friendly and inclusive environment.</strong>"
+msgid ""
+"Django Girls is an initiative aimed at introducing women who have never "
+"coded before to the world of technology and increasing the diversity within "
+"the tech industry. We do that by organizing workshops and inviting women to "
+"join us to learn how to build the internet using HTML, CSS, Python and "
+"Django <strong>in a safe, friendly and inclusive environment.</strong>"
 msgstr ""
 
 #: templates/organize/commitment.html:31
-msgid "As a Django Girls Organizer, you make a commitement to foster and advance Django Girls values:"
+msgid ""
+"As a Django Girls Organizer, you make a commitement to foster and advance "
+"Django Girls values:"
 msgstr ""
 
 #: templates/organize/commitment.html:35
-msgid "The workshop you organize will strive to provide safe, inclusive, friendly and positive experience for everyone attending and coaching"
+msgid ""
+"The workshop you organize will strive to provide safe, inclusive, friendly "
+"and positive experience for everyone attending and coaching"
 msgstr ""
 
 #: templates/organize/commitment.html:39
-msgid "<span>You will require everyone involved with the workshop to comply with <a href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
+#, python-format
+msgid ""
+"<span>You will require everyone involved with the workshop to comply with <a "
+"href=\"%(coc_url)s\">Django Girls Code of Conduct</a></span>"
 msgstr ""
 
 #: templates/organize/commitment.html:44
-msgid "You’ll strive to have tons of fun while organizing your amazing workshop!"
+msgid ""
+"You’ll strive to have tons of fun while organizing your amazing workshop!"
 msgstr ""
 
 #: templates/organize/commitment.html:49
@@ -3964,7 +5745,10 @@ msgid "Welcome to Django Girls!"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:12
-msgid "We’re delighted to welcome you as a part of Django Girls family! We’ve deployed your event’s website now and an information pack with access details is on the way to your inbox right now."
+msgid ""
+"We’re delighted to welcome you as a part of Django Girls family! We’ve "
+"deployed your event’s website now and an information pack with access "
+"details is on the way to your inbox right now."
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:14
@@ -3984,7 +5768,8 @@ msgid "Our private community of organizers on Slack (a group chat application)"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:27
-msgid "Workshop Box, a starter kit full of goodies and decorations for your event"
+msgid ""
+"Workshop Box, a starter kit full of goodies and decorations for your event"
 msgstr ""
 
 #: templates/organize/confirmation-of-acceptance.html:31
@@ -3995,12 +5780,96 @@ msgstr ""
 msgid "Good luck and see you on Slack 👋<br />Django Girls Team"
 msgstr ""
 
+#: templates/organize/event_funding.html:6
+msgid "Apply for Sponsorship from our Global Partners"
+msgstr ""
+
+#: templates/organize/event_funding.html:8
+msgid ""
+"Some of our global partners also fund Django Girls workshops. However, they "
+"prefer that Django Girls Foundation handle the sponsorship application "
+"process and they only handle sending the money to the workshop organizers. "
+"Django Girls has done this in the past with GitHub sponsorships though that "
+"is no longer available."
+msgstr ""
+
+#: templates/organize/event_funding.html:15
+msgid ""
+"Starting November 2023, Django Girls will be handling sponsorship "
+"applications for workshops. The organisations Django Girls are handling the "
+"sponsorship process are listed below with the terms and conditions of the "
+"sponsorship."
+msgstr ""
+
+#: templates/organize/event_funding.html:23
+msgid ""
+"Starting November 2023, sponsorship applications to the DSF will be handled "
+"by Django Girls Foundation. The terms and conditions of this sponsorship as "
+"laid out by the DSF are as follows:"
+msgstr ""
+
+#: templates/organize/event_funding.html:29
+msgid ""
+"The DSF has set aside a limited budget for Django Girls workshops "
+"sponsorship spread out through the year. For this reason, they will only "
+"sponsorship only one event per city per year (within 12 months)."
+msgstr ""
+
+#: templates/organize/event_funding.html:35
+msgid ""
+"The typical DSF sponsorship will be $300 per event, or $500 when the "
+"assumption is that the group has large needs and difficulty fundraising or "
+"events outside of the US or Western Europe."
+msgstr ""
+
+#: templates/organize/event_funding.html:40
+msgid ""
+"The DSF funds events, not long term boot camps therefore this application "
+"form should only be used for Django Girls workshop applications only."
+msgstr ""
+
+#: templates/organize/event_funding.html:45
+msgid "The DSF's support has to be publicly recognised and acknowledged."
+msgstr ""
+
+#: templates/organize/event_funding.html:46
+msgid ""
+"The DSF has to receive a report of the event via their email <a "
+"href=\"mailto:dsfboard@googlegroups.com\">dsfboard@googlegroups.com</a> "
+"which should be copied to <a href=\"mailto:hello@djangogirls."
+"org\">hello@djangogirls.org</a>."
+msgstr ""
+
+#: templates/organize/event_funding.html:53
+msgid ""
+"In your application, please share your budget and if your budget "
+"requirements are more than the funding the DSF can provide, also share your "
+"other funding sources and how you wish to offset the deficit. Funding from "
+"the DSF will only be approved once we are sure that the event will indeed "
+"take place because your event has adequate funding. The DSF will only fund "
+"events whose costs are appropriate, realistic and have a solid plan for the "
+"remaining funds."
+msgstr ""
+
+#: templates/organize/event_funding.html:60
+msgid ""
+"To apply for DSF funding, please fill in <a href=\"https://docs.google.com/"
+"forms/d/1KBQKnwY0uFBB0R7HOJIA3VAr9PsUywnp-9yX9El9-Wk/viewform\">this form</"
+"a>.\""
+msgstr ""
+
+#: templates/organize/form/step1_previous_event.html:31
+#: templates/organize/form/step2_application.html:25
+msgid "Application to organize a workshop"
+msgstr ""
+
 #: templates/organize/form/step1_previous_event.html:45
 msgid "Have you organized a Django Girls workshop before?"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:48
-msgid "If so, the form will be much shorter as we already know a lot about you! :)"
+msgid ""
+"If so, the form will be much shorter as we already know a lot about you! :)"
 msgstr ""
 
 #: templates/organize/form/step1_previous_event.html:80
@@ -4009,17 +5878,16 @@ msgstr ""
 msgid "Go to next step"
 msgstr ""
 
-#: templates/organize/form/step1_previous_event.html:31
-#: templates/organize/form/step2_application.html:25
-msgid "Application to organize a workshop"
-msgstr ""
-
 #: templates/organize/form/step2_application.html:39
-msgid "Tell us a little bit about yourself. What’s your background and daily occupation?"
+msgid ""
+"Tell us a little bit about yourself. What’s your background and daily "
+"occupation?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:56
-msgid "What motivated or inspired you to do it? What is your goal in organizing an event?"
+msgid ""
+"What motivated or inspired you to do it? What is your goal in organizing an "
+"event?"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:73
@@ -4027,7 +5895,9 @@ msgid "Check boxes next to all the things that describe you"
 msgstr ""
 
 #: templates/organize/form/step2_application.html:95
-msgid "If you helped organize a different workshop or event before, or are involved in your local community, we’d love to hear about it!"
+msgid ""
+"If you helped organize a different workshop or event before, or are involved "
+"in your local community, we’d love to hear about it!"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:25
@@ -4057,6 +5927,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:71
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1638
 msgid "Email address"
 msgstr ""
 
@@ -4065,7 +5936,10 @@ msgid "Your organizing team"
 msgstr ""
 
 #: templates/organize/form/step3_organizers.html:86
-msgid "Who is going to organize this event with you? Please confirm with your co-organizers that they agreed for you to provide their information here. They will be able to access your event’s emails and edit your event’s website."
+msgid ""
+"Who is going to organize this event with you? Please confirm with your co-"
+"organizers that they agreed for you to provide their information here. They "
+"will be able to access your event’s emails and edit your event’s website."
 msgstr ""
 
 #: templates/organize/form/step4_workshop_type.html:25
@@ -4091,10 +5965,6 @@ msgstr ""
 #: templates/organize/form/step5_workshop.html:32
 #: templates/organize/form/step5_workshop_remote.html:32
 msgid "Tell us all about your Django Girls event!"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:34
-msgid "Please know that we are only accepting applications for remote workshops at this time."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:46
@@ -4124,7 +5994,10 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:85
 #: templates/organize/form/step5_workshop_remote.html:85
-msgid "There should be <b>at least 3 months</b> between now and your event's date, and <b>6 months</b> after the previous workshop in that region. Please enter your date in dd/mm/yyyy format."
+msgid ""
+"There should be <b>at least 3 months</b> between now and your event's date, "
+"and <b>6 months</b> after the previous workshop in that region. Please enter "
+"your date in dd/mm/yyyy format."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:89
@@ -4143,43 +6016,42 @@ msgstr ""
 
 #: templates/organize/form/step5_workshop.html:122
 #: templates/organize/form/step5_workshop_remote.html:104
-msgid "It doesn’t need to be very specific yet, but we would love to see your ideas."
+msgid ""
+"It doesn’t need to be very specific yet, but we would love to see your ideas."
 msgstr ""
 
 #: templates/organize/form/step5_workshop.html:140
 #: templates/organize/form/step5_workshop_remote.html:122
-msgid "Have you approached them to ask if they would be interested in helping out?"
+msgid ""
+"Have you approached them to ask if they would be interested in helping out?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:176
-msgid "How will you host your in-person workshop during the Covid-19 pandemic?"
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:177
-msgid "Please provide information on how you plan to ensure safety for attendees and coaches for your in-person workshop during the Covid-19 pandemic."
-msgstr ""
-
-#: templates/organize/form/step5_workshop.html:194
+#: templates/organize/form/step5_workshop.html:157
 #: templates/organize/form/step5_workshop_remote.html:157
-msgid "How do you intent to make your workshop inclusive and promote diversity?"
+msgid ""
+"How do you intent to make your workshop inclusive and promote diversity?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:195
+#: templates/organize/form/step5_workshop.html:158
 #: templates/organize/form/step5_workshop_remote.html:158
-msgid "Please tell us how you intend to make sure your workshop is inclusive to people from marginalised communities and promote diversity."
+msgid ""
+"Please tell us how you intend to make sure your workshop is inclusive to "
+"people from marginalised communities and promote diversity."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:212
+#: templates/organize/form/step5_workshop.html:175
 #: templates/organize/form/step5_workshop_remote.html:175
 msgid "Any additional you may want to share with us?"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:213
+#: templates/organize/form/step5_workshop.html:176
 #: templates/organize/form/step5_workshop_remote.html:176
-msgid "Please provide any additional information you may want to share with us and may think may help your application."
+msgid ""
+"Please provide any additional information you may want to share with us and "
+"may think may help your application."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:258
+#: templates/organize/form/step5_workshop.html:200
 #: templates/organize/form/step5_workshop_remote.html:200
 msgid "Finish!"
 msgstr ""
@@ -4189,7 +6061,9 @@ msgid "How will you host your workshop remotely?"
 msgstr ""
 
 #: templates/organize/form/step5_workshop_remote.html:140
-msgid "Please provide information on how you plan to host your workshop remotely, that is, what tools will you use."
+msgid ""
+"Please provide information on how you plan to host your workshop remotely, "
+"that is, what tools will you use."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:15
@@ -4197,23 +6071,39 @@ msgid "You rock!"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:17
-msgid "Thank you so much for taking the time to submit your application to organize the Django Girls workshop in your city. We’re now going to review your application and will get back to you shortly."
+msgid ""
+"Thank you so much for taking the time to submit your application to organize "
+"the Django Girls workshop in your city. We’re now going to review your "
+"application and will get back to you shortly."
 msgstr ""
 
 #: templates/organize/form/thank_you.html:19
-msgid "In the meantime, if you want to start planning your workshop, here are few things that can help you:"
+msgid ""
+"In the meantime, if you want to start planning your workshop, here are few "
+"things that can help you:"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:23
-msgid "Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
+msgid ""
+"Read our <a href=\"https://organize.djangogirls.org/\">Organizer’s Manual</a>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:26
-msgid "<span>Read experiences of other organizers in   <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a></span>"
+#, python-format
+msgid ""
+"<span>Read experiences of other organizers in   <a href=\"http://blog."
+"djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, "
+"<a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-"
+"wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog."
+"djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-"
+"namibia\">Windhoek</a> and <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</"
+"a></span>"
 msgstr ""
 
 #: templates/organize/form/thank_you.html:34
-msgid "Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
+msgid ""
+"Get to know our <a href=\"https://coach.djangogirls.org/\">Coaching Guide</a>"
 msgstr ""
 
 #: templates/organize/index.html:9
@@ -4221,11 +6111,13 @@ msgid "Organize Django Girls workshop"
 msgstr ""
 
 #: templates/organize/index.html:16
-msgid "Django Girls events are organized by groups of wonderful volunteers in cities all over the world. Events are always non-profit and free for participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or organizers. Attendees don’t need any previous knowledge about programming and there are no age limitations. All attendees need is a laptop and some curiosity!"
-msgstr ""
-
-#: templates/organize/index.html:25
-msgid "As of 2020, Django Girls workshops can only be held remotely. This is due to the ongoing Global Pandemic, and allows workshops continue while ensuring the safety of our organisers, volunteers and participants. We will review this decision in 2021, and hope to also allow for in-person workshops as soon as it is safe to do so."
+msgid ""
+"Django Girls events are organized by groups of wonderful volunteers in "
+"cities all over the world. Events are always non-profit and free for "
+"participants. We <strong><u>DO NOT PAY</u></strong> coaches, speakers or "
+"organizers. Attendees don’t need any previous knowledge about programming "
+"and there are no age limitations. All attendees need is a laptop and some "
+"curiosity!"
 msgstr ""
 
 #: templates/organize/index.html:24
@@ -4233,15 +6125,24 @@ msgid "In-Person Workshops"
 msgstr ""
 
 #: templates/organize/index.html:27
-msgid "An in-person workshop is any workshop where participants, coaches, and organisers, all meet in the same physical location. Participants can work together in teams and support from coaches is done face-to-face."
+msgid ""
+"An in-person workshop is any workshop where participants, coaches, and "
+"organisers, all meet in the same physical location. Participants can work "
+"together in teams and support from coaches is done face-to-face."
 msgstr ""
 
 #: templates/organize/index.html:34
-msgid "These workshops should only be conducted when it is safe to do so, and you may be asked in your application to provide evidence of why you feel this type of worshops is safe, and what, if any, safety measures you will be putting in place."
+msgid ""
+"These workshops should only be conducted when it is safe to do so, and you "
+"may be asked in your application to provide evidence of why you feel this "
+"type of worshops is safe, and what, if any, safety measures you will be "
+"putting in place."
 msgstr ""
 
 #: templates/organize/index.html:42
-msgid "If you are not sure if it is safe to hold an in-person workshop, you might prefer to organise a remote workshop instead."
+msgid ""
+"If you are not sure if it is safe to hold an in-person workshop, you might "
+"prefer to organise a remote workshop instead."
 msgstr ""
 
 #: templates/organize/index.html:47
@@ -4249,15 +6150,26 @@ msgid "Remote Workshops"
 msgstr ""
 
 #: templates/organize/index.html:50
-msgid "A remote workshop is a workshop conducted online, where participants, coaches and organisers are in different physical locations."
+msgid ""
+"A remote workshop is a workshop conducted online, where participants, "
+"coaches and organisers are in different physical locations."
 msgstr ""
 
 #: templates/organize/index.html:57
-msgid "This type of workshop may be more suitable in situations where it might not be safe, affordable, or logistically possible to host a workshop in-person, or where difficulties finding sponsorship would be a barrier to running to the workshop in-person. Remote workshops also allow for more flexibility with the location of your attendees and coaches."
+msgid ""
+"This type of workshop may be more suitable in situations where it might not "
+"be safe, affordable, or logistically possible to host a workshop in-person, "
+"or where difficulties finding sponsorship would be a barrier to running to "
+"the workshop in-person. Remote workshops also allow for more flexibility "
+"with the location of your attendees and coaches."
 msgstr ""
 
 #: templates/organize/index.html:67
-msgid "Since July 2014, <span>%(organizers_count)s</span> volunteers organized <span>%(past_events_count)s</span> Django Girls workshops. Join them and <a href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
+#, python-format
+msgid ""
+"Since July 2014, <span>%(organizers_count)s</span> volunteers organized "
+"<span>%(past_events_count)s</span> Django Girls workshops. Join them and <a "
+"href=\"%(prerequisites_url)s\">bring Django Girls to your city!</a>"
 msgstr ""
 
 #: templates/organize/index.html:73
@@ -4265,7 +6177,9 @@ msgid "The Value of Organizing Django Girls"
 msgstr ""
 
 #: templates/organize/index.html:77
-msgid "Join a crowd of over 500 passionate, kind and helpful organizers all over the world"
+msgid ""
+"Join a crowd of over 500 passionate, kind and helpful organizers all over "
+"the world"
 msgstr ""
 
 #: templates/organize/index.html:80
@@ -4297,31 +6211,50 @@ msgid "Django Girls Workshop Tutorial"
 msgstr ""
 
 #: templates/organize/index.html:108
+msgid "Apply for Event Sponsorship"
+msgstr ""
+
+#: templates/organize/index.html:111
 msgid "Private mailing list &amp; Slack"
 msgstr ""
 
-#: templates/organize/index.html:121
-msgid "Django Girls helped me gain more self-confidence and gave me a boost to keep learning. I’ve created my own blog and then prepared workshops and taught other women to code. Nothing is impossible with this bunch of positive people!"
+#: templates/organize/index.html:124
+msgid ""
+"Django Girls helped me gain more self-confidence and gave me a boost to keep "
+"learning. I’ve created my own blog and then prepared workshops and taught "
+"other women to code. Nothing is impossible with this bunch of positive "
+"people!"
 msgstr ""
 
-#: templates/organize/index.html:127
+#: templates/organize/index.html:130
 msgid "Agata Grdal, organizer of Django Girls Wrocław"
 msgstr ""
 
-#: templates/organize/index.html:134
+#: templates/organize/index.html:137
 msgid "Experiences of Django Girls organizers"
 msgstr ""
 
-#: templates/organize/index.html:142
-msgid "Organizers of Django Girls Windhoek, Namibia share their experience of organizing an event in Africa. <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:145
+msgid ""
+"Organizers of Django Girls Windhoek, Namibia share their experience of "
+"organizing an event in Africa. <a href=\"http://blog.djangogirls.org/"
+"post/139654610313/django-girls-workshop-in-windhoek-namibia\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:151
-msgid "A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:154
+msgid ""
+"A Toolkit of Awesome: tips &amp; tricks from seasoned Django Girls "
+"organizers in Budapest, Hungary. <a href=\"http://blog.djangogirls.org/"
+"post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Read "
+"more&nbsp;»</a>"
 msgstr ""
 
-#: templates/organize/index.html:160
-msgid "Learn how Django Girls Seoul built a local tech community using events as their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
+#: templates/organize/index.html:163
+msgid ""
+"Learn how Django Girls Seoul built a local tech community using events as "
+"their main tool. <a href=\"http://blog.djangogirls.org/post/152858499038/"
+"django-girls-seoul-workshop-2\">Read more&nbsp;»</a>"
 msgstr ""
 
 #: templates/organize/prerequisites.html:29
@@ -4329,19 +6262,17 @@ msgid "Prerequisities to organize a Django Girls workshop"
 msgstr ""
 
 #: templates/organize/prerequisites.html:32
-msgid "Yay! You want to organize a Django Girls workshop! That’s wonderful. Before we can get you started, there are few things requirements that we’d like to confirm with you to make sure your workshop is going to be planned as smoothly as possible:"
+msgid ""
+"Yay! You want to organize a Django Girls workshop! That’s wonderful. Before "
+"we can get you started, there are few things requirements that we’d like to "
+"confirm with you to make sure your workshop is going to be planned as "
+"smoothly as possible:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:42
-msgid "Confirm that you understand that we are only accepting applications for remote workshops at this time:"
-msgstr ""
-
-#: templates/organize/prerequisites.html:48
-msgid "The event you're organizing will be remote"
-msgstr ""
-
-#: templates/organize/prerequisites.html:42
-msgid "Confirm that you’ve read the following chapters of our <a href=\"http://organize.djangogirls.org/\">Organizer's Manual</a>:"
+msgid ""
+"Confirm that you’ve read the following chapters of our <a href=\"http://"
+"organize.djangogirls.org/\">Organizer's Manual</a>:"
 msgstr ""
 
 #: templates/organize/prerequisites.html:51
@@ -4369,7 +6300,9 @@ msgid "You’re at least 18 years old"
 msgstr ""
 
 #: templates/organize/prerequisites.html:87
-msgid "Your workshop will be free for participants, and women will have preference in attending"
+msgid ""
+"Your workshop will be free for participants, and women will have preference "
+"in attending"
 msgstr ""
 
 #: templates/organize/prerequisites.html:93
@@ -4377,7 +6310,9 @@ msgid "The event you’re organizing will be non-profit"
 msgstr ""
 
 #: templates/organize/prerequisites.html:100
-msgid "You will not pay coaches, speakers or organizers therefore you will not request money from sponsors to pay coaches, speakers or organizers."
+msgid ""
+"You will not pay coaches, speakers or organizers therefore you will not "
+"request money from sponsors to pay coaches, speakers or organizers."
 msgstr ""
 
 #: templates/organize/prerequisites.html:111
@@ -4389,7 +6324,11 @@ msgid "Suspension of In-Person Workshop Applications"
 msgstr ""
 
 #: templates/organize/suspend.html:11
-msgid "Please note that due to the Global Covid-19 Pandemic, we have suspended all in-person workshop applications. We have updated our Organiser Manual to support remote workshops as a potential alternative. Please consider applying for a remote workshop instead."
+msgid ""
+"Please note that due to the Global Covid-19 Pandemic, we have suspended all "
+"in-person workshop applications. We have updated our Organiser Manual to "
+"support remote workshops as a potential alternative. Please consider "
+"applying for a remote workshop instead."
 msgstr ""
 
 #: templates/organize/suspend.html:18
@@ -4401,7 +6340,10 @@ msgid "Password Reset Complete"
 msgstr ""
 
 #: templates/registration/password_reset_complete.html:8
-msgid "All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome now.</a> &#x1F496; Thanks for all you do!"
+#, python-format
+msgid ""
+"All done! Go ahead and get back to <a href=\"%(admin_url)s\">being awesome "
+"now.</a> &#x1F496; Thanks for all you do!"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:4
@@ -4409,7 +6351,9 @@ msgid "Password Reset"
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:7
-msgid "Alright, the big event. Enter a new, super safe and super memorable (just to you!) password."
+msgid ""
+"Alright, the big event. Enter a new, super safe and super memorable (just to "
+"you!) password."
 msgstr ""
 
 #: templates/registration/password_reset_confirm.html:11
@@ -4422,7 +6366,11 @@ msgid "Check Your"
 msgstr ""
 
 #: templates/registration/password_reset_done.html:12
-msgid "We just sent reset instructions to your email. If you have any issues, <a href=%(reset_url)s>try again</a> and if you still don't get anything, <a href=\"%(contact_url)s\">say hello</a>!"
+#, python-format
+msgid ""
+"We just sent reset instructions to your email. If you have any issues, <a "
+"href=%(reset_url)s>try again</a> and if you still don't get anything, <a "
+"href=\"%(contact_url)s\">say hello</a>!"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:4
@@ -4430,7 +6378,10 @@ msgid "Forget your password?"
 msgstr ""
 
 #: templates/registration/password_reset_form.html:7
-msgid "Been thinking about cupcakes and high fives too much lately? It's okay, we can make a new password for you. Enter your email and we'll send you reset instructions."
+msgid ""
+"Been thinking about cupcakes and high fives too much lately? It's okay, we "
+"can make a new password for you. Enter your email and we'll send you reset "
+"instructions."
 msgstr ""
 
 #: templates/registration/password_reset_form.html:11
@@ -4447,23 +6398,38 @@ msgid "Fill the form available on this page to apply for a GitHub grant."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:14
-msgid "GitHub can sponsor one Django Girls workshop per city with a 250$ grant. Applications must be received 2 months before the date of your workshop to be considered."
+msgid ""
+"GitHub can sponsor one Django Girls workshop per city with a 250$ grant. "
+"Applications must be received 2 months before the date of your workshop to "
+"be considered."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:22
-msgid "Before applying, your website needs to be ready and online. Then, you need to <a href=\"%(events_url)s\">check if an event already happened in your city</a> and if they received money from GitHub (check their sponsors section)."
+#, python-format
+msgid ""
+"Before applying, your website needs to be ready and online. Then, you need "
+"to <a href=\"%(events_url)s\">check if an event already happened in your "
+"city</a> and if they received money from GitHub (check their sponsors "
+"section)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:30
-msgid "If your event is the first in your city or if the previous ones didn't receive sponsoring from GitHub, you can apply."
+msgid ""
+"If your event is the first in your city or if the previous ones didn't "
+"receive sponsoring from GitHub, you can apply."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:36
-msgid "Note: Filling this form will be long. You'll have to download and edit some documents (invoice, bank information, etc)."
+msgid ""
+"Note: Filling this form will be long. You'll have to download and edit some "
+"documents (invoice, bank information, etc)."
 msgstr ""
 
 #: templates/sponsor/sponsor-request.html:42
-msgid "We send those requests once every two weeks to GitHub. <b>Next deadline: %(deadline)s.</b>"
+#, python-format
+msgid ""
+"We send those requests once every two weeks to GitHub. <b>Next deadline: "
+"%(deadline)s.</b>"
 msgstr ""
 
 #: templates/story/stories.html:9
@@ -4471,372 +6437,1560 @@ msgid "Django Girls Story"
 msgstr ""
 
 #: templates/story/stories.html:11
-msgid "“Your Django Story” is a volunteer-run interview series for the Django Girls blog that features women who make awesome things with Python and Django."
+msgid ""
+"“Your Django Story” is a volunteer-run interview series for the Django Girls "
+"blog that features women who make awesome things with Python and Django."
 msgstr ""
 
 #: templates/story/stories.html:18
-msgid "Each week we feature a new developer who tells us about how she got started on her journey with code, what she did before becoming a programmer, the cool things she’s currently working on, and much more. Each interview also features advice for aspiring developers, which is always a great read!"
+msgid ""
+"Each week we feature a new developer who tells us about how she got started "
+"on her journey with code, what she did before becoming a programmer, the "
+"cool things she’s currently working on, and much more. Each interview also "
+"features advice for aspiring developers, which is always a great read!"
 msgstr ""
 
 #: templates/story/stories.html:26
-msgid "Many of the women we’ve featured got their start at Django Girls workshops, and went on to found their own companies, secure full-time jobs as developers, and run Django Girls events."
+msgid ""
+"Many of the women we’ve featured got their start at Django Girls workshops, "
+"and went on to found their own companies, secure full-time jobs as "
+"developers, and run Django Girls events."
 msgstr ""
 
 #: templates/story/stories.html:33
-msgid "If you would like to suggest someone to be featured in “Your Django Story” (or would like to nominate yourself!), please <a href=\"mailto:story@djangogirls.org\">contact us!</a>"
+msgid ""
+"If you would like to suggest someone to be featured in “Your Django "
+"Story” (or would like to nominate yourself!), please <a href=\"mailto:"
+"story@djangogirls.org\">contact us!</a>"
 msgstr ""
 
-#: djangogirls/settings.py:108
-msgid "Brazilian Portuguese"
+#: venv/lib/python3.10/site-packages/_pytest/config/argparsing.py:445
+#, python-format
+msgid "ambiguous option: %(option)s could match %(matches)s"
 msgstr ""
 
-#: djangogirls/settings.py:111
-msgid "Korean"
+#: venv/lib/python3.10/site-packages/captcha/fields.py:20
+#: venv/lib/python3.10/site-packages/captcha/fields.py:21
+msgid "Error verifying reCAPTCHA, please try again."
 msgstr ""
 
-#: djangogirls/settings.py:112
-msgid "Persian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:496
+#, python-brace-format
+msgid "{editor}: Editing failed"
 msgstr ""
 
-#: djangogirls/settings.py:114
-msgid "Russian"
+#: venv/lib/python3.10/site-packages/click/_termui_impl.py:500
+#, python-brace-format
+msgid "{editor}: Editing failed: {e}"
 msgstr ""
 
-#: djangogirls/settings.py:115
-msgid "Spanish"
+#: venv/lib/python3.10/site-packages/click/core.py:1097
+msgid "Aborted!"
 msgstr ""
 
-#: templates/core/coc.html:4
-msgid "Django Girls Code of Conduct"
+#: venv/lib/python3.10/site-packages/click/core.py:1282
+#: venv/lib/python3.10/site-packages/click/decorators.py:495
+msgid "Show this message and exit."
 msgstr ""
 
-#: templates/core/coc.html:13
-msgid "This document is also available in:"
+#: venv/lib/python3.10/site-packages/click/core.py:1313
+#: venv/lib/python3.10/site-packages/click/core.py:1339
+#, python-brace-format
+msgid "(Deprecated) {text}"
 msgstr ""
 
-#: templates/core/coc.html:42
-msgid "Django Girls aims to be a welcoming event, where people meet in a friendly environment. Accordingly, we expect that all participants are expected to show respect and courtesy to other participants throughout the workshop."
+#: venv/lib/python3.10/site-packages/click/core.py:1357
+msgid "Options"
 msgstr ""
 
-#: templates/core/coc.html:50
-msgid "To make clear what is expected, all delegates/attendees, speakers, exhibitors, organizers and volunteers at any Django Girls event are required to conform to the following Code of Conduct. Organizers will enforce this code before and throughout the event."
+#: venv/lib/python3.10/site-packages/click/core.py:1383
+#, python-brace-format
+msgid "Got unexpected extra argument ({args})"
+msgid_plural "Got unexpected extra arguments ({args})"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1399
+msgid "DeprecationWarning: The command {name!r} is deprecated."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1605
+msgid "Commands"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1637
+msgid "Missing command."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:1715
+msgid "No such command {name!r}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2271
+msgid "Value must be an iterable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2291
+#, python-brace-format
+msgid "Takes {nargs} values but 1 was given."
+msgid_plural "Takes {nargs} values but {len} were given."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2734
+#, python-brace-format
+msgid "env var: {var}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2764
+msgid "(dynamic)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2777
+#, python-brace-format
+msgid "default: {default}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/core.py:2790
+msgid "required"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:400
+#, python-format
+msgid "%(prog)s, version %(version)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/decorators.py:464
+msgid "Show the version and exit."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:43
+#: venv/lib/python3.10/site-packages/click/exceptions.py:79
+#, python-brace-format
+msgid "Error: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:71
+#, python-brace-format
+msgid "Try '{command} {option}' for help."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:120
+#, python-brace-format
+msgid "Invalid value: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:122
+#, python-brace-format
+msgid "Invalid value for {param_hint}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:178
+msgid "Missing argument"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:180
+msgid "Missing option"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:182
+msgid "Missing parameter"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:184
+#, python-brace-format
+msgid "Missing {param_type}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:191
+#, python-brace-format
+msgid "Missing parameter: {param_name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:211
+#, python-brace-format
+msgid "No such option: {name}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:223
+#, python-brace-format
+msgid "Did you mean {possibility}?"
+msgid_plural "(Possible options: {possibilities})"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:261
+msgid "unknown error"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/exceptions.py:268
+msgid "Could not open file {filename!r}: {message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:231
+msgid "Argument {name!r} takes {nargs} values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:413
+msgid "Option {name!r} does not take a value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/parser.py:474
+msgid "Option {name!r} requires an argument."
+msgid_plural "Option {name!r} requires {nargs} arguments."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:316
+msgid "Shell completion is not supported for Bash versions older than 4.4."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/shell_completion.py:322
+msgid "Couldn't detect Bash version, shell completion is not supported."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:160
+msgid "Repeat for confirmation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:176
+msgid "Error: The value you entered was invalid."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:178
+#, python-brace-format
+msgid "Error: {e.message}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:189
+msgid "Error: The two entered values do not match."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:245
+msgid "Error: invalid input"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/termui.py:776
+msgid "Press any key to continue..."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:265
+#, python-brace-format
+msgid ""
+"Choose from:\n"
+"\t{choices}"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:297
+msgid "{value!r} is not {choice}."
+msgid_plural "{value!r} is not one of {choices}."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:387
+msgid "{value!r} does not match the format {format}."
+msgid_plural "{value!r} does not match the formats {formats}."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:409
+msgid "{value!r} is not a valid {number_type}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:465
+#, python-brace-format
+msgid "{value} is not in the range {range}."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:606
+msgid "{value!r} is not a valid boolean."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:630
+msgid "{value!r} is not a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:811
+msgid "file"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:813
+msgid "directory"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:815
+msgid "path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:861
+msgid "{name} {filename!r} does not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:870
+msgid "{name} {filename!r} is a file."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:878
+#, python-brace-format
+msgid "{name} '{filename}' is a directory."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:887
+msgid "{name} {filename!r} is not readable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:896
+msgid "{name} {filename!r} is not writable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:905
+msgid "{name} {filename!r} is not executable."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/click/types.py:972
+#, python-brace-format
+msgid "{len_type} values are required, but {len_value} was given."
+msgid_plural "{len_type} values are required, but {len_value} were given."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/messages/apps.py:7
+msgid "Messages"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/sitemaps/apps.py:8
+msgid "Site Maps"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/staticfiles/apps.py:9
+msgid "Static Files"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/contrib/syndication/apps.py:7
+msgid "Syndication"
+msgstr ""
+
+#. Translators: String used to replace omitted page numbers in elided page
+#. range generated by paginators, e.g. [1, 2, '…', 5, 6, 7, '…', 9, 10].
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:30
+msgid "…"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:51
+msgid "That page number is not an integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:53
+msgid "That page number is less than 1"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/paginator.py:58
+msgid "That page contains no results"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:22
+msgid "Enter a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:93
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:678
+msgid "Enter a valid URL."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:151
+msgid "Enter a valid integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:162
+msgid "Enter a valid email address."
+msgstr ""
+
+#. Translators: "letters" means latin letters: a-z and A-Z.
+#: venv/lib/python3.10/site-packages/django/core/validators.py:265
+msgid ""
+"Enter a valid “slug” consisting of letters, numbers, underscores or hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:272
+msgid ""
+"Enter a valid “slug” consisting of Unicode letters, numbers, underscores, or "
+"hyphens."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:281
+#: venv/lib/python3.10/site-packages/django/core/validators.py:291
+#: venv/lib/python3.10/site-packages/django/core/validators.py:314
+msgid "Enter a valid IPv4 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:299
+#: venv/lib/python3.10/site-packages/django/core/validators.py:315
+msgid "Enter a valid IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:309
+#: venv/lib/python3.10/site-packages/django/core/validators.py:313
+msgid "Enter a valid IPv4 or IPv6 address."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:343
+msgid "Enter only digits separated by commas."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:349
+#, python-format
+msgid "Ensure this value is %(limit_value)s (it is %(show_value)s)."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:382
+#, python-format
+msgid "Ensure this value is less than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:391
+#, python-format
+msgid "Ensure this value is greater than or equal to %(limit_value)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:401
+#, python-format
+msgid ""
+"Ensure this value has at least %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at least %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:416
+#, python-format
+msgid ""
+"Ensure this value has at most %(limit_value)d character (it has "
+"%(show_value)d)."
+msgid_plural ""
+"Ensure this value has at most %(limit_value)d characters (it has "
+"%(show_value)d)."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:435
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:292
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:327
+msgid "Enter a number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:437
+#, python-format
+msgid "Ensure that there are no more than %(max)s digit in total."
+msgid_plural "Ensure that there are no more than %(max)s digits in total."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:442
+#, python-format
+msgid "Ensure that there are no more than %(max)s decimal place."
+msgid_plural "Ensure that there are no more than %(max)s decimal places."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:447
+#, python-format
+msgid ""
+"Ensure that there are no more than %(max)s digit before the decimal point."
+msgid_plural ""
+"Ensure that there are no more than %(max)s digits before the decimal point."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:509
+#, python-format
+msgid ""
+"File extension “%(extension)s” is not allowed. Allowed extensions are: "
+"%(allowed_extensions)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/core/validators.py:562
+msgid "Null characters are not allowed."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1210
+#: venv/lib/python3.10/site-packages/django/forms/models.py:768
+msgid "and"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/base.py:1212
+#, python-format
+msgid "%(model_name)s with this %(field_labels)s already exists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:100
+#, python-format
+msgid "Value %(value)r is not a valid choice."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:101
+msgid "This field cannot be null."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:102
+msgid "This field cannot be blank."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:103
+#, python-format
+msgid "%(model_name)s with this %(field_label)s already exists."
+msgstr ""
+
+#. Translators: The 'lookup_type' is one of 'date', 'year' or 'month'.
+#. Eg: "Title must be unique for pub_date year"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:107
+#, python-format
+msgid ""
+"%(field_label)s must be unique for %(date_field_label)s %(lookup_type)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:126
+#, python-format
+msgid "Field of type: %(field_type)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:958
+#, python-format
+msgid "“%(value)s” value must be either True or False."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:959
+#, python-format
+msgid "“%(value)s” value must be either True, False, or None."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:961
+msgid "Boolean (Either True or False)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1002
+#, python-format
+msgid "String (up to %(max_length)s)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1096
+msgid "Comma-separated integers"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1145
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid date format. It must be in YYYY-MM-DD "
+"format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1147
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1290
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD) but it is an invalid "
+"date."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1150
+msgid "Date (without time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1288
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in YYYY-MM-DD HH:MM[:ss[."
+"uuuuuu]][TZ] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1292
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (YYYY-MM-DD HH:MM[:ss[.uuuuuu]]"
+"[TZ]) but it is an invalid date/time."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1296
+msgid "Date (with time)"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1444
+#, python-format
+msgid "“%(value)s” value must be a decimal number."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1446
+msgid "Decimal number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1585
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in [DD] [[HH:]MM:]ss[."
+"uuuuuu] format."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1588
+msgid "Duration"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1661
+msgid "File path"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1727
+#, python-format
+msgid "“%(value)s” value must be a float."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1729
+msgid "Floating point number"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1767
+#, python-format
+msgid "“%(value)s” value must be an integer."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1769
+msgid "Integer"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1852
+msgid "Big (8 byte) integer"
 msgstr ""
 
-#: templates/core/coc.html:57
-msgid "In short"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1867
+msgid "Small integer"
 msgstr ""
 
-#: templates/core/coc.html:61
-msgid "Django Girls is dedicated to providing a harassment-free workshop experience for everyone, regardless of gender, sexual orientation, disability, physical appearance, body size, race, or religion."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1875
+msgid "IPv4 address"
 msgstr ""
 
-#: templates/core/coc.html:66
-msgid "We do not tolerate harassment of workshop participants in any form."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1906
+msgid "IP address"
 msgstr ""
 
-#: templates/core/coc.html:67
-msgid "Sexual language and imagery is not appropriate for any workshop venue, including talks."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1986
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1987
+#, python-format
+msgid "“%(value)s” value must be either None, True or False."
 msgstr ""
 
-#: templates/core/coc.html:69
-msgid "Be kind to others. Do not insult or put down other attendees. Behave professionally. Don't publish photographs of people without their consent. Remember that harassment and sexist, racist, or exclusionary jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:1989
+msgid "Boolean (Either True, False or None)"
 msgstr ""
 
-#: templates/core/coc.html:76
-msgid "Conference participants violating these rules may be sanctioned or expelled from the workshop without a refund at the discretion of the workshop organizers."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2043
+msgid "Positive big integer"
 msgstr ""
 
-#: templates/core/coc.html:83
-msgid "Longer version"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2056
+msgid "Positive integer"
 msgstr ""
 
-#: templates/core/coc.html:86
-msgid "Harassment includes offensive verbal comments related to gender, sexual orientation, disability, physical appearance, body size, race, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2069
+msgid "Positive small integer"
 msgstr ""
 
-#: templates/core/coc.html:94
-msgid "Participants asked to stop any harassing behavior are expected to comply immediately."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2083
+#, python-format
+msgid "Slug (up to %(max_length)s)"
 msgstr ""
 
-#: templates/core/coc.html:97
-msgid "Be careful in the words that you choose. Remember that sexist, racist, and other exclusionary jokes can be offensive to those around you. Excessive swearing and offensive jokes are not appropriate for Django Girls."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2115
+msgid "Text"
 msgstr ""
 
-#: templates/core/coc.html:104
-msgid "If a participant engages in harassing behavior, the workshop organizers may take any action they deem appropriate, including warning the offender or expulsion from the workshop with no refund."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2181
+#, python-format
+msgid ""
+"“%(value)s” value has an invalid format. It must be in HH:MM[:ss[.uuuuuu]] "
+"format."
 msgstr ""
 
-#: templates/core/coc.html:110
-msgid "We expect participants to follow these rules at all workshop venues and workshop-related social events."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2183
+#, python-format
+msgid ""
+"“%(value)s” value has the correct format (HH:MM[:ss[.uuuuuu]]) but it is an "
+"invalid time."
 msgstr ""
 
-#: templates/core/coc.html:112
-msgid "Reporting harassment"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2186
+msgid "Time"
 msgstr ""
 
-#: templates/core/coc.html:115
-msgid "If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact your coach or one of the organizers immediately. If your concern is with the organizing team, please email details to coc@djangogirls.org."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2312
+msgid "URL"
 msgstr ""
 
-#: templates/core/coc.html:122
-msgid "The staff is well informed on how to deal with the incident and how to further proceed with the situation. Conference staff will be happy to help participants contact hotel/venue security or local law enforcement, provide escorts, or otherwise assist those experiencing harassment to feel safe for the duration of the conference. We value your attendance."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2334
+msgid "Raw binary data"
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:6
-msgid "Thank you for submitting the application to organize Django Girls in %(city)s! Yay!"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2399
+#, python-format
+msgid "“%(value)s” is not a valid UUID."
 msgstr ""
 
-#: templates/emails/organize/application_confirmation.html:33
-msgid "Our <a href=\"https://organize.djangogirls.org/\">Organizer's Manual</a> describes quite well the process of organizing a workshop. You can also read experiences of other organizers on our blog: <a href=\"http://blog.djangogirls.org/post/152858499038/django-girls-seoul-workshop-2\">Seoul</a>, <a href=\"http://blog.djangogirls.org/post/143835232733/django-girls-wroc%%C5%%82aw-3-192-applications-32\">Wrocław</a>, <a href=\"http://blog.djangogirls.org/post/139654610313/django-girls-workshop-in-windhoek-namibia\">Windhoek</a> or <a href=\"http://blog.djangogirls.org/post/138915381173/a-toolkit-of-awesome-tips-tricks-from-seasoned\">Budapest</a>."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/__init__.py:2401
+msgid "Universally unique identifier"
 msgstr ""
 
-#: applications/forms.py:80
-msgid "Confirmation of your application for %(page_title)s"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:226
+msgid "File"
 msgstr ""
 
-#: applications/views.py:248 applications/views.py:274
-msgid "Missing parameters"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/files.py:375
+msgid "Image"
 msgstr ""
 
-#: applications/views.py:259 applications/views.py:282
-msgid "Applications have been updated"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:18
+msgid "A JSON object"
 msgstr ""
 
-#: applications/views.py:299
-msgid "Something went wrong with your RSVP link. Please contact us at %(email)s with your name."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/json.py:20
+msgid "Value must be valid JSON."
 msgstr ""
 
-#: applications/views.py:309
-msgid "Your participation in the workshop has been confirmed! We can't wait to meet you. We will be in touch with details soon."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:790
+#, python-format
+msgid "%(model)s instance with %(field)s %(value)r does not exist."
 msgstr ""
 
-#: applications/views.py:315
-msgid "Your answer has been saved, thanks for letting us know. Your spot will be assigned to another person on the waiting list."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:792
+msgid "Foreign Key (type determined by related field)"
 msgstr ""
 
-#: core/admin/event.py:235
-msgid "Organizer %(user_name)s has been removed"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1045
+msgid "One-to-one relationship"
 msgstr ""
 
-#: core/admin/event.py:263
-msgid "%(user_name)s has been added to your event, yay! They've been also invited to Slack and should receive credentials to login in an e-mail."
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1099
+#, python-format
+msgid "%(from)s-%(to)s relationship"
 msgstr ""
 
-#: core/admin/event.py:280
-msgid "Add organizers"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1100
+#, python-format
+msgid "%(from)s-%(to)s relationships"
 msgstr ""
 
-#: core/views.py:181
-msgid "No translation for language %(lang)s"
+#: venv/lib/python3.10/site-packages/django/db/models/fields/related.py:1142
+msgid "Many-to-many relationship"
 msgstr ""
 
-#: organize/admin.py:184
-msgid "Application for %(city)s, %(country)s has been moved to %(status)s"
+#. Translators: If found as last label character, these punctuation
+#. characters will prevent the default label_suffix to be appended to the label
+#: venv/lib/python3.10/site-packages/django/forms/boundfield.py:150
+msgid ":?.!"
 msgstr ""
 
-#: templates/admin/base_site.html:5
-msgid "Django Girls admin"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:247
+msgid "Enter a whole number."
 msgstr ""
 
-#: templates/admin/base_site.html:12
-msgid "Django Girls administration"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:402
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1146
+msgid "Enter a valid date."
 msgstr ""
 
-#: templates/core/2016-2017.html:219
-msgid "We'd like to acknowledge that even though the total number of responses received is a significant representative sample of the Django Girls alumni, it is likely that most of the women who responded to our survey stayed active in the tech industry after attending our workshops and hence the results could be positively skewed."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:426
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1147
+msgid "Enter a valid time."
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$806</span> of <span class=\"highlighted-number\">$1,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:454
+msgid "Enter a valid date/time."
 msgstr ""
 
-#: templates/core/index.html:203
-msgid "They already sponsor us! 💕"
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:488
+msgid "Enter a valid duration."
 msgstr ""
 
-#: templates/core/index.html:222
-msgid "These incredible companies are actively helping us to change the ratio in the tech industry by supporting us in other ways. <br /> If you wish to join them, <a href=\"%(contact_url)s\">drop us a line</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:489
+#, python-brace-format
+msgid "The number of days must be between {min_days} and {max_days}."
 msgstr ""
 
-#: applications/decorators.py:21
-msgid "\"page_url\" slug must be present to user this decorator."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:552
+msgid "No file was submitted. Check the encoding type on the form."
 msgstr ""
 
-#: applications/questions.py:147
-msgid "Data collected through this form is used only for the purpose of Django Girls events. We're using Third Party Sites and Services to make it happen: for example, we're using Sendgrid to send you emails. Don't worry: We don't share your data with spammers, and we don't sell it! More info on our Privacy policy <a href='/privacy-cookies/'>here</a>."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:553
+msgid "No file was submitted."
 msgstr ""
 
-#: core/validators.py:30
-msgid "Please provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:554
+msgid "The submitted file is empty."
 msgstr ""
 
-#: globalpartners/admin.py:53
-msgid "Introduction email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:556
+#, python-format
+msgid "Ensure this filename has at most %(max)d character (it has %(length)d)."
+msgid_plural ""
+"Ensure this filename has at most %(max)d characters (it has %(length)d)."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:559
+msgid "Please either submit a file or check the clear checkbox, not both."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:620
+msgid ""
+"Upload a valid image. The file you uploaded was either not an image or a "
+"corrupted image."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:782
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:872
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1309
+#, python-format
+msgid "Select a valid choice. %(value)s is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:873
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:988
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1308
+msgid "Enter a list of values."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:989
+msgid "Enter a complete value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1205
+msgid "Enter a valid UUID."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/fields.py:1235
+msgid "Enter a valid JSON."
+msgstr ""
+
+#. Translators: This is the default suffix added to form field labels
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:76
+msgid ":"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/forms.py:203
+#, python-format
+msgid "(Hidden field %(name)s) %(error)s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:61
+#, python-format
+msgid ""
+"ManagementForm data is missing or has been tampered with. Missing fields: "
+"%(field_names)s. You may need to file a bug report if the issue persists."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:370
+#, python-format
+msgid "Please submit at most %d form."
+msgid_plural "Please submit at most %d forms."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:377
+#, python-format
+msgid "Please submit at least %d form."
+msgid_plural "Please submit at least %d forms."
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:405
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:412
+msgid "Order"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/formsets.py:417
+msgid "Delete"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:763
+#, python-format
+msgid "Please correct the duplicate data for %(field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:767
+#, python-format
+msgid "Please correct the duplicate data for %(field)s, which must be unique."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:773
+#, python-format
+msgid ""
+"Please correct the duplicate data for %(field_name)s which must be unique "
+"for the %(lookup)s in %(date_field)s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:782
+msgid "Please correct the duplicate values below."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1109
+msgid "The inline value did not match the parent instance."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1193
+msgid "Select a valid choice. That choice is not one of the available choices."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/models.py:1311
+#, python-format
+msgid "“%(pk)s” is not a valid value."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/utils.py:172
+#, python-format
+msgid ""
+"%(datetime)s couldn’t be interpreted in time zone %(current_timezone)s; it "
+"may be ambiguous or it may not exist."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:427
+msgid "Clear"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:428
+msgid "Currently"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:429
+msgid "Change"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:738
+msgid "Unknown"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/forms/widgets.py:740
+msgid "No"
+msgstr ""
+
+#. Translators: Please do not add spaces around commas.
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:817
+msgid "yes,no,maybe"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:846
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:863
+#, python-format
+msgid "%(size)d byte"
+msgid_plural "%(size)d bytes"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:865
+#, python-format
+msgid "%s KB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:867
+#, python-format
+msgid "%s MB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:869
+#, python-format
+msgid "%s GB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:871
+#, python-format
+msgid "%s TB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/template/defaultfilters.py:873
+#, python-format
+msgid "%s PB"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:66
+msgid "p.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:67
+msgid "a.m."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:72
+msgid "PM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:73
+msgid "AM"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:146
+msgid "midnight"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dateformat.py:148
+msgid "noon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Monday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Tuesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Wednesday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Thursday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:6
+msgid "Friday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Saturday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:7
+msgid "Sunday"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Mon"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Tue"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Wed"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Thu"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:10
+msgid "Fri"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sat"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:11
+msgid "Sun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "January"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "February"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "March"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "April"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "May"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:14
+msgid "June"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "July"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "August"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "September"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "October"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:15
+msgid "November"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:16
+msgid "December"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jan"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "feb"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "mar"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "apr"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "may"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:19
+msgid "jun"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "jul"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "aug"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "sep"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "oct"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "nov"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:20
+msgid "dec"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:23
+msgctxt "abbrev. month"
+msgid "Jan."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:24
+msgctxt "abbrev. month"
+msgid "Feb."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:25
+msgctxt "abbrev. month"
+msgid "March"
 msgstr ""
 
-#: globalpartners/admin.py:64
-msgid "Renewal email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:26
+msgctxt "abbrev. month"
+msgid "April"
 msgstr ""
 
-#: globalpartners/admin.py:75
-msgid "Request for promotional material email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:27
+msgctxt "abbrev. month"
+msgid "May"
 msgstr ""
 
-#: globalpartners/admin.py:86
-msgid "Thank you email for %(contact_person)s, of %(company_name)s has been sent."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:28
+msgctxt "abbrev. month"
+msgid "June"
 msgstr ""
 
-#: organize/admin.py:159
-msgid "The application is already deployed"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:29
+msgctxt "abbrev. month"
+msgid "July"
 msgstr ""
 
-#: organize/models.py:94
-msgid "Information about local restrictions for physical restrictions due to Covid-19 pandemic."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:30
+msgctxt "abbrev. month"
+msgid "Aug."
 msgstr ""
 
-#: organize/models.py:106
-msgid "Confirmation that you will postpone or have a remote event if your governmentregulations for Covid-19 change."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:31
+msgctxt "abbrev. month"
+msgid "Sept."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:16
-msgid "Send Prospective Sponsor email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:32
+msgctxt "abbrev. month"
+msgid "Oct."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:19
-msgid "Send Renewal email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:33
+msgctxt "abbrev. month"
+msgid "Nov."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:23
-msgid "Send Promotional Material email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:34
+msgctxt "abbrev. month"
+msgid "Dec."
 msgstr ""
 
-#: templates/admin/globalpartners/globalpartner/change_form.html:26
-msgid "Send Thank You email"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:37
+msgctxt "alt. month"
+msgid "January"
 msgstr ""
 
-#: templates/admin/organize/eventapplication/change_form.html:27
-msgid "Application deployed."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:38
+msgctxt "alt. month"
+msgid "February"
 msgstr ""
 
-#: templates/core/2016-2017.html:88
-msgid "Map of Django Girls events from January 2016 to July 2017"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:39
+msgctxt "alt. month"
+msgid "March"
 msgstr ""
 
-#: templates/core/index.html:56
-msgid "Since 2014, an army of <span class=\"highlighted-number\">%(organizers_count)s volunteers</span> in the Django Girls community organized <span class=\"highlighted-number\">%(all_events_count)s events.</span> We've been to <span class=\"highlighted-number\">%(cities_count)s cities</span> in <span class=\"highlighted-number\">%(country_count)s countries</span> (<a href=\"%(event_map_url)s\">see them all on a map</a>)."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:40
+msgctxt "alt. month"
+msgid "April"
 msgstr ""
 
-#: templates/core/index.html:64
-msgid "A total of <span class=\"highlighted-number\">%(attendees_sum)s incredible women attended</span> events organized by members of our community."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:41
+msgctxt "alt. month"
+msgid "May"
 msgstr ""
 
-#: templates/core/index.html:76
-msgid "We open sourced the <a href=\"http://organize.djangogirls.org/\">Organizer Manual</a> that provides you with all information required to organize Django Girls workshop. By volunteering to organize, you're joining a vibrant and supportive community of %(organizers_count)s organizers all over the world!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:42
+msgctxt "alt. month"
+msgid "June"
 msgstr ""
 
-#: templates/core/index.html:143
-msgid "<span class=\"highlighted-number\">$1,661</span> of <span class=\"highlighted-number\">$2,500</span> monthly goal pledged"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:43
+msgctxt "alt. month"
+msgid "July"
 msgstr ""
 
-#: templates/core/index.html:183
-msgid "Check out our podcast!"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:44
+msgctxt "alt. month"
+msgid "August"
 msgstr ""
 
-#: templates/core/index.html:185
-msgid "We have a new <a href=\"https://anchor.fm/djangogirls\">podcast</a> that is being hosted by trustees <a href=\"http://blog.djangogirls.org/post/138923168468\"> Aisha</a> and <a href=\"http://blog.djangogirls.org/post/172001842084\">Leona</a> where they talk with many awesome people from our community. Check out the <a href=\"https://anchor.fm/s/7aa83714/podcast/rss\">RSS Feed</a> for the <a href=\"https://anchor.fm/djangogirls\">podcast</a> which is available on multiple platforms such as <a href=\"https://podcasts.apple.com/us/podcast/django-girls-podcast/id1602881437\">Apple Pod</a>, <a href=\"https://podcasts.google.com/feed/aHR0cHM6Ly9hbmNob3IuZm0vcy83YWE4MzcxNC9wb2RjYXN0L3Jzcw?ep=14\">Google Pod</a>, <a href=\"https://music.amazon.ca/podcasts/afe571fc-bc45-4fcb-871f-3b5a4bb4560f/django-girls-podcast?ref=dm_sh_pXP60O3XBTy3Vb5o5JmSB1coQ\">Amazon Music</a>, and <a href=\"https://open.spotify.com/show/5sHA8wy4ttUtPgwXHL2lf5\">Spotify</a> ."
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:45
+msgctxt "alt. month"
+msgid "September"
 msgstr ""
 
-#: templates/donations/donate.html:83
-msgid "Are you a company interested in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:46
+msgctxt "alt. month"
+msgid "October"
 msgstr ""
 
-#: templates/donations/sponsors.html:8
-msgid "Our Global Partners"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:47
+msgctxt "alt. month"
+msgid "November"
 msgstr ""
 
-#: templates/donations/sponsors.html:11
-msgid "Our global partners are companies who are supporting our work by donating to us either monthly through <a href=\"https://www.patreon.com/djangogirls\" target=\"_blank\">Patreon</a> or through annual sponsorships. Want to join these amazing companies in sponsoring us? Our <a href=\"https://drive.google.com/file/d/1T2jL9tnu5ZkNvkQRAxd7jlt_BnX7VCLE/view?usp=sharing\">corporate sponsorships</a> start at 100 USD per month. <a href=\"%(contact_url)s\">Contact us!</a> 📨"
+#: venv/lib/python3.10/site-packages/django/utils/dates.py:48
+msgctxt "alt. month"
+msgid "December"
 msgstr ""
 
-#: templates/donations/sponsors.html:21
-msgid "Diamond - $10,000+ per year 💞✨"
+#: venv/lib/python3.10/site-packages/django/utils/ipv6.py:8
+msgid "This is not a valid IPv6 address."
 msgstr ""
 
-#: templates/donations/sponsors.html:40
-msgid "Platinum - $5,000+ per year 💝✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:71
+#, python-format
+msgctxt "String to return when truncating text"
+msgid "%(truncated_text)s…"
 msgstr ""
 
-#: templates/donations/sponsors.html:59
-msgid "Gold - $2,500+ per year 💖✨"
+#: venv/lib/python3.10/site-packages/django/utils/text.py:240
+msgid "or"
 msgstr ""
 
-#: templates/donations/sponsors.html:78
-msgid "Silver - $1,000+ per year 💗✨"
+#. Translators: This string is used as a separator between list elements
+#: venv/lib/python3.10/site-packages/django/utils/text.py:259
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:94
+msgid ", "
 msgstr ""
 
-#: templates/global/footer.html:15 templates/jobboard/index.html:7
-msgid "Job Board"
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:9
+#, python-format
+msgid "%d year"
+msgid_plural "%d years"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:10
+#, python-format
+msgid "%d month"
+msgid_plural "%d months"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:11
+#, python-format
+msgid "%d week"
+msgid_plural "%d weeks"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:12
+#, python-format
+msgid "%d day"
+msgid_plural "%d days"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:13
+#, python-format
+msgid "%d hour"
+msgid_plural "%d hours"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/utils/timesince.py:14
+#, python-format
+msgid "%d minute"
+msgid_plural "%d minutes"
+msgstr[0] ""
+msgstr[1] ""
+msgstr[2] ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:110
+msgid "Forbidden"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:111
+msgid "CSRF verification failed. Request aborted."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:115
+msgid ""
+"You are seeing this message because this HTTPS site requires a “Referer "
+"header” to be sent by your Web browser, but none was sent. This header is "
+"required for security reasons, to ensure that your browser is not being "
+"hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:120
+msgid ""
+"If you have configured your browser to disable “Referer” headers, please re-"
+"enable them, at least for this site, or for HTTPS connections, or for “same-"
+"origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:124
+msgid ""
+"If you are using the <meta name=\"referrer\" content=\"no-referrer\"> tag or "
+"including the “Referrer-Policy: no-referrer” header, please remove them. The "
+"CSRF protection requires the “Referer” header to do strict referer checking. "
+"If you’re concerned about privacy, use alternatives like <a "
+"rel=\"noreferrer\" …> for links to third-party sites."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:132
+msgid ""
+"You are seeing this message because this site requires a CSRF cookie when "
+"submitting forms. This cookie is required for security reasons, to ensure "
+"that your browser is not being hijacked by third parties."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:137
+msgid ""
+"If you have configured your browser to disable cookies, please re-enable "
+"them, at least for this site, or for “same-origin” requests."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/csrf.py:142
+msgid "More information is available with DEBUG=True."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:41
+msgid "No year specified"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:61
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:111
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:208
+msgid "Date out of range"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:90
+msgid "No month specified"
 msgstr ""
 
-#: templates/global/footer.html:26 templates/global/menu.html:33
-msgid "Our Sponsors"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:142
+msgid "No day specified"
 msgstr ""
 
-#: templates/global/footer.html:62
-msgid "<b>%(applicants_sum)s</b> applicants"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:188
+msgid "No week specified"
 msgstr ""
 
-#: templates/global/footer.html:63
-msgid "<b>%(attendees_sum)s</b> attendees"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:338
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:367
+#, python-format
+msgid "No %(verbose_name_plural)s available"
 msgstr ""
 
-#: templates/global/menu.html:25
-msgid "Jobs"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:594
+#, python-format
+msgid ""
+"Future %(verbose_name_plural)s not available because %(class_name)s."
+"allow_future is False."
 msgstr ""
 
-#: templates/global/menu.html:29
-msgid "Donate to us 💕"
+#: venv/lib/python3.10/site-packages/django/views/generic/dates.py:628
+#, python-format
+msgid "Invalid date string “%(datestr)s” given format “%(format)s”"
 msgstr ""
 
-#: templates/jobboard/index.html:11
-msgid " Django Girls global partners are hiring! Want to see your job posted here? \n"
-"            <a href=\"/contact/\">Contact us</a> about becoming a global partner for Django Girls \n"
-"            and recruit the best talent for your organization. "
+#: venv/lib/python3.10/site-packages/django/views/generic/detail.py:54
+#, python-format
+msgid "No %(verbose_name)s found matching the query"
 msgstr ""
 
-#: templates/jobboard/index.html:39 templates/jobboard/job.html:23
-msgid "Apply here"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:67
+msgid "Page is not “last”, nor can it be converted to an int."
 msgstr ""
 
-#: templates/jobboard/index.html:43
-msgid "More information"
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:72
+#, python-format
+msgid "Invalid page (%(page_number)s): %(message)s"
 msgstr ""
 
-#: templates/jobboard/index.html:57
-msgid "Sorry, no job openings at the moment."
+#: venv/lib/python3.10/site-packages/django/views/generic/list.py:154
+#, python-format
+msgid "Empty list and “%(class_name)s.allow_empty” is False."
 msgstr ""
 
-#: templates/jobboard/job.html:26
-msgid "Sorry the job listing does not exist."
+#: venv/lib/python3.10/site-packages/django/views/static.py:40
+msgid "Directory indexes are not allowed here."
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:157
-msgid "What are your current local restrictions?"
+#: venv/lib/python3.10/site-packages/django/views/static.py:42
+#, python-format
+msgid "“%(path)s” does not exist"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:158
-msgid "Please also provide a link to your government website outlining this."
+#: venv/lib/python3.10/site-packages/django/views/static.py:80
+#, python-format
+msgid "Index of %(directory)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:230
-msgid "Will you change your workshop to remote or postpone if the situation changes in your country?"
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:7
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:221
+msgid "The install worked successfully! Congratulations!"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:231
-msgid "Confirm you will postpone or host remote workshop if Covid-19 situation changes in your city."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:207
+#, python-format
+msgid ""
+"View <a href=\"https://docs.djangoproject.com/en/%(version)s/releases/\" "
+"target=\"_blank\" rel=\"noopener\">release notes</a> for Django %(version)s"
 msgstr ""
 
-#: templates/organize/form/step5_workshop.html:237
-msgid " I confirm that should my local restrictions change to prevent the workshop from going ahead in person safely, I will change to a remote workshop, or postpone until restrictions are lifted and it is safe to go ahead."
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:222
+#, python-format
+msgid ""
+"You are seeing this page because <a href=\"https://docs.djangoproject.com/en/"
+"%(version)s/ref/settings/#debug\" target=\"_blank\" "
+"rel=\"noopener\">DEBUG=True</a> is in your settings file and you have not "
+"configured any URLs."
 msgstr ""
 
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:230
+msgid "Django Documentation"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:231
+msgid "Topics, references, &amp; how-to’s"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:239
+msgid "Tutorial: A Polling App"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:240
+msgid "Get started with Django"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:248
+msgid "Django Community"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/django/views/templates/default_urlconf.html:249
+msgid "Connect, get help, or contribute"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:404
+#, python-format
+msgid "Content purported to be compressed with %s but failed to decompress."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:568
+#, python-format
+msgid "Unsupported value for qop: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:572
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:650
+#, python-format
+msgid "Unsupported value for algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:645
+msgid "The challenge doesn't contain a server nonce, or this one is empty."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:655
+#, python-format
+msgid "Unsupported value for pw-algorithm: %s."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/httplib2/__init__.py:1464
+msgid "Redirected but the response is missing a Location: header."
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/isort/main.py:159
+msgid "show this help message and exit"
+msgstr ""
+
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:333
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:340
+#: venv/lib/python3.10/site-packages/test/integ/test_sendgrid.py:347
+msgid "global"
+msgstr ""


### PR DESCRIPTION
To fix the typo from the issue we need to run `django-admin makemessages --all` to regenerate the translations :)
I hope this PR looks forward to that.

Solves #910 
@marksweb 

Thanks!