### PR TITLE
fix: add distinct() to CoachAdmin queryset to prevent MultipleObjects…

### DIFF
--- a/coach/admin.py
+++ b/coach/admin.py
@@ -19,7 +19,7 @@ class CoachAdmin(admin.ModelAdmin):
         qs = super().get_queryset(request)
         if request.user.is_superuser:
             return qs
-        return qs.filter(eventpagecontent__event__team=request.user)
+        return qs.filter(eventpagecontent__event__team=request.user).distinct()
 
     def get_form(self, request, obj=None, **kwargs):
         form = super().get_form(request, obj, **kwargs)

--- a/tests/coach/test_admin.py
+++ b/tests/coach/test_admin.py
@@ -17,12 +17,8 @@ def test_get_queryset_for_organizer_no_duplicates(client, organizer_peter, futur
     in the queryset, preventing MultipleObjectsReturned when the admin calls get()."""
     coach = Coach.objects.create(name="Anna Smith")
 
-    content1 = EventPageContent.objects.create(
-        event=future_event, name="coaches", content="a", position=1
-    )
-    content2 = EventPageContent.objects.create(
-        event=future_event, name="mentors", content="b", position=2
-    )
+    content1 = EventPageContent.objects.create(event=future_event, name="coaches", content="a", position=1)
+    content2 = EventPageContent.objects.create(event=future_event, name="mentors", content="b", position=2)
     content1.coaches.add(coach)
     content2.coaches.add(coach)
 

--- a/tests/coach/test_admin.py
+++ b/tests/coach/test_admin.py
@@ -1,0 +1,48 @@
+import pytest
+from django.contrib.admin.sites import AdminSite
+from django.urls import reverse
+
+from coach.admin import CoachAdmin
+from coach.models import Coach
+from core.models import EventPageContent
+
+
+@pytest.fixture
+def coach_admin():
+    return CoachAdmin(Coach, AdminSite())
+
+
+def test_get_queryset_for_organizer_no_duplicates(client, organizer_peter, future_event):
+    """A coach linked to multiple EventPageContent blocks should appear only once
+    in the queryset, preventing MultipleObjectsReturned when the admin calls get()."""
+    coach = Coach.objects.create(name="Anna Smith")
+
+    content1 = EventPageContent.objects.create(
+        event=future_event, name="coaches", content="a", position=1
+    )
+    content2 = EventPageContent.objects.create(
+        event=future_event, name="mentors", content="b", position=2
+    )
+    content1.coaches.add(coach)
+    content2.coaches.add(coach)
+
+    client.force_login(organizer_peter)
+    admin_instance = CoachAdmin(Coach, AdminSite())
+    request = client.get(reverse("admin:coach_coach_changelist")).wsgi_request
+    request.user = organizer_peter
+
+    qs = admin_instance.get_queryset(request)
+    assert qs.filter(pk=coach.pk).count() == 1
+
+
+def test_get_queryset_for_superuser_returns_all(admin_client, admin_user):
+    """Superuser should see all coaches."""
+    Coach.objects.create(name="Coach A")
+    Coach.objects.create(name="Coach B")
+
+    admin_instance = CoachAdmin(Coach, AdminSite())
+    request = admin_client.get(reverse("admin:coach_coach_changelist")).wsgi_request
+    request.user = admin_user
+
+    qs = admin_instance.get_queryset(request)
+    assert qs.count() == 2


### PR DESCRIPTION
`CoachAdmin.get_queryset` filters coaches via `eventpagecontent__event__team`, which is a many-to-many join. When a coach is linked to multiple `EventPageContent` blocks, this join produces duplicate rows in the queryset. Django admin then calls `queryset.get(pk=object_id)` on that queryset when opening a coach record, which raises `MultipleObjectsReturned` because it finds the same coach multiple times.

Fixed by adding `.distinct()` to the queryset filter, so each coach appears only once regardless of how many `EventPageContent` blocks they are linked to. This is consistent with how `SponsorAdmin.get_queryset` already handles the same pattern.

Fixes #1075