### PR TITLE
Add new video to website and add shop link

### DIFF
--- a/static/source/css/event.styl
+++ b/static/source/css/event.styl
@@ -118,6 +118,7 @@ a, a:hover
     height: 100%
     background: rgba(0,0,0,0.6)
     color: white
+    letter-spacing: 3px
     button, input, optgroup, select, textarea
         color: initial
 

--- a/templates/core/faq.html
+++ b/templates/core/faq.html
@@ -9,13 +9,23 @@
         <div class="col-md-12">
             <h1>{% trans "FAQ: Frequently Asked Questions" %}</h1>
 
-            <p>
-              {% url 'contact:landing' as contact_url %}
-              {% blocktrans trimmed %}
-                Django Girls events have been happening all over the world for a while now, and we get some repeat
-                questions. If you need more help: <a href="{{ contact_url }}">contact us</a>!
-              {% endblocktrans %}
-            </p>
+            <div class="row">
+              <div class="col-md-6">
+                <p>
+                  {% url 'contact:landing' as contact_url %}
+                  {% blocktrans trimmed %}
+                    Django Girls events have been happening all over the world for a while now, and we get some repeat
+                    questions. If you need more help: <a href="{{ contact_url }}">contact us</a>!
+                  {% endblocktrans %}
+                </p>
+              </div>
+              <div class="col-md-6">
+                <iframe src="//player.vimeo.com/video/112325567?title=0&amp;byline=0&amp;portrait=0&amp;color=ff9933" width="585" height="329" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+              </div>
+
+            </div>
+
+            
 
             <h2>{% trans "Django Girls workshops" %}</h2>
             {% include 'includes/_faq.html' %}
@@ -25,7 +35,7 @@
             <div class="panel-group" id="accordion">
                 <div class="panel panel-default">
                     <div class="panel-heading">
-                        <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#Django_Girls_sexist">
+                        <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#Django_Girls_sexist">
                             <strong>{% trans "Q: Isn't Django Girls sexist?" %}</strong>
                         </a>
                     </div>
@@ -105,7 +115,7 @@
 
             <div class="panel panel-default">
                 <div class="panel-heading">
-                   <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#Django_Girls_trans_inclusive">
+                   <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#Django_Girls_trans_inclusive">
                        <strong>{% trans "Q: Are Django Girls events trans-inclusive?" %}</strong>
                    </a>
                 </div>
@@ -134,7 +144,7 @@
 
             <div class="panel panel-default">
                 <div class="panel-heading">
-                    <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#Django_Girls_for_men"><strong>Q: Is there a Django Girls for men?</strong></a>
+                    <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#Django_Girls_for_men"><strong>Q: Is there a Django Girls for men?</strong></a>
                 </div>
                 <div id="Django_Girls_for_men" class="panel-collapse collapse">
                     <div class="panel-body">

--- a/templates/core/index.html
+++ b/templates/core/index.html
@@ -44,7 +44,7 @@
                     {# <p><a href="">Learn more about Django Girls »</a></p> #}
                 </div>
                 <div class="col-md-6">
-                  <iframe src="//player.vimeo.com/video/112325567?title=0&amp;byline=0&amp;portrait=0&amp;color=ff9933" width="585" height="329" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
+                  <iframe src="//player.vimeo.com/video/953132851?title=0&amp;byline=0&amp;portrait=0&amp;color=ff9933" width="585" height="329" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen></iframe>
                 </div>
             </div>
 

--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -42,6 +42,7 @@
             <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
                 <li><a class="dropdown-item" href="{% url 'core:events' %}">{% trans "Events" %}</a></li>
                 <li><hr class="dropdown-divider"></li>
+                <li><a class="dropdown-item" href="https://django-girls.myspreadshop.co.uk" target="_blank">{% trans "Shop" %}</a></li>
                 <li><a class="dropdown-item" href="{% url 'core:newsletter' %}">{% trans "Newsletter" %}</a></li>
                 <li><a class="dropdown-item" href="https://blog.djangogirls.org/">{% trans "Our blog" %}</a></li>
             </ul>

--- a/templates/includes/_faq.html
+++ b/templates/includes/_faq.html
@@ -3,7 +3,7 @@
 <div class="panel-group" id="accordion">
     <div class="panel panel-default">
         <div class="panel-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#apply"><strong>{% trans "Q: How can I register?" %}</strong></a>
+            <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#apply"><strong>{% trans "Q: How can I register?" %}</strong></a>
         </div>
         <div id="apply" class="panel-collapse collapse">
             <div class="panel-body">
@@ -20,7 +20,7 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#too_late"><strong>{% trans "Q: I missed the deadline! Can I still apply to a workshop?" %}</strong></a>
+            <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#too_late"><strong>{% trans "Q: I missed the deadline! Can I still apply to a workshop?" %}</strong></a>
         </div>
         <div id="too_late" class="panel-collapse collapse">
             <div class="panel-body">
@@ -38,7 +38,7 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#coach_sponsor"><strong>{% trans "Q: I want to coach or sponsor an event!" %}</strong></a>
+            <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#coach_sponsor"><strong>{% trans "Q: I want to coach or sponsor an event!" %}</strong></a>
         </div>
         <div id="coach_sponsor" class="panel-collapse collapse">
             <div class="panel-body">
@@ -49,7 +49,7 @@
 
     <div class="panel panel-default">
         <div class="panel-heading">
-            <a class="accordion-toggle" data-toggle="collapse" data-parent="#accordion" href="#tutorial"><strong>{% trans "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?" %}</strong></a>
+            <a class="accordion-toggle" data-bs-toggle="collapse" data-parent="#accordion" href="#tutorial"><strong>{% trans "Q: I'm following Django Girls tutorial and something is not working in my code: can you help me debug it?" %}</strong></a>
         </div>
         <div id="tutorial" class="panel-collapse collapse">
             <div class="panel-body">


### PR DESCRIPTION
Changes in this PR
- Add 10th anniversary video to homepage
- Move Warsaw video to FAQs.
- Add shop link to What's new
- Add spacing for event overlay
- Fix FAQs data toggle