### PR TITLE
feat: Allow translation management from docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,25 +2,34 @@ FROM python:3.10.9-bullseye
 
 RUN apt-get update \
     && apt-get upgrade -yq \
+    && apt-get -y install locales \
+    && apt-get -y install gettext \
+    && apt-get -y install poedit \
     && apt-get install -yq --no-install-recommends \
         nodejs \
-        npm
+        npm \
+    && apt-get clean; rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /usr/share/doc/*
 
-ENV APP_DIR=/var/www/app
-WORKDIR ${APP_DIR}
+RUN sed -i -e 's/# en_US.UTF-8 UTF-8/en_US.UTF-8 UTF-8/' /etc/locale.gen \
+    && sed -i -e 's/# en_US ISO-8859-1/en_US ISO-8859-1/' /etc/locale.gen \
+    && sed -i -e 's/# en_US.ISO-8859-15 ISO-8859-15/en_US.ISO-8859-15 ISO-8859-15/' /etc/locale.gen \
+    && dpkg-reconfigure --frontend=noninteractive locales \
+    && update-locale
 
-COPY requirements.txt ${APP_DIR}/requirements.txt
+WORKDIR /var/www/app
+
+COPY requirements.txt ./requirements.txt
 
 RUN pip install pip-tools \
     && pip-sync
 
-COPY package.json ${APP_DIR}/package.json
+COPY package.json ./package.json
 
 RUN npm install \
     && npm install -g gulp
 
 COPY rootfs /
-COPY . ${APP_DIR}
+COPY . .
 
 RUN gulp local
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /var/www/app
 
 COPY requirements.txt ./requirements.txt
 
-RUN pip install pip-tools \
+RUN pip install --upgrade pip pip-tools \
     && pip-sync
 
 COPY package.json ./package.json

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.8"
-
 services:
   app:
     container_name: djangogirls-app

--- a/locale/es/LC_MESSAGES/django.po
+++ b/locale/es/LC_MESSAGES/django.po
@@ -6170,7 +6170,7 @@ msgstr ""
 #: templates/organize/form/step3_organizers.html:114
 #: templates/organize/form/step3_organizers.html:154
 msgid "Email address"
-msgstr ""
+msgstr "Correo electrónico"
 
 #: templates/organize/form/step3_organizers.html:85
 msgid "Your organizing team"

--- a/rootfs/entrypoint.sh
+++ b/rootfs/entrypoint.sh
@@ -1,5 +1,11 @@
 #!/bin/sh -e
 
+echo "Make messages"
+./manage.py makemessages --all
+
+echo "Compile messages"
+./manage.py compilemessages
+
 echo "Applying database migrations"
 ./manage.py migrate
 


### PR DESCRIPTION
This gets docker to run `makemessages` and `compilemessages` which should help to maintain a consistent way to manage the message catalog and keep it up to date as people are working.

I thought about having the two commands in `entrypoint.sh` commented out and then uncommented when people want to run them, but that will lead to them never being ran.

I'd rather people had these files generatead and had to think about if they need to commit changes, than changes not getting created and the codebase falling behind POeditor or conflicts being created again.