### PR TITLE
Quick fix for issue #1033

### DIFF
--- a/templates/organize/prerequisites.html
+++ b/templates/organize/prerequisites.html
@@ -60,7 +60,7 @@
                                 <li class="checkbox-wrapper">
                                     <input type="checkbox" id="environment" name="environment" required />
                                     <label for="environment">
-                                        <a href="https://organize.djangogirls.org/environment/">{% trans "Environment at Django Girls workshop" %}</a>
+                                        <a href="https://organize.djangogirls.org/environment.html">{% trans "Environment at Django Girls workshop" %}</a>
                                     </label>
                                 </li>
                                 <li class="checkbox-wrapper">


### PR DESCRIPTION
This solves issue #1033 

Just `templates/organize/prerequisite.html` template has been modified in order to redirect to the proper `environment prerequisite` in the `Organize Workshop Form`

Instead of: https://organize.djangogirls.org/environment/

we use: https://organize.djangogirls.org/environment.html