### PR TITLE
Remove gitter on website

### DIFF
--- a/templates/core/contribute.html
+++ b/templates/core/contribute.html
@@ -163,28 +163,6 @@
 
             <div class="row clearfix">
                 <div class="col-md-6">
-                    <h3>{% trans "Help on Gitter!" %}</h3>
-                    <div class="cover">
-                        <a href="https://gitter.im/DjangoGirls/tutorial">
-                            <img src="{% static 'img/global/contribute/gitter.jpg' %}" alt="{% trans "A web page opened on a computer." %}" />
-                        </a>
-                    </div>
-                    <div class="info">
-                        <p>
-                          {% blocktrans trimmed %}
-                            Many people are doing our tutorial outside of a workshop. Sometimes, they get stuck and need help. How about spending a few hours a week helping them?
-                          {% endblocktrans %}
-                        </p>
-
-                        <p>
-                          {% blocktrans trimmed %}
-                            This <a href="https://gitter.im/DjangoGirls/tutorial">Gitter room</a> is designed to be a friendly space, especially for beginners.
-                            Remember that our <a href="https://djangogirls.org/pages/coc/">Code of Conduct</a> also applies there.
-                          {% endblocktrans %}
-                        </p>
-                    </div>
-                </div>
-                <div class="col-md-6">
                     <h3>{% trans "Want to do more?" %}</h3>
                     <div class="cover">
                         <a href="https://trello.com/b/q7p6jcfg/django-girls">


### PR DESCRIPTION
Our Gitter page has a lot of spam, so we are removing it from all pages and resources.