### PR TITLE
chore: Bump packages to try to avoid setuptools issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -70,7 +70,7 @@ django-bleach==3.0.1
     # via -r requirements.in
 django-click==2.3.0
     # via -r requirements.in
-django-countries==7.5.1
+django-countries==8.2.0
     # via -r requirements.in
 django-date-extensions==3.1.2
     # via -r requirements.in

--- a/requirements.txt
+++ b/requirements.txt
@@ -78,7 +78,7 @@ django-debug-toolbar==3.8.1
     # via -r requirements.in
 django-extensions==3.2.1
     # via -r requirements.in
-django-formtools==2.3
+django-formtools==2.5.1
     # via -r requirements.in
 django-gulp-rev==0.2
     # via -r requirements.in


### PR DESCRIPTION
The test suite is failing due to;

```
django.template.library.InvalidTemplateLibrary: Invalid template library specified. ImportError raised when trying to load 'django_countries.templatetags.countries': No module named 'pkg_resources'
```

The later versions of `django-countries` should resolve this by no longer using that import.