### PR TITLE
Add created_at date to list display in admin

### DIFF
--- a/core/admin/event.py
+++ b/core/admin/event.py
@@ -65,6 +65,7 @@ class EventAdmin(admin.ModelAdmin):
         "is_past_event",
         "has_stats",
         "is_frozen",
+        "created_at",
     )
     list_filter = (OpenRegistrationFilter,)
     search_fields = ("city", "country", "name")

--- a/organize/admin.py
+++ b/organize/admin.py
@@ -34,6 +34,7 @@ class EventApplicationAdmin(admin.ModelAdmin):
         "city",
         "country",
         "date",
+        "created_at",
         "main_organizer",
         "status",
         "comment",


### PR DESCRIPTION
- Add `created_at` date to the list display for event applications.
- Add `created_at` date to the list display for events.