### PR TITLE
Fix keyerror for page_title in confirmation email

### DIFF
--- a/applications/forms.py
+++ b/applications/forms.py
@@ -77,9 +77,9 @@ class ApplicationForm(forms.Form):
 
         if application.email:
             # Send confirmation email
-            subject = _("Confirmation of your application for %(page_title)s") % {
-                "page_title": self.form.event.page_title
-            }
+            page_title = self.form.event.page_title
+            subject = _("Confirmation of your application for %(page_title)s") % {"page_title": page_title}
+
             body = render_to_string(
                 "emails/application_confirmation.html",
                 {


### PR DESCRIPTION
Changes in this pull request:
- Get page_title value before string interpolation in the subject
- Use page_title variable in the dict for string interpolation.