### PR TITLE
Fix error when getting coordinates during EventApplication creation

### DIFF
--- a/core/utils.py
+++ b/core/utils.py
@@ -1,4 +1,5 @@
 from datetime import date, datetime, timedelta
+from json import JSONDecodeError
 
 import requests
 from django.utils import timezone
@@ -18,7 +19,7 @@ def get_coordinates_for_city(city, country):
         formatted_lat = "{:.7f}".format(float(data["lat"]))
         formatted_lon = "{:.7f}".format(float(data["lon"]))
         return f"{formatted_lat}, {formatted_lon}"
-    except (IndexError, KeyError):
+    except (IndexError, KeyError, JSONDecodeError):
         return None
 
 

--- a/tests/core/test_utils.py
+++ b/tests/core/test_utils.py
@@ -1,3 +1,4 @@
+import json
 from datetime import date
 from unittest import mock
 
@@ -60,6 +61,14 @@ def test_returns_none_when_invalid_results(mock_get):
             "q": "PretendTown, UK",
         },
     )
+    assert result is None
+
+
+@mock.patch("requests.get")
+def test_get_coordinates_for_city_invalid_response(mock_get):
+    # Raise JSONDecodeError when trying to parse the response
+    mock_get.return_value.json.side_effect = json.JSONDecodeError("error", "doc", 0)
+    result = get_coordinates_for_city("Prague", "Czechia")
     assert result is None
 
 

--- a/tests/organize/test_models.py
+++ b/tests/organize/test_models.py
@@ -43,7 +43,10 @@ def test_deploy_event_from_previous_event(get_or_create_gmail, base_application,
 
 @mock.patch("organize.models.gmail_accounts.get_or_create_gmail")
 def test_send_deployed_email(get_or_create_gmail, base_application, mailoutbox, stock_pictures):
-    get_or_create_gmail.return_value = (f"{base_application.city}@djangogirls.org", "asd123ASD")
+    get_or_create_gmail.return_value = (
+        f"{base_application.city}@djangogirls.org",
+        "asd123ASD",
+    )
 
     base_application.create_event()
     event = base_application.deploy()
@@ -123,7 +126,10 @@ def test_previous_application_with_approximate_date(data_dict, previous_applicat
 
 def test_coorganizer_str(base_application):
     org = Coorganizer.objects.create(
-        event_application=base_application, email="anna@example.com", first_name="Anna", last_name="Smith"
+        event_application=base_application,
+        email="anna@example.com",
+        first_name="Anna",
+        last_name="Smith",
     )
     assert str(org) == f"{org.first_name} {org.last_name} <{org.email}>"
 


### PR DESCRIPTION
Fixes #961.

The error was apparently caused by the call to Nominatim, where, for some reason, it was returning the 403 status (I tested locally and couldn't reproduce it). Then, because such response was invalid, a `JSONDecodeError` was raised during the `res.json()` call.

This adds `JSONDecodeError` to the except block, so we'll catch it and return `None` in case the parsing fails for any reason.

Added a unit test to confirm the fix.