### PR TITLE
Change menu layout, remove crowdfunding page

### DIFF
--- a/core/admin/event.py
+++ b/core/admin/event.py
@@ -102,7 +102,7 @@ class EventAdmin(admin.ModelAdmin):
     def get_readonly_fields(self, request, obj=None):
         fields = set(self.readonly_fields) | {"full_url"}
         if obj and not request.user.is_superuser:
-            fields.update({"city", "country", "email", "is_on_homepage", "name", "page_url", "team"})
+            fields.update({"city", "country", "email", "is_on_homepage", "name", "page_url"})
             # Don't let change objects for events that already happened
             if not obj.is_upcoming():
                 fields.update({x.name for x in self.model._meta.fields})
@@ -168,6 +168,7 @@ class EventAdmin(admin.ModelAdmin):
                 _("Event website"),
                 {"fields": ["page_title", "page_description", "page_main_color", "page_custom_css", "is_page_live"]},
             ),
+            (_("Team"), {"fields": ["main_organizer", "team"]}),
             (
                 _("Statistics"),
                 {

--- a/core/views.py
+++ b/core/views.py
@@ -7,6 +7,7 @@ from django.utils import timezone
 from django.utils.translation import gettext_lazy as _
 from django_date_extensions.fields import ApproximateDate
 
+from applications.questions import get_organiser_menu
 from patreonmanager.models import FundraisingStatus
 from story.models import Story
 
@@ -85,7 +86,10 @@ def event(request, page_url):
         {
             "event": event_obj,
             "menu": event_obj.menu.all(),
+            "organizer_menu": get_organiser_menu(page_url),
             "content": event_obj.content.prefetch_related("coaches", "sponsors").filter(is_public=True),
+            "page_url": page_url,
+            "user": user,
         },
     )
 

--- a/templates/event/menu.html
+++ b/templates/event/menu.html
@@ -12,6 +12,11 @@
         {% for item in menu %}
         <li class="nav-item px-2"><a href="{% build_menu_item_url item.url event.page_url %}">{{ item.title }}</a></li>
         {% endfor %}
+        {% if user.is_staff %}
+          {% for item in organizer_menu %}
+          <li class="nav-item px-2"><a href="{% build_menu_item_url item.url event.page_url %}">{{ item.title }}</a></li>
+          {% endfor %}
+        {% endif %}
       </ul>
     </div><!--/.nav-collapse -->
   </div>

--- a/templates/global/menu.html
+++ b/templates/global/menu.html
@@ -14,7 +14,6 @@
                 </a>
                 <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
                     <li><a class="dropdown-item" href="{% url 'donations:index' %}">{% trans "Corporate Sponsorships" %}</a></li>
-                    <li><a class="dropdown-item" href="{% url 'donations:crowdfunding' %}" target="_blank">{% trans "Crowdfunding" %}</a></li>
                     <li><a class="dropdown-item" href="{% url 'donations:donate' %}">{% trans "Donate to us" %}</a></li>
                     <li><a class="dropdown-item" href="https://www.patreon.com/djangogirls">{% trans "Our Patreon Page" %}</a></li>
                     <li><hr class="dropdown-divider"></li>
@@ -34,16 +33,16 @@
             </li>
 
             <li class="nav-item px-2">
-            <a class="nav-link" href="{% url 'jobboard:index' %}">{% trans "Tech Jobs Board" %}</a>
+            <a class="dropdown-item" href="{% url 'core:events' %}">{% trans "Events" %}</a>
             </li>
+
             <li class="nav-item dropdown px-2">
             <a class="nav-link dropdown-toggle" href="#" id="navbarDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                 {% trans "What's new?" %}  <span class="caret"></span>
             </a>
             <ul class="dropdown-menu" aria-labelledby="navbarDropdown">
-                <li><a class="dropdown-item" href="{% url 'core:events' %}">{% trans "Events" %}</a></li>
+                <li><a class="dropdown-item" href="{% url 'jobboard:index' %}">{% trans "Tech Jobs Board" %}</a></li>
                 <li><hr class="dropdown-divider"></li>
-                <li><a class="dropdown-item" href="{% url 'donations:crowdfunding' %}" target="_blank">{% trans "Crowdfunding" %}</a></li>
                 <li><a class="dropdown-item" href="https://django-girls.myspreadshop.co.uk" target="_blank">{% trans "Shop" %}</a></li>
                 <li><a class="dropdown-item" href="{% url 'core:newsletter' %}">{% trans "Newsletter" %}</a></li>
                 <li><a class="dropdown-item" href="https://blog.djangogirls.org/">{% trans "Our blog" %}</a></li>


### PR DESCRIPTION
Changes in this PR
- Make events link to a standalone
- Remove crowdfunding link
- Add applications and messaging links to the event menu
- Enable organisers to add co-organisers